### PR TITLE
fix: pruning the sampler's packet table blocked the send path for 178 ms

### DIFF
--- a/internal/congestion/bbr_tuic.go
+++ b/internal/congestion/bbr_tuic.go
@@ -546,6 +546,36 @@ func saturatingByteAdd(a quiccongestion.ByteCount, b uint64) quiccongestion.Byte
 // The emulator finding was real and is not addressed by this: on a constant
 // path the controller does stay in startup too long. Fixing that needs a
 // mechanism that does not also discard the live path's noise.
+// appLimited reports whether the application, rather than the path, is what
+// is holding the sending rate down. quic-go's congestion interface has no
+// OnApplicationLimited callback, so it has to be inferred, and the inference
+// has to be conservative in one specific direction: BBR only updates its
+// bandwidth filter from samples that are *not* app-limited, so marking too
+// eagerly does not make the estimate cautious, it stops the estimate existing.
+//
+// Being under the congestion window is not the test. A paced sender is almost
+// always under its window -- that is what pacing does -- so `priorInFlight <
+// window` is true nearly every event on a busy connection. Measured on a
+// healthy 100 Mbit/s transfer, that marked 347 of 347 samples app-limited and
+// left the bandwidth estimate at 18 kB/s, about seven hundred times under the
+// rate actually flowing. The controller was running with no working estimate
+// of the path at all.
+//
+// Outside Drain the rule is deliberately liberal: any unused window counts.
+// That looks wrong -- on a saturating transfer it marks nearly every sample,
+// and the bandwidth filter then updates only from the rare event that fills
+// the window exactly -- and it has been tightened twice and reverted twice.
+// Requiring a burst of unused window, or half the window, measures better on
+// the emulator and costs more than half the throughput on the real China-US
+// path, where delivery-rate samples are noisy-low and this marking is what
+// keeps them out of the filter. See TestTUICAppLimitedCountsAnyUnusedWindow-
+// OutsideDrain and DESIGN-MULTIPATH.md 7.6 before touching it again.
+//
+// A near-100% app-limited count in the telemetry is therefore expected, not a
+// symptom. Note also that the /metrics endpoint reports one lane: with
+// --quic-pool that is usually the pooled control connection, which really is
+// idle, so a low bandwidth estimate there says nothing about the lane carrying
+// the data.
 func (b *TUICBBRSender) appLimited(priorInFlight quiccongestion.ByteCount) bool {
 	window := b.GetCongestionWindow()
 	if priorInFlight >= window {

--- a/internal/congestion/bbr_tuic_bw.go
+++ b/internal/congestion/bbr_tuic_bw.go
@@ -1,6 +1,8 @@
 package congestion
 
 import (
+	"slices"
+
 	"math/bits"
 	"time"
 
@@ -306,21 +308,29 @@ func (e *tuicBandwidthEstimator) onAckEvent(now monotime.Time, bytes, round uint
 	e.onAck(now, bytes, round, appLimited)
 }
 
+// pruneStates drops the oldest quarter of the table when it fills.
+//
+// Packet numbers are assigned in send order, so the oldest states are the
+// lowest numbers and one partial selection finds the cut. The previous version
+// rescanned the whole map to find a single oldest entry and did that 2048
+// times -- about 17 million map iterations, on the send path, every time an
+// 8192-entry table filled. At 200 Mbit/s that is roughly every 0.4 seconds.
 func (e *tuicBandwidthEstimator) pruneStates() {
 	remove := tuicMaxSendStates / 4
-	for i := 0; i < remove; i++ {
-		var oldestPN quiccongestion.PacketNumber
-		var oldest monotime.Time
-		first := true
-		for pn, state := range e.packetStates {
-			if first || state.sentTime.Before(oldest) {
-				oldestPN, oldest, first = pn, state.sentTime, false
-			}
-		}
-		if first {
-			return
-		}
-		delete(e.packetStates, oldestPN)
+	if remove <= 0 || len(e.packetStates) == 0 {
+		return
+	}
+	if remove >= len(e.packetStates) {
+		clear(e.packetStates)
+		return
+	}
+	numbers := make([]quiccongestion.PacketNumber, 0, len(e.packetStates))
+	for pn := range e.packetStates {
+		numbers = append(numbers, pn)
+	}
+	slices.Sort(numbers)
+	for _, pn := range numbers[:remove] {
+		delete(e.packetStates, pn)
 	}
 }
 

--- a/internal/congestion/bbr_tuic_test.go
+++ b/internal/congestion/bbr_tuic_test.go
@@ -670,3 +670,50 @@ func TestSeedBandwidthLeavesAnUnmeasuredRoundTripUnset(t *testing.T) {
 		t.Fatalf("min_rtt is %v from a seed alone, want 0 so the sender measures it", got)
 	}
 }
+
+// pruneStates drops the oldest quarter when the table fills. It ran on the
+// send path and rescanned the whole map once per entry removed -- about 17
+// million map iterations for one call at the 8192-entry bound, which at
+// 200 Mbit/s recurs roughly every 0.4 s.
+func TestPruneStatesDropsTheOldestQuarter(t *testing.T) {
+	e := newTUICBandwidthEstimator()
+	now := monotime.Now()
+	for i := 0; i < tuicMaxSendStates; i++ {
+		e.packetStates[quiccongestion.PacketNumber(i)] = tuicPacketState{
+			sentTime: now.Add(time.Duration(i) * time.Microsecond),
+		}
+	}
+	e.pruneStates()
+
+	removed := tuicMaxSendStates / 4
+	if len(e.packetStates) != tuicMaxSendStates-removed {
+		t.Fatalf("table holds %d after prune, want %d", len(e.packetStates), tuicMaxSendStates-removed)
+	}
+	// Packet numbers are assigned in send order, so the oldest are the lowest.
+	for i := 0; i < removed; i++ {
+		if _, ok := e.packetStates[quiccongestion.PacketNumber(i)]; ok {
+			t.Fatalf("packet %d survived the prune, want the oldest quarter gone", i)
+		}
+	}
+	for i := removed; i < tuicMaxSendStates; i++ {
+		if _, ok := e.packetStates[quiccongestion.PacketNumber(i)]; !ok {
+			t.Fatalf("packet %d was pruned, want the newest three quarters kept", i)
+		}
+	}
+}
+
+// A prune must stay cheap enough to sit on the send path.
+func BenchmarkPruneStates(b *testing.B) {
+	now := monotime.Now()
+	for b.Loop() {
+		b.StopTimer()
+		e := newTUICBandwidthEstimator()
+		for i := 0; i < tuicMaxSendStates; i++ {
+			e.packetStates[quiccongestion.PacketNumber(i)] = tuicPacketState{
+				sentTime: now.Add(time.Duration(i) * time.Microsecond),
+			}
+		}
+		b.StartTimer()
+		e.pruneStates()
+	}
+}


### PR DESCRIPTION
## The bug

The delivery sampler bounds its per-packet state table at 8192 entries. On overflow it dropped the oldest quarter — by rescanning the whole map to find one oldest entry, 2048 times. ~17 million map iterations, **on the send path**.

Benchmarked at the bound:

| | ns/op |
|---|---:|
| before | 178,212,927 (**178 ms**) |
| after | 583,273 (0.58 ms) |

178 ms is most of a round trip on the target path, and at 200 Mbit/s the table refills roughly every 0.4 s — so a bulk transfer froze the sender for near an RTT, two or three times a second.

This is a plausible cause of the interactive-tail result in `docs/MEASUREMENTS-20260816.md`: SSH p99 302 ms idle → 940 ms under queqiao's own bulk load, worse than TUIC or Hysteria2, in the case bulk isolation exists to protect.

Packet numbers are assigned in send order, so the oldest states are the lowest numbers and one sort finds the cut. Same result, 306× faster.

## Also in here

Documentation on `appLimited`, which I tightened and then reverted. Requiring a burst of unused window — or half the window — measures better on the emulator and has now twice been measured to cost more than half the throughput on the real path. `TestTUICAppLimitedCountsAnyUnusedWindowOutsideDrain` already asserts the liberal rule and caught the change. Two things worth writing down so the next person doesn't repeat it:

- A near-100% app-limited count is **expected**, not a symptom.
- `/metrics` reports a single lane. With `--quic-pool` that is usually the idle pooled control connection, so a low bandwidth estimate there says nothing about the lane carrying data. Verified: with `--quic-pool=false` the same client reports a sane estimate.

## Verification

New test asserts the prune drops exactly the oldest quarter and keeps the rest; a benchmark pins the cost. `go build`, `go vet`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)