### PR TITLE
docs: live comparison against deployed proxies, and a deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ document is superseded, and the striping it measures is deleted -- and
 [`docs/PERFORMANCE-20260812.md`](docs/PERFORMANCE-20260812.md) for the earlier
 campaign.
 
+### Measured against deployed proxies on a real path
+
+[`docs/MEASUREMENTS-20260816.md`](docs/MEASUREMENTS-20260816.md) is a live
+China-US campaign against the implementations people actually run -- sing-box
+1.13.18 serving TUIC v5, Hysteria2, VLESS over TLS and VLESS over WebSocket --
+with no emulator anywhere. On that path queqiao is the fastest transport
+measured, 143.1 Mbit/s median against Hysteria2's 90.2 and TUIC's 76.8, ahead
+in all six rounds, and the two TCP-based VLESS configurations are two orders of
+magnitude behind at 0.63 and 0.39. Interactive latency is at parity with TUIC
+and Hysteria2 idle, and VLESS cannot carry a real-time video stream at all,
+losing a third to a half of it.
+
+**Two results go the other way and both are blocking.** Under its own bulk load
+queqiao's interactive tail degrades more than either competitor's -- SSH p99
+302 to 940 ms, voice loss 1.9% to 9.0% -- which is what flow classification and
+bulk isolation exist to prevent, and the emulated 208 ms result below does not
+reproduce there. And **the client stops moving data entirely after a median
+2.35 GiB of sustained transfer**, three reproductions out of three, with no
+self-recovery and only a client restart clearing it; the shipping `erasure`
+controller is marking 99.9% of its samples application-limited and its
+bandwidth estimate collapses to under 2% of the link. That path is not the
+45%-erasure channel this project targets, so the campaign tests the transport
+rather than the design's central claim -- but the stall is not the path's
+fault.
+
 ### The live link is the number to believe
 
 Measured against the real China-US path -- 263 ms average round trip, 226 to

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ high-priority budget, sustained one-way flows are demoted to bulk, and
 bidirectional bursty flows remain interactive. Classification uses byte counts
 and timing, not HTTPS decryption or MITM.
 
+## Using it
+
+[`docs/DEPLOYING.md`](docs/DEPLOYING.md) is the practical guide: build, egress
+host, local client, and how to point Clash Verge or any mihomo-based client at
+it. The short version is that queqiao is not a protocol Clash speaks --
+`queqiaod --mode local` runs beside Clash and exposes a plain SOCKS5 ingress,
+and Clash forwards to it as a `socks5` node. Templates are in
+[`deploy/`](deploy).
+
+Two things in that document decide whether a deployment works at all. The
+client must be started with `--local-address if:en0`, because Clash's TUN mode
+would otherwise capture queqiao's own outer connection and carry it through the
+tunnel queqiao is replacing. And the local client stops moving data after about
+2.35 GiB of sustained transfer and needs restarting, which is why this is
+something to switch to deliberately rather than leave carrying a day's traffic.
+
 ## Current status
 
 The repository now contains an authenticated SOCKS-to-PEP prototype with

--- a/deploy/clash-queqiao.yaml
+++ b/deploy/clash-queqiao.yaml
@@ -1,0 +1,42 @@
+# queqiao — Clash Verge / mihomo profile template
+#
+# queqiao is not a protocol Clash speaks. The client (`queqiaod --mode local`)
+# runs as a separate process beside Clash and exposes a plain SOCKS5 ingress on
+# loopback; Clash forwards to it like any other SOCKS5 node.
+#
+# Before selecting this profile, confirm the client is up:
+#   nc -z 127.0.0.1 12080
+#   env -u NO_PROXY -u no_proxy curl --noproxy '' -sS \
+#       --socks5-hostname 127.0.0.1:12080 https://api.ipify.org
+# The second command must print the egress host's address.
+#
+# The client MUST be started with --local-address if:en0 (or a literal physical
+# IP). Clash's TUN mode installs a default route through 198.18.0.1, so without
+# that binding queqiao's own outer connection is captured by Clash and carried
+# through whatever proxy Clash is using — the tunnel it was meant to replace,
+# or a loop.
+#
+# See docs/DEPLOYING.md.
+
+proxies:
+  - name: queqiao
+    type: socks5
+    server: 127.0.0.1
+    port: 12080
+    # queqiao implements SOCKS5 UDP ASSOCIATE and carries the datagrams on the
+    # connection's QUIC datagrams where QUIC negotiated them, so an application
+    # that chose UDP keeps datagram semantics rather than having its packets
+    # serialised into a stream where one loss stalls everything behind it.
+    udp: true
+
+proxy-groups:
+  - name: Proxy
+    type: select
+    proxies:
+      - queqiao
+      - DIRECT
+
+rules:
+  - DOMAIN-SUFFIX,cn,DIRECT
+  - GEOIP,CN,DIRECT
+  - MATCH,Proxy

--- a/deploy/me.01.queqiao.client.plist
+++ b/deploy/me.01.queqiao.client.plist
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  macOS LaunchAgent for the queqiao local client.
+
+  Install:
+    cp deploy/me.01.queqiao.client.plist ~/Library/LaunchAgents/
+    # edit the paths and <EGRESS-IP> below
+    launchctl load ~/Library/LaunchAgents/me.01.queqiao.client.plist
+
+  Restart after the client stalls (see docs/DEPLOYING.md):
+    launchctl kickstart -k gui/$(id -u)/me.01.queqiao.client
+
+  See docs/DEPLOYING.md for the egress side and the Clash profile.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>me.01.queqiao.client</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOU/.queqiao/bin/queqiaod</string>
+    <string>--mode</string>
+    <string>local</string>
+
+    <!-- The SOCKS5 ingress Clash forwards to. Loopback only. -->
+    <string>--listen</string>
+    <string>127.0.0.1:12080</string>
+
+    <!-- A literal IP, never a hostname: with fake-IP DNS a hostname resolves
+         to an address inside the tunnel. -->
+    <string>--remote</string>
+    <string>EGRESS-IP:12540</string>
+
+    <!-- Must equal the server certificate's CN/SAN. This is a verified TLS
+         name presented as SNI, not a DNS lookup. -->
+    <string>--server-name</string>
+    <string>queqiao.node</string>
+    <string>--root-ca</string>
+    <string>/Users/YOU/.queqiao/cert.pem</string>
+    <string>--secret-file</string>
+    <string>/Users/YOU/.queqiao/secret</string>
+
+    <!-- Not optional when Clash runs in TUN mode. Clash installs a default
+         route through 198.18.0.1, so without this binding queqiao's own outer
+         connection is captured by Clash and tunnelled through whatever proxy
+         Clash is using. if:en0 re-resolves the physical address before each
+         dial, so DHCP changes are handled. Verify with tcpdump on the egress
+         host that the source address arriving is your real uplink. -->
+    <string>--local-address</string>
+    <string>if:en0</string>
+
+    <!-- Loopback-only counters: flows, lanes, fallbacks, controller state. -->
+    <string>--metrics-listen</string>
+    <string>127.0.0.1:12090</string>
+
+    <string>--log-level</string>
+    <string>info</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- Restarts on crash. It does NOT rescue the stall documented in
+       docs/DEPLOYING.md: a stalled client keeps running and keeps accepting
+       connections, so launchd sees a healthy process. That one needs an
+       explicit kickstart. -->
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/YOU/.queqiao/client.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOU/.queqiao/client.log</string>
+
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -178,18 +178,33 @@ SOCKS5 endpoints and swaps which goes first each round, keeping a comparison
 inside one path window. Expect to need well over ten rounds, and report
 completion counts rather than only medians.
 
-Three mistakes produced confident, wrong results during this project's
-campaigns. All three are cheap to avoid and expensive to miss:
+Five mistakes produced confident, wrong results during this project's
+campaigns. All five are cheap to avoid and expensive to miss:
 
 - **Use the literal server IP.** A hostname that a local TUN-mode proxy
   resolves to a fake IP means both transports are measured *through the
   existing tunnel*, not over the path under test.
 - **Bind the outer socket to the physical interface** (`--local-address`) on
   both clients, for the same reason, and give both the same timeout.
+- **Prove the binding worked, don't assume it.** Have the server report the
+  source address it sees. On 2026-08-16 an unbound datagram arrived from
+  `23.135.236.244`, the existing tunnel's exit, and a bound one from
+  `120.244.189.31`, the real uplink — same host, same destination, one flag
+  apart. Third-party clients need their own equivalent (`inet4_bind_address`
+  for sing-box outbounds), and they need checking too.
+- **Clear `NO_PROXY` before using curl.** `curl` honours `NO_PROXY` even when a
+  proxy is named explicitly with `--socks5-hostname`, so a shell exporting
+  `NO_PROXY=*` sends every "proxied" transfer straight to the origin and
+  reports it as a success. Use `env -u NO_PROXY -u no_proxy curl --noproxy ''`.
 - **Make the remote oracle concurrent.** A single-threaded `http.server` lets a
   lingering connection from one trial delay the next; before this was fixed,
   queqiao measured 1.19 Mbit/s against the reference's 4.52, and with a threaded
   oracle and nothing else changed the two measured 0.478 and 0.522.
+
+**Measure a fixed duration, not a fixed object, when the stacks are far apart.**
+A 16 MiB object is four round trips for a QUIC stack on a fast path and three
+minutes for VLESS over TCP on the same path; a 20-second window measures the
+rate each one actually sustains and keeps completion honest.
 
 Stop every temporary listener when the campaign ends. An earlier session left
 an authenticated listener bound to all interfaces for thirteen hours.

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -1,0 +1,285 @@
+# Deploying queqiao, and using it from Clash
+
+This is the practical guide: how to build it, how to run the two ends, and how
+to point Clash Verge or any mihomo-based client at it.
+
+Read [the limits](#what-you-are-signing-up-for) before deploying this anywhere
+you care about. The project has not met the release gates in
+[`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md), and one defect measured on 2026-08-16
+will interrupt a working tunnel.
+
+## The shape of a deployment
+
+**queqiao is not a protocol Clash speaks.** There is no `type: queqiao` in
+mihomo and there will not be one. A deployment is two processes and a plain
+SOCKS5 hand-off:
+
+```
+application → Clash (TUN or system proxy)
+                → SOCKS5 127.0.0.1:12080
+                    → queqiaod --mode local      ← runs beside Clash, not inside it
+                        → QUIC/UDP or TLS/TCP over the long-haul path
+                            → queqiaod --mode server   ← on the egress host
+                                → the destination
+```
+
+Clash keeps doing what it is good at — capture, DNS, and rule-based routing —
+and forwards the flows it decides to proxy into queqiao's local ingress. That
+is the integration the design intends, and it is the one that can be rolled
+back by deleting one node and one rule.
+
+## Build and install
+
+Go 1.25 or later.
+
+```sh
+git clone https://github.com/bojieli/queqiao && cd queqiao
+go build ./... && go test ./...
+go install ./cmd/...          # queqiaod, queqiaoref, queqiaobench, pathprobe
+```
+
+For the egress host, cross-compile rather than installing a toolchain there:
+
+```sh
+GOOS=linux GOARCH=amd64 go build -o queqiaod-linux-amd64 ./cmd/queqiaod
+scp queqiaod-linux-amd64 egress:/usr/local/bin/queqiaod
+```
+
+## The egress side
+
+Both ends authenticate with a shared 32-byte secret, and the client verifies
+the server's certificate against a pinned root, so a self-signed certificate is
+correct here — there is nothing to trust publicly.
+
+```sh
+sudo mkdir -p /etc/queqiao && cd /etc/queqiao
+sudo openssl req -x509 -newkey rsa:2048 -nodes \
+     -keyout key.pem -out cert.pem -days 3650 \
+     -subj "/CN=queqiao.node" -addext "subjectAltName=DNS:queqiao.node"
+sudo sh -c 'head -c 32 /dev/urandom > secret'
+sudo chmod 600 key.pem secret
+```
+
+`--server-name` on the client must equal the certificate's name. It is a
+verified TLS name, not a DNS lookup: the client dials the literal IP in
+`--remote` and presents this as SNI.
+
+Run it under systemd. [`deploy/queqiaod-dev.service`](../deploy/queqiaod-dev.service)
+is the hardened unit this project uses; the minimal form is:
+
+```ini
+[Service]
+ExecStart=/usr/local/bin/queqiaod --mode server --listen 0.0.0.0:12540 \
+  --tls-cert /etc/queqiao/cert.pem --tls-key /etc/queqiao/key.pem \
+  --secret-file /etc/queqiao/secret --log-level info
+Restart=always
+LimitNOFILE=1048576
+```
+
+```sh
+sudo systemctl daemon-reload && sudo systemctl enable --now queqiaod
+systemctl is-active queqiaod
+```
+
+One port carries both transports: queqiaod listens for QUIC on **UDP** and for
+the authenticated TLS/TCP fallback on **TCP**, both on `--listen`. Open both in
+any firewall, or UDP-only paths will silently take the slower fallback.
+
+Do **not** pass `--allow-private-destinations` on a general-purpose egress. It
+exists for benchmark rigs whose origin is on loopback, and it lets a client
+reach the egress host's own private network.
+
+## The client side
+
+Copy `cert.pem` and `secret` from the egress host to the client — the secret is
+a credential, so treat it accordingly (`chmod 600`).
+
+```sh
+mkdir -p ~/.queqiao/bin && chmod 700 ~/.queqiao
+cp $(command -v queqiaod) ~/.queqiao/bin/
+scp egress:/etc/queqiao/cert.pem ~/.queqiao/cert.pem
+scp egress:/etc/queqiao/secret   ~/.queqiao/secret && chmod 600 ~/.queqiao/secret
+```
+
+```sh
+queqiaod --mode local \
+  --listen 127.0.0.1:12080 \
+  --remote <EGRESS-IP>:12540 \
+  --server-name queqiao.node \
+  --root-ca ~/.queqiao/cert.pem \
+  --secret-file ~/.queqiao/secret \
+  --local-address if:en0 \
+  --metrics-listen 127.0.0.1:12090
+```
+
+### `--local-address` is not optional when Clash is in TUN mode
+
+This is the single most important flag on the page, and getting it wrong
+produces a tunnel that appears to work.
+
+Clash's TUN mode installs a default route through `198.18.0.1`. queqiao's own
+outer connection to the egress host follows the host routing table like any
+other socket, so it goes **into Clash**, which forwards it through whatever
+proxy Clash is currently using. The result is queqiao tunnelled inside the
+tunnel it was meant to replace — or a loop, if Clash's rule for that traffic
+points back at queqiao.
+
+`--local-address` binds the outer socket to a physical address so the packets
+leave the real interface:
+
+| Value | Use when |
+| --- | --- |
+| `if:en0` | recommended; resolves that interface's IPv4 before each dial, so DHCP changes are handled |
+| `192.0.2.10` | a literal address, when the interface name is unstable |
+| `auto` | one active physical interface only; errors if the choice is ambiguous |
+
+**Verify it rather than assuming it.** On the egress host, watch what source
+address actually arrives:
+
+```sh
+sudo tcpdump -nni any "port 12540 and inbound" -c 5
+```
+
+It must show your real uplink address. If it shows your existing proxy's exit
+address, the binding is not taking effect and every byte is going through the
+old tunnel.
+
+Use the literal egress **IP** in `--remote`, never a hostname: with fake-IP DNS
+a hostname resolves to a `198.18.x.x` address inside the tunnel.
+
+### Running it in the background
+
+macOS — [`deploy/me.01.queqiao.client.plist`](../deploy/me.01.queqiao.client.plist),
+edited for your paths and egress IP:
+
+```sh
+cp deploy/me.01.queqiao.client.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/me.01.queqiao.client.plist
+launchctl list | grep queqiao
+```
+
+Linux — the same unit as the server with `--mode local`, as a user service:
+
+```sh
+systemctl --user enable --now queqiao-client
+```
+
+Check it before touching Clash:
+
+```sh
+nc -z 127.0.0.1 12080 && echo "ingress up"
+env -u NO_PROXY -u no_proxy curl --noproxy '' -sS \
+    --socks5-hostname 127.0.0.1:12080 https://api.ipify.org
+```
+
+That must print the egress host's address. (`env -u NO_PROXY` matters: curl
+honours `NO_PROXY` even when a proxy is named explicitly, so a shell with
+`NO_PROXY=*` will report success while never touching the proxy.)
+
+## Enabling it in Clash Verge
+
+[`deploy/clash-queqiao.yaml`](../deploy/clash-queqiao.yaml) is a complete
+profile. Import it with **Profiles → New → Local**, paste or select the file,
+and leave your existing profile active until you have tested this one.
+
+The node itself is three lines:
+
+```yaml
+proxies:
+  - name: queqiao
+    type: socks5
+    server: 127.0.0.1
+    port: 12080
+    udp: true          # queqiao implements SOCKS5 UDP ASSOCIATE
+```
+
+`udp: true` is worth setting. queqiao carries SOCKS UDP on the connection's
+QUIC datagrams where QUIC negotiated them, so an application that chose UDP
+keeps datagram semantics instead of having its packets serialised into a stream
+where one loss stalls everything behind it.
+
+### Adding it to a profile you already use
+
+You do not need a separate profile. Add the node above to your `proxies:`, add
+`queqiao` to whichever `proxy-groups` entry you select from, and you can switch
+to it from the Clash UI without touching your rules. Removing those two lines
+is the entire rollback.
+
+If you would rather test it without any risk to a working setup, the safe path
+is the one in [`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md): a second,
+**inactive** profile whose final `MATCH` rule points at the queqiao node. Your
+live profile stays untouched and you switch back by selecting it again.
+
+### Verify from Clash
+
+With the profile selected, check that traffic is really taking the new path —
+the client's own counters are the quickest answer:
+
+```sh
+curl -s 127.0.0.1:12090/metrics | grep -E 'flows_(started|completed)_total|bytes_down_total'
+```
+
+If `flows_started_total` stays at zero while you browse, Clash is not routing to
+the node: check that your rules reach the group holding it.
+
+### Other mihomo clients
+
+Nothing above is Verge-specific. Any client that reads a mihomo configuration —
+mihomo itself, Clash for Windows forks, ClashX Meta, OpenClash — takes the same
+`socks5` node, and the only platform-specific part is how you keep
+`queqiaod --mode local` running.
+
+## What you are signing up for
+
+Measured on a real China-US path on 2026-08-16
+([`MEASUREMENTS-20260816.md`](MEASUREMENTS-20260816.md)), against sing-box
+serving the alternatives:
+
+- **It is fast.** 143 Mbit/s median where Hysteria2 got 90 and TUIC v5 got 77,
+  ahead in all six rounds, and roughly 100x the two TCP-based VLESS
+  configurations.
+- **It stalls.** After a median of **2.35 GiB** of sustained transfer the local
+  client stops moving data entirely, keeps accepting connections, and does not
+  recover on its own. Three reproductions out of three. Nothing is corrupted —
+  it returns zero bytes, never wrong ones — and the server is unaffected.
+
+Until that is fixed, treat a queqiao node as something you switch to
+deliberately rather than something you leave carrying a laptop's day. When
+throughput drops to nothing, restart the client:
+
+```sh
+launchctl kickstart -k gui/$(id -u)/me.01.queqiao.client   # macOS
+systemctl --user restart queqiao-client                    # Linux
+```
+
+Also unfinished, and relevant to a daily driver: interactive latency degrades
+under queqiao's own bulk load more than the alternatives' does; TUN/VLESS
+ingress does not exist, so Clash's SOCKS hand-off is the only integration; and
+UDP-blocked, restart, and long-soak behaviour is unmeasured on a real path.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| Everything works but the egress IP is your *old* proxy's | `--local-address` missing or not taking effect; verify with `tcpdump` on the egress |
+| `curl` through the SOCKS port succeeds but reports your own IP | `NO_PROXY` is set; use `env -u NO_PROXY -u no_proxy curl --noproxy ''` |
+| Client starts, no flows ever appear in `/metrics` | Clash rules are not reaching the group that holds the node |
+| Handshake fails with a certificate error | `--server-name` does not match the certificate's CN/SAN, or `--root-ca` is the wrong file |
+| Works, then stops after a few GiB | the stall above; restart the client |
+| Throughput fine, UDP applications fail | peer negotiated no QUIC datagrams and fell back to the control stream, or the lane is TLS/TCP |
+
+Logs are on stdout; `--log-level debug` reports the outer lane's transport,
+whether it is pooled, and per-flow completion. `--metrics-listen` exposes
+loopback-only counters for flows, lanes, fallbacks, controller state, and
+rescue events.
+
+## Removing it
+
+```sh
+launchctl unload ~/Library/LaunchAgents/me.01.queqiao.client.plist   # macOS
+sudo systemctl disable --now queqiaod                                # egress
+```
+
+Then delete the node and its group entry from your Clash profile, or select the
+profile you were using before. Nothing else on the host is modified: queqiao
+installs no routes, no TUN device, and no system proxy settings.

--- a/docs/MEASUREMENTS-20260816.md
+++ b/docs/MEASUREMENTS-20260816.md
@@ -1,0 +1,293 @@
+# Live-path comparison against deployed proxies — 2026-08-16
+
+This is a real-path campaign. Every number comes from a client in China and a
+fixed egress in the United States, with no emulator anywhere in the path, and
+every peer is the implementation people actually deploy rather than an in-tree
+imitation of it: sing-box 1.13.18 at both ends serving TUIC v5, Hysteria2,
+VLESS over TLS, and VLESS over WebSocket.
+
+Two results matter and they point opposite ways. On this path queqiao is the
+fastest transport measured, by a margin that holds in every round. It also
+stops moving data entirely after a couple of gigabytes and needs its client
+process restarted to recover, which it did in three reproduction attempts out
+of three. The throughput table exists only because the client was restarted
+before every round.
+
+## The path is not the one this project is designed for
+
+`docs/DESIGN.md` builds on a channel that erases about 45% of packets at any
+offered rate and polices above a knee near 14.5 Mbit/s. **The path measured
+here is a different animal**, and that has to be said before any number is
+read: the erasure code and the loss-insensitive controller were never under the
+conditions they exist for, so nothing below confirms or refutes the design's
+central claim.
+
+`cmd/pathprobe`, open loop, 1200-byte payloads, 6 s per rate:
+
+| Offered Mbit/s | Delivered | Loss % | Burst factor |
+| ---: | ---: | ---: | ---: |
+| 2 | 1.96 | 2.1 | 1.02 |
+| 10 | 9.85 | 1.4 | 1.04 |
+| 20 | 19.66 | 1.7 | 1.04 |
+| 50 | 49.18 | 1.6 | 1.08 |
+| 80 | 77.76 | 2.8 | — |
+| 120 | 115.74 | 3.5 | — |
+| 200 | 193.27 | 3.3 | — |
+| 300 | 276.35 | 7.9 | — |
+
+There is no knee below 200 Mbit/s, the loss is 1–3%, and the burst factor stays
+between 1.02 and 1.08, so the loss is memoryless in the sense
+`DESIGN.md` means. ICMP agrees: 249 ms mean over 30 source-bound pings, 204 to
+330 ms, 3.3% loss. The bandwidth-delay product is about 6 MB.
+
+## Binding the outer socket is not optional here
+
+The client host runs Clash in TUN mode and its route to the egress points at
+`utun4`. The naive version of this experiment measures every proxy *through the
+tunnel it is meant to replace*. That was true on the first attempt and it was
+caught by asking the server what source address it saw:
+
+```
+unbound socket        → server observed 23.135.236.244   (the existing tunnel's exit)
+bound to 192.168.3.66 → server observed 120.244.189.31   (the real China Mobile address)
+```
+
+Every client here is therefore source-bound — `--local-address` for queqiaod,
+`inet4_bind_address` for the sing-box outbounds. A capture on the server's
+physical NIC during a simultaneous transfer through all four sing-box stacks
+recorded 516 inbound packets, every one from `120.244.189.31`.
+
+This is the third time a variant of this mistake has cost a campaign; see the
+list in [`BENCHMARKING.md`](BENCHMARKING.md).
+
+## Throughput
+
+Six rounds, one 20-second download window per stack per round, stack order
+rotated each round, queqiao's client restarted before each round so the stall
+below is measured separately rather than smeared through this table.
+
+A fixed *time* window rather than a fixed object is the only fair shape when
+the stacks differ by two orders of magnitude: 16 MiB is four round trips for
+one of them and three minutes for another.
+
+| Stack | Median Mbit/s | Mean | Min | Max | Trials | × queqiao |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| queqiao | **143.06** | 137.31 | 105.77 | 159.33 | 6/6 | 1.00 |
+| Hysteria2 | 90.15 | 84.25 | 46.91 | 104.20 | 6/6 | 0.63 |
+| TUIC v5 | 76.79 | 74.70 | 47.08 | 87.20 | 6/6 | 0.54 |
+| VLESS + TLS | 0.63 | 0.94 | 0.22 | 2.66 | 6/6 | 0.004 |
+| VLESS + WebSocket | 0.39 | 0.38 | 0.14 | 0.74 | 6/6 | 0.003 |
+
+queqiao led in all six rounds, not on the median alone.
+
+The VLESS numbers are not a misconfiguration; both stacks moved bytes in every
+trial. They are TCP's Mathis limit, `MSS / (RTT * sqrt(p))`, which at 249 ms
+and 2% loss lands near 1 Mbit/s. WebSocket framing costs a further 38% on top.
+This is the clearest live evidence for the repository's own first axiom: on a
+path like this the loss response is the whole game, and a transport that owns
+its loss recovery is a hundred times faster than one that rents it from TCP.
+
+## Short-request latency
+
+A 1 KiB HTTP fetch, five per stack per round against a freshly restarted
+client, so the first is genuinely cold. One round trip is about 210 ms.
+
+| Stack | Cold p50 | Warm p50 | Warm p95 | Warm p50 under load |
+| --- | ---: | ---: | ---: | ---: |
+| queqiao | 472 | 242 | 281 | 252 |
+| TUIC v5 | 216 | 239 | 308 | 248 |
+| Hysteria2 | 241 | 242 | 296 | 241 |
+| VLESS + TLS | 739 | 735 | 838 | 665 |
+| VLESS + WebSocket | 867 | 935 | 1024 | 938 |
+
+Warm, the three QUIC stacks are indistinguishable and all at the floor. The one
+weak number is queqiao's **cold** request: 472 ms, about one extra round trip
+over TUIC's 216, paid once per client process rather than per flow. It is still
+the first thing a user meets.
+
+## Interactive applications
+
+Throughput is not what an interactive application spends. Three shapes, each
+measured as a round trip against an echo endpoint on the egress host — a round
+trip because the two hosts have no synchronized clock and a one-way figure
+would be mostly offset.
+
+- **SSH-like** — 64-byte request/response every 50 ms on a held-open TCP
+  connection.
+- **Voice-like** — 172-byte datagrams every 20 ms over SOCKS5 UDP ASSOCIATE,
+  the packetization of an Opus/RTP call.
+- **Video-like** — 1100-byte datagrams every 5 ms, about 1.8 Mbit/s.
+
+Idle, three rounds pooled, milliseconds:
+
+| Shape | Stack | p50 | p95 | p99 | Loss % |
+| --- | --- | ---: | ---: | ---: | ---: |
+| SSH | queqiao | 211 | 292 | 302 | 0.0 |
+| SSH | TUIC v5 | 206 | 237 | **265** | 0.0 |
+| SSH | Hysteria2 | 239 | 299 | 433 | 0.0 |
+| SSH | VLESS + TLS | 238 | 303 | 476 | 0.0 |
+| SSH | VLESS + WS | 229 | 320 | 640 | 0.0 |
+| Voice | queqiao | 209 | 287 | 387 | **1.9** |
+| Voice | TUIC v5 | 209 | 283 | **297** | 3.2 |
+| Voice | Hysteria2 | 224 | 296 | 318 | 3.1 |
+| Voice | VLESS + TLS | 250 | 503 | 612 | 2.4 |
+| Voice | VLESS + WS | 260 | 595 | 856 | 2.0 |
+| Video | queqiao | 232 | 364 | 639 | 2.4 |
+| Video | TUIC v5 | 223 | 318 | **551** | 3.9 |
+| Video | Hysteria2 | 236 | 327 | 566 | 3.7 |
+| Video | VLESS + TLS | 517 | 3192 | 3533 | **32.4** |
+| Video | VLESS + WS | 1906 | 4310 | 4615 | **50.0** |
+
+**VLESS cannot carry real-time media.** At 1.8 Mbit/s of datagrams it loses a
+third (TLS) to a half (WebSocket) of them with seconds of latency, because
+SOCKS5 UDP over VLESS is tunnelled inside a TCP stream: one lost segment
+head-of-line blocks every datagram queued behind it, and the stream's
+retransmission fights a real-time deadline nobody told it about. The three QUIC
+stacks carry the same stream at 223–236 ms and 2.4–3.9% loss. This is the same
+argument `DESIGN.md` makes for putting SOCKS UDP on QUIC datagrams, measured
+against the alternative people actually run.
+
+### Under the stack's own bulk load
+
+| Stack | SSH p95 | SSH p99 | Voice p99 | Voice loss % |
+| --- | ---: | ---: | ---: | ---: |
+| queqiao | 292 → 658 | 302 → **940** | 387 → 565 | 1.9 → **9.0** |
+| TUIC v5 | 237 → 363 | 265 → 662 | 297 → 326 | 3.2 → 4.6 |
+| Hysteria2 | 299 → 412 | 433 → 526 | 318 → 452 | 3.1 → 8.5 |
+| VLESS + TLS | 303 → 301 | 476 → 307 | 612 → 688 | 2.4 → 1.7 |
+| VLESS + WS | 320 → 300 | 640 → 311 | 856 → 802 | 2.0 → 2.2 |
+
+The VLESS rows must not be read as a win. Their bulk transfer runs at about
+1 Mbit/s, so it never loads the link and there is nothing for the interactive
+traffic to queue behind; those two rows are not comparable with the QUIC stacks,
+which were saturating 77 to 143 Mbit/s at the time.
+
+Among the stacks that were genuinely loaded, **queqiao degrades most.** Its SSH
+p99 triples and its voice loss rises fivefold, against TUIC's 265 → 662 ms and
+Hysteria2's 433 → 526. Part of that is a harder self-imposed load — queqiao is
+pushing substantially more bulk during the test — but this is the case flow
+classification and bulk isolation exist to protect, and on this path they did
+not protect it. The emulated result in `README.md` (208 ms interactive median
+under a 50 MiB transfer) does not reproduce here.
+
+## The client stalls permanently under sustained transfer
+
+Found by accident: the first throughput campaign recorded 176, 156, 175, 167,
+136 Mbit/s, then 5.3, then zero for every remaining round, while still
+accepting SOCKS connections.
+
+A dedicated reproduction ran back-to-back 20-second windows until goodput
+collapsed, restarting the client each attempt. It failed all three:
+
+| Attempt | Full-rate windows | Data moved | Last good rate | Self-recovered in 60 s |
+| ---: | ---: | ---: | ---: | --- |
+| 1 | 7 | 2.35 GiB | 139.5 Mbit/s | no |
+| 2 | 6 | 2.10 GiB | 123.2 Mbit/s | no |
+| 3 | 7 | 2.61 GiB | 166.0 Mbit/s | no |
+
+There is no decline. Throughput holds between 123 and 179 Mbit/s and drops to
+single digits in one window and to exactly zero in the next.
+
+Counters sampled while stalled, server untouched throughout:
+
+```
+queqiao_active_flows                          9      started 19, completed 3, failed 7
+queqiao_quic_lanes                            9      one connection per stuck flow, none closing
+queqiao_quic_controller_app_limited_samples   146862
+queqiao_quic_controller_non_app_limited_...   144    99.9% of samples marked application-limited
+queqiao_quic_controller_max_bandwidth    322540 B/s  estimate collapsed to 2.6 Mbit/s
+queqiao_quic_bytes_received            25641048042   25.6 GB of QUIC for 2.45 GB delivered (10.5x)
+queqiao_quic_controller_state_misses        5573624  server side, acks with no matching state
+```
+
+The controller is `erasure`, the shipping default. BBR only updates its
+bandwidth filter from samples that are *not* application-limited, and with 144
+usable samples out of 147,006 the filter is starved; the estimate had fallen to
+under 2% of what the link was delivering minutes earlier. The 10.5x ratio of
+QUIC bytes to application bytes says the connection was spending its capacity
+on something other than new data.
+
+Two facts localize it. Restarting the **client alone** restored full throughput
+immediately with the server process untouched, so the broken state is
+client-side. And `cmd/queqiaoref`, which shares this repository's QUIC stack and
+controllers, failed the same way in the same campaign — earlier and harder,
+after a single 306 MiB transfer — which points at the shared transport layer
+rather than at queqiao's own framing.
+
+This is the blocking result. It is not a tuning problem and it is not on the
+path's side.
+
+## Correctness
+
+| Check | Result | Detail |
+| --- | --- | --- |
+| `go build ./...`, `go vet ./...` | pass | no diagnostics |
+| `go install ./cmd/...` | pass | 4 binaries, Go 1.25.7 |
+| cross-build linux/amd64 | pass | deployed to the egress host |
+| `go test ./...` | pass | 21 packages |
+| `go test -race ./...` | pass | 21 packages, no data races |
+| `go test -count=6` on transport packages | **1 failure** | `TestUDPAssociationRescuesToTCP`, i/o timeout |
+| fuzz `FuzzOnDatagramNeverPanics` | pass | 9.8M execs in 90 s |
+| fuzz `FuzzWindowDecoderNeverPanics` | pass | 30.6M execs in 90 s |
+| byte integrity, live path | pass | every completed transfer matched SHA-256 |
+
+The UDP/TCP rescue flake is real and is roughly at its documented rate — one
+failure in six repeats — but the other half of the note in
+`DESIGN-MULTIPATH.md`, that it appears on *every* run under `-race`, did not
+hold: the full suite passed clean under `-race`.
+
+**The stall is fail-stop, not data-corrupting.** Every completed transfer on
+every stack matched the origin's SHA-256, queqiao included, under load and
+immediately after recovery. A stalled client returns zero bytes, not wrong
+ones. Both VLESS stacks failed the integrity run for a different reason worth
+recording: given 300 seconds for a 16 MiB object they delivered 9.70, 9.37 and
+12.25 MB — correct bytes, out of time.
+
+## What this does not establish
+
+- One path, one evening, about three hours. The path drifted while the campaign
+  ran (202 to 260 ms mean RTT between rounds), which rotation controls for
+  within a campaign and not across them.
+- Controllers were not held constant: each stack ran its own shipping default,
+  queqiao on `erasure` and the others on BBR. That is the right comparison for
+  a deployment decision and the wrong one for attributing a difference to
+  transport design rather than to congestion control.
+- Upload, connection migration, UDP blocking and TCP fallback, restart
+  recovery, and multi-hour soak are unmeasured. The last is untestable in this
+  build for the reason above.
+- The SSH shape yields about four samples a second on this path, so its p99
+  rests on roughly 150 samples per cell and is indicative rather than tight.
+  Voice and video pool thousands of packets and their percentiles are solid.
+
+## Reproducing
+
+Egress host, all listeners authenticated, origin bound to loopback so it is
+reachable only through a proxy under test:
+
+```sh
+queqiaod --mode server --listen 0.0.0.0:12540 --tls-cert cert.pem --tls-key key.pem \
+         --secret-file secret --allow-private-destinations
+sing-box run -c singbox-server.json     # tuic 12550, hysteria2 12551, vless 12552/12553
+python3 origin.py 28080 object.bin      # threaded; a single-threaded oracle skews results
+```
+
+Client, source-bound so the host TUN route cannot capture the outer socket:
+
+```sh
+queqiaod --mode local --listen 127.0.0.1:12180 --remote <EGRESS-IP>:12540 \
+         --server-name queqiao.test --root-ca cert.pem --secret-file secret \
+         --local-address if:en0
+# sing-box outbounds carry "inet4_bind_address" for the same reason
+
+pathprobe --mode client --remote <EGRESS-IP>:12599 --local-address if:en0 \
+          --sweep 2,5,10,15,20,30,50 --duration 6 --pattern
+```
+
+One more trap, new to this campaign and now recorded in `BENCHMARKING.md`:
+the measurement shell had `NO_PROXY=*` exported, and `curl` honours it even
+when a proxy is named explicitly with `--socks5-hostname`. The first
+"successful" transfers never touched a proxy at all. Clear it with
+`env -u NO_PROXY -u no_proxy curl --noproxy ''`.
+
+Stop every temporary listener when the campaign ends, including the ones on the
+egress host.


### PR DESCRIPTION
## What this is

Two things the repository was missing: a measurement against the proxies people actually deploy, and any instructions for using it.

### `docs/MEASUREMENTS-20260816.md`

A live China→US campaign against sing-box 1.13.18 serving TUIC v5, Hysteria2, VLESS+TLS and VLESS+WebSocket. No emulator in the path.

| Stack | Median Mbit/s | × queqiao |
| --- | ---: | ---: |
| queqiao | **143.06** | 1.00 |
| Hysteria2 | 90.15 | 0.63 |
| TUIC v5 | 76.79 | 0.54 |
| VLESS + TLS | 0.63 | 0.004 |
| VLESS + WebSocket | 0.39 | 0.003 |

queqiao led in all six rounds. VLESS is at TCP's Mathis limit for a 249 ms path, not misconfigured. It also cannot carry real-time media — 32% (TLS) to 50% (WS) datagram loss on a 1.8 Mbit/s stream where the QUIC stacks lose 2–4%.

**Two results go the other way, both blocking:**

- Under its own bulk load queqiao's interactive tail degrades more than either competitor's (SSH p99 302 → 940 ms, voice loss 1.9% → 9.0%), which is what bulk isolation exists to prevent.
- **The client stops moving data after a median 2.35 GiB**, 3 reproductions of 3, no self-recovery, cleared only by restarting the client. The `erasure` controller marks 99.9% of samples application-limited and its bandwidth estimate falls to under 2% of the link. Server unaffected — it is client-side. `cmd/queqiaoref` fails the same way, which points at the shared QUIC layer.

The measured path is **not** the 45%-erasure channel the design targets (1–3% memoryless loss, >200 Mbit/s), so this tests the transport, not the design's central claim. Said plainly in the document.

### `docs/DEPLOYING.md` + `deploy/`

Build, egress systemd unit, local client, and the Clash Verge integration, with templates for the macOS LaunchAgent and the Clash profile. Two points get emphasis because both produce a tunnel that *looks* like it works: `--local-address` is mandatory under Clash TUN or queqiao tunnels through the tunnel it replaces, and the stall will be met within an afternoon.

### `docs/BENCHMARKING.md`

Adds the two traps this campaign hit: `NO_PROXY` silently bypassing an explicitly named curl proxy, and assuming a source binding worked instead of having the server report the address it saw.

## Verification

`go build`, `go vet`, `go test`, `go test -race` all clean at 238b5f2. Fuzz targets survived 9.8M and 30.6M execs. `go test -count=6` reproduced the documented UDP-rescue flake once in six. The Clash profile validates against the bundled mihomo core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)