### PR TITLE
Fix aborted-transfer flow lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ and Clash forwards to it as a `socks5` node. Templates are in
 Two things in that document decide whether a deployment works at all. The
 client must be started with `--local-address if:en0`, because Clash's TUN mode
 would otherwise capture queqiao's own outer connection and carry it through the
-tunnel queqiao is replacing. And a download cancelled part-way through can
-leave a flow hung, which after several such aborts stops the client passing
-traffic until it is restarted -- transfers that run to completion are fine --
-which is why this is something to switch to deliberately rather than leave
-carrying a day's traffic. See [`docs/STALL-20260817.md`](docs/STALL-20260817.md).
+tunnel queqiao is replacing. The cancelled-download flow leak described in the
+same guide is fixed; its diagnosis and regression proof remain in
+[`docs/STALL-20260817.md`](docs/STALL-20260817.md).
 
 ## Current status
 
@@ -114,21 +112,21 @@ magnitude behind at 0.63 and 0.39. Interactive latency is at parity with TUIC
 and Hysteria2 idle, and VLESS cannot carry a real-time video stream at all,
 losing a third to a half of it.
 
-**Two results go the other way and both are blocking.** Under its own bulk load
+**One result goes the other way and is still blocking.** Under its own bulk load
 queqiao's interactive tail degrades more than either competitor's -- SSH p99
 302 to 940 ms, voice loss 1.9% to 9.0% -- which is what flow classification and
 bulk isolation exist to prevent, and the emulated 208 ms result below does not
-reproduce there. And **the client stops moving data entirely**, with no
-self-recovery and only a client restart clearing it.
+reproduce there.
 
 That stall has since been diagnosed as two unrelated defects, neither of them
 the path's doing -- it reproduces on the emulator with no network involved.
 [`docs/STALL-20260817.md`](docs/STALL-20260817.md) has both. A seeded round
 trip becoming a permanent `min_rtt` is **fixed**, and it was depressing every
 throughput number above by about 30%: the same live windows now measure around
-200 Mbit/s. What remains is triggered by *aborted* transfers, which that
-campaign's fixed-duration windows performed on every trial; 30 consecutive
-transfers run to completion leave no residue at all.
+200 Mbit/s. The other defect was triggered by *aborted* transfers, which that
+campaign's fixed-duration windows performed on every trial. It is also fixed:
+local close is now a bounded lifecycle event, and the peer cancels response
+work immediately rather than waiting for data the application discarded.
 
 That path is also not the 45%-erasure channel this project targets, so the
 campaign tests the transport rather than the design's central claim.

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -240,23 +240,13 @@ serving the alternatives:
   configurations. Since the `min_rtt` fix in
   [`STALL-20260817.md`](STALL-20260817.md) the same windows measure about
   200 Mbit/s.
-- **Cancelled downloads can stall it.** A transfer aborted part-way through can
-  leave a flow hung, holding a connection the server keeps sending into.
-  Several of those saturate the link with data nobody reads, and the client
-  stops passing traffic until it is restarted. Transfers that run to completion
-  do not do this — 30 consecutive 16 MiB downloads left one connection open and
-  no residue. Nothing is corrupted either way: a stalled client returns zero
-  bytes, never wrong ones, and the server is unaffected. Diagnosis and
-  reproduction in [`STALL-20260817.md`](STALL-20260817.md).
-
-Until that is fixed, treat a queqiao node as something you switch to
-deliberately rather than something you leave carrying a laptop's day. When
-throughput drops to nothing, restart the client:
-
-```sh
-launchctl kickstart -k gui/$(id -u)/me.01.queqiao.client   # macOS
-systemctl --user restart queqiao-client                    # Linux
-```
+- **Cancelled downloads no longer retain flows.** The former failure left the
+  client and server sending into a closed application until several abandoned
+  transfers saturated the link. Local EOF is now signalled across the flow,
+  stalled response delivery escalates to a bounded full-close, and the peer
+  cancels its sender immediately. The original diagnosis and deterministic
+  regression coverage are in
+  [`STALL-20260817.md`](STALL-20260817.md).
 
 Also unfinished, and relevant to a daily driver: interactive latency degrades
 under queqiao's own bulk load more than the alternatives' does; TUN/VLESS
@@ -271,7 +261,7 @@ UDP-blocked, restart, and long-soak behaviour is unmeasured on a real path.
 | `curl` through the SOCKS port succeeds but reports your own IP | `NO_PROXY` is set; use `env -u NO_PROXY -u no_proxy curl --noproxy ''` |
 | Client starts, no flows ever appear in `/metrics` | Clash rules are not reaching the group that holds the node |
 | Handshake fails with a certificate error | `--server-name` does not match the certificate's CN/SAN, or `--root-ca` is the wrong file |
-| Works, then stops after a few GiB | the stall above; restart the client |
+| An older build works, then stops after several cancelled transfers | upgrade both endpoints; this was the abort lifecycle defect fixed in `STALL-20260817.md` |
 | Throughput fine, UDP applications fail | peer negotiated no QUIC datagrams and fell back to the control stream, or the lane is TLS/TCP |
 
 Logs are on stdout; `--log-level debug` reports the outer lane's transport,

--- a/docs/MEASUREMENTS-20260816.md
+++ b/docs/MEASUREMENTS-20260816.md
@@ -176,9 +176,10 @@ under a 50 MiB transfer) does not reproduce here.
 > unrelated defects, and the byte count was not the trigger. One -- a seeded
 > round trip becoming a permanent `min_rtt` -- is fixed, and it was also
 > depressing every throughput number in this document by about 30%. The
-> other is triggered by *aborted* transfers, which this campaign's
-> fixed-duration windows performed on every single trial; transfers that run
-> to completion do not stall.
+> other was triggered by *aborted* transfers, which this campaign's
+> fixed-duration windows performed on every single trial. It is fixed by the
+> bounded local-close lifecycle described there; transfers that run to
+> completion never exhibited it.
 
 Found by accident: the first throughput campaign recorded 176, 156, 175, 167,
 136 Mbit/s, then 5.3, then zero for every remaining round, while still

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -115,10 +115,19 @@ negotiate the capability.
 `CLOSE` with `FlagFin` is a directional half-close. A sender may later send
 the same final sequence with `FlagCloseAbort` when its application socket has
 fully closed and the peer should release an otherwise idle keep-alive
-destination. The receiver acknowledges the abort sequence before closing its
-inner connection. This escalation is deliberately delayed after the normal
-final ACK so legitimate half-closed uploads and interactive sessions can
-continue to receive response bytes.
+destination. `FlagCloseAbort` is cancellation rather than an ordered FIN: the
+receiver stops its sender and closes its inner connection immediately, even if
+the abort sequence is beyond a reassembly gap, then makes a bounded best effort
+to acknowledge that sequence. Waiting for the gap would retain response chunks
+that the vanished application can never acknowledge.
+
+A local EOF alone does not trigger this escalation because TCP exposes
+`CloseWrite` and `Close` the same way. The abort grace begins once response
+data is present but cannot make application progress, or after the peer has
+acknowledged the normal FIN. Successful application writes renew it; a failed
+write proves the full close and escalates immediately. After sending the abort,
+the sender drains its final ACK for a bounded interval and then terminates the
+flow regardless.
 
 ## Backpressure
 

--- a/docs/STALL-20260817.md
+++ b/docs/STALL-20260817.md
@@ -83,7 +83,7 @@ measured bottleneck on the wire — which is what one BBR sender probing alone
 would have done, and that is the property the share exists to preserve. A lone
 member takes no cap at all, having nothing to compound with.
 
-## Defect 2: an aborted transfer can leave a flow hung (open)
+## Defect 2: an aborted transfer can leave a flow hung (fixed)
 
 The live stall survives the fix above. It reproduced again at window 10 and
 4.41 GiB — a larger figure than before only because the transport is now
@@ -138,13 +138,51 @@ cancelled, and the flow is never closed. Six more goroutines sit in
 taken the error path, which does call `cancelRun` and `closeAll`. So both
 directions are alive and both are waiting on transport-side events.
 
-**Nothing observes that the local application socket is gone.** A transfer cut
-off with `--max-time` resets the SOCKS connection rather than closing it
-cleanly, and neither worker is watching for that; the flow waits on a scheduler
-whose source will never produce another byte and whose chunks will never
-complete. The fix belongs in the flow lifecycle — the inner connection's death
-has to cancel the run context — and is not a one-line change, which is why it
-is not in this commit.
+**Nothing observed that the local application socket was gone.** A transfer cut
+off with `--max-time` could look like an ordinary send-side EOF, while a
+reassembly gap prevented the receive worker from attempting the write that
+would have discovered the missing reader. The flow then waited on a scheduler
+whose chunks could never complete.
+
+### Fix and regression proof
+
+The fix is deliberately portable and lives in the flow lifecycle rather than
+an OS socket probe. TCP exposes a peer's `CloseWrite` and `Close` as the same
+EOF, so `POLLHUP`, a zero-length read, or a platform-specific syscall cannot
+reliably distinguish the legitimate half-close from the vanished application.
+
+The lifecycle now has four explicit rules:
+
+1. `flowSource` publishes local EOF and its final source sequence to the
+   receive worker. EOF alone remains quiet; it does not abort a legitimate
+   half-closed upload.
+2. Once response data is buffered behind a gap, or the peer has acknowledged
+   the normal FIN, lack of application progress is bounded. Successful writes
+   renew the grace; a failed write proves the reader is gone and escalates at
+   once.
+3. `CLOSE_ABORT` is cancellation, not an ordered FIN. The receiver closes its
+   endpoint and stops its response scheduler immediately, even when earlier
+   data is missing, because the application has said that none of those bytes
+   remain useful.
+4. The sender gives the abort ACK a bounded drain and then closes `done`. That
+   last signal also interrupts a concurrent 45-second lane-replacement wait,
+   so result ordering cannot recreate the leak.
+
+The regression tests reduce the live failure to deterministic in-memory
+flows: an out-of-order response plus an unacknowledged request must terminate
+without an abort ACK; response progress must preserve a real half-close; a
+failed application write must send the abort immediately; and a received abort
+must stop an unacknowledged response scheduler and close the destination. The
+focused set passes under the race detector, the full Go suite passes, and all
+six Linux, macOS, and Windows CI build targets compile.
+
+The original live reproduction also passes with the fix. Fourteen back-to-back
+20-second cancellations moved 5.50 GiB; every window remained live at
+110.6–210.1 Mbit/s. After the final drain the client reported 14 flows started,
+13 completed, one failed, **zero active flows and zero lanes**. The server held
+no origin connections and only its listening descriptors. The one failure was
+accounted and released rather than becoming the unbounded residue measured
+above.
 
 This matters in normal use — cancelling a download, closing a tab mid-load —
 and it is the reason the deployment guide still says to treat a queqiao node as
@@ -153,7 +191,8 @@ something to switch to deliberately.
 Reproduce with `scripts/`-style loops or directly:
 
 ```sh
-# Leaks. Watch queqiao_active_flows and queqiao_quic_lanes climb.
+# Historical failing reproduction. On an affected build, watch
+# queqiao_active_flows and queqiao_quic_lanes climb.
 for w in $(seq 1 14); do
   curl -sS --max-time 20 --socks5-hostname 127.0.0.1:12080 \
        -o /dev/null http://ORIGIN/stream
@@ -197,7 +236,6 @@ on the same transfer.
 
 ## Still open after this
 
-- The abort leak above.
 - **The interactive tail under bulk load is unexplained.** The send-path prune
   fix was expected to help and, re-measured over three rounds, did not: SSH p99
   under load came out 802 / 3267 / 606 ms against 940 before, and voice under

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -59,8 +59,9 @@ const (
 	// retention when the peer closes its last lane at exactly that point.
 	flowCompletionGrace = 5 * time.Second
 	// A local EOF is ambiguous between TCP half-close and full application
-	// close. Wait for the final ACK, then escalate only after an idle grace;
-	// interactive sessions get more time for legitimate quiet periods.
+	// close. Escalate only after response traffic stops making progress, or
+	// after the peer has acknowledged the local FIN; interactive sessions get
+	// more time for legitimate quiet periods.
 	flowAbortGrace        = 5 * time.Second
 	interactiveAbortGrace = 30 * time.Second
 	remoteFinDrainGrace   = 500 * time.Millisecond
@@ -77,8 +78,9 @@ const (
 )
 
 var (
-	errFlowIdleTimeout = errors.New("flow idle timeout")
-	errFlowLifetime    = errors.New("flow lifetime exceeded")
+	errFlowIdleTimeout       = errors.New("flow idle timeout")
+	errFlowLifetime          = errors.New("flow lifetime exceeded")
+	errLocalApplicationClose = errors.New("local application closed")
 )
 
 type mpLane struct {
@@ -238,9 +240,14 @@ type multipathFlow struct {
 	controlLaneShared func() bool
 	started           time.Time
 	completionGrace   time.Duration
-	bytesUp           atomic.Uint64
-	bytesDown         atomic.Uint64
-	class             atomic.Uint32
+	// abortGrace and abortDrainGrace are zero in production. Tests shorten
+	// the two independently so the inactivity and bounded-drain state machine
+	// can be exercised without sleeping for seconds.
+	abortGrace      time.Duration
+	abortDrainGrace time.Duration
+	bytesUp         atomic.Uint64
+	bytesDown       atomic.Uint64
+	class           atomic.Uint32
 	// ackTrack answers "has this range arrived?", which is what clocks every
 	// lane. scheduler and sendCtx let a lane joined mid-flow start carrying
 	// data as soon as it is admitted.
@@ -263,7 +270,11 @@ type multipathFlow struct {
 	finSent           atomic.Bool
 	remoteFinSeen     atomic.Bool
 	localClosed       atomic.Bool
+	localClosedOnce   sync.Once
+	localClosedCh     chan struct{}
 	remoteAbort       atomic.Bool
+	remoteAbortOnce   sync.Once
+	remoteAbortCh     chan struct{}
 	localAbortSent    atomic.Bool
 	laneFailures      atomic.Uint64
 	// onProtocolReset is called when the peer rejects this flow's open on
@@ -332,7 +343,8 @@ func newMultipathFlow(ctx context.Context, inner net.Conn, sessionID [16]byte, f
 		sendAckFlag: sendAckFlag, recvAckFlag: recvAckFlag,
 		lanes: make(map[uint64]*mpLane), events: make(chan inboundEvent, maxLaneEvents), laneErr: make(chan laneFailure, maxLaneEvents),
 		finalAck: make(chan struct{}, 1), sendDone: make(chan struct{}),
-		done: make(chan struct{}), ackWake: make(chan struct{}, 1), ackErr: make(chan error, 1),
+		done: make(chan struct{}), localClosedCh: make(chan struct{}), remoteAbortCh: make(chan struct{}),
+		ackWake: make(chan struct{}, 1), ackErr: make(chan error, 1),
 		classifier: classifier.New(classifier.DefaultConfig()), started: time.Now(), completionGrace: flowCompletionGrace,
 	}
 	if len(loggers) > 0 && loggers[0] != nil {
@@ -505,10 +517,42 @@ func (f *multipathFlow) snapshot() flowSnapshot {
 }
 
 func (f *multipathFlow) localAbortGrace() time.Duration {
+	if f.abortGrace > 0 {
+		return f.abortGrace
+	}
 	if classifier.Class(f.class.Load()) == classifier.ClassInteractive {
 		return interactiveAbortGrace
 	}
 	return flowAbortGrace
+}
+
+func (f *multipathFlow) localAbortDrainGrace() time.Duration {
+	if f.abortDrainGrace > 0 {
+		return f.abortDrainGrace
+	}
+	return finalAckWriteGrace
+}
+
+// noteLocalClose publishes the source sequence before announcing EOF. The
+// receive side may have to send a full-close marker before the scheduler has
+// delivered every source chunk, so sendFinal is too late to be the first place
+// that records this sequence.
+func (f *multipathFlow) noteLocalClose(sequence uint64) {
+	f.sendSequence(sequence)
+	f.localClosed.Store(true)
+	if f.localClosedCh != nil {
+		f.localClosedOnce.Do(func() { close(f.localClosedCh) })
+	}
+}
+
+// noteRemoteAbort makes an explicit full close an out-of-band cancellation
+// source for the sender. Waiting for its outstanding chunks to be acknowledged
+// cannot work: the peer has just said that its application will not read them.
+func (f *multipathFlow) noteRemoteAbort() {
+	f.remoteAbort.Store(true)
+	if f.remoteAbortCh != nil {
+		f.remoteAbortOnce.Do(func() { close(f.remoteAbortCh) })
+	}
 }
 
 func (f *multipathFlow) observeTransport(lanes []*mpLane) {
@@ -994,6 +1038,21 @@ func (f *multipathFlow) run(ctx context.Context) (FlowStats, error) {
 		select {
 		case err := <-results:
 			completed++
+			if errors.Is(err, errLocalApplicationClose) ||
+				(f.localAbortSent.Load() && f.doneChanClosed()) {
+				// The full-close marker has had a bounded opportunity to reach
+				// the peer. It is now safe to stop the sibling sender even when
+				// its scheduler still holds chunks the vanished application can
+				// never acknowledge. A local cancellation is a clean flow end,
+				// not a transport failure.
+				cancelRun()
+				f.closeAll()
+				stats.Ended = time.Now()
+				stats.BytesSent = f.bytesUp.Load()
+				stats.BytesRead = f.bytesDown.Load()
+				stats.LaneBytes = f.laneStats()
+				return stats, nil
+			}
 			if err != nil {
 				// A destination can reset immediately after the client has
 				// sent its FIN. Give the receive worker a short bounded window
@@ -1751,6 +1810,13 @@ func (f *multipathFlow) acknowledgeRemoteFIN(ctx context.Context, sequence uint6
 	f.remoteFinSequence.Store(sequence)
 	f.remoteFinSeen.Store(true)
 	f.ackClosing.Store(true)
+	if abort {
+		// Publish cancellation before any best-effort close or ACK. The send
+		// scheduler may hold response chunks forever once the peer has removed
+		// its reader, and must not depend on those operations succeeding.
+		f.noteRemoteAbort()
+		_ = f.inner.Close()
+	}
 	if cw, ok := f.inner.(closeWriter); ok {
 		if err := cw.CloseWrite(); err != nil && !expectedHalfCloseError(err) {
 			return err
@@ -1769,11 +1835,6 @@ func (f *multipathFlow) acknowledgeRemoteFIN(ctx context.Context, sequence uint6
 		}
 		return err
 	}
-	if abort {
-		f.remoteAbort.Store(true)
-		// No response bytes remain useful after an explicit full-close.
-		_ = f.inner.Close()
-	}
 	return nil
 }
 
@@ -1783,9 +1844,9 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 	var lastAckSequence uint64
 	var abortTimer *time.Timer
 	var abortTimerC <-chan time.Time
-	resetAbortTimer := func() {
+	resetAbortTimer := func(delay time.Duration) {
 		if abortTimer == nil {
-			abortTimer = time.NewTimer(f.localAbortGrace())
+			abortTimer = time.NewTimer(delay)
 		} else {
 			if !abortTimer.Stop() {
 				select {
@@ -1793,17 +1854,76 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 				default:
 				}
 			}
-			abortTimer.Reset(f.localAbortGrace())
+			abortTimer.Reset(delay)
 		}
 		abortTimerC = abortTimer.C
+	}
+	startLocalAbort := func() error {
+		if !f.localAbortSent.CompareAndSwap(false, true) {
+			return nil
+		}
+		if len(f.healthyLanes()) == 0 {
+			return errors.New("no healthy lane for local abort")
+		}
+		writeCtx, cancel := context.WithTimeout(ctx, f.localAbortDrainGrace())
+		err := f.writeControl(writeCtx, protocol.Frame{Header: protocol.Header{
+			Version: protocol.Version, Type: protocol.TypeClose,
+			Flags:     protocol.FlagFin | protocol.FlagCloseAbort,
+			SessionID: f.sessionID, FlowID: f.flowID, Sequence: f.finSequence.Load(),
+			Class: protocol.Class(f.class.Load()),
+		}}, nil)
+		cancel()
+		return err
+	}
+	deliverToInner := func(out []byte) error {
+		if len(out) == 0 || f.localAbortSent.Load() {
+			return nil
+		}
+		if err := writeFull(f.inner, out); err != nil {
+			if !expectedHalfCloseError(err) && !expectedDestinationCloseError(err) {
+				return err
+			}
+			// A failed response write is direct proof that this was a full
+			// close, not merely a send-side half-close. Escalate immediately;
+			// waiting for the inactivity grace would retain the peer's sender
+			// and endpoint for no benefit.
+			f.noteLocalClose(f.bytesUp.Load())
+			if err := startLocalAbort(); err != nil {
+				f.closeAll()
+				return errLocalApplicationClose
+			}
+			resetAbortTimer(f.localAbortDrainGrace())
+			return nil
+		}
+		f.observe(len(out), false)
+		f.bytesDown.Add(uint64(len(out)))
+		if f.localClosed.Load() {
+			// A successful write proves that the application kept its receive
+			// half open. Measure the grace from the last such proof, not from
+			// the original EOF.
+			resetAbortTimer(f.localAbortGrace())
+		}
+		return nil
 	}
 	defer func() {
 		if abortTimer != nil {
 			abortTimer.Stop()
 		}
 	}()
+	// EOF is published by flowSource. It cannot by itself arm the timer: TCP
+	// presents CloseWrite and Close identically, so a quiet local EOF may be a
+	// legitimate half-close. Buffered response data, a successful response
+	// write, or the peer's final ACK supplies the additional evidence that
+	// makes a bounded response-side grace appropriate.
+	localClosedC := f.localClosedCh
+	sendDoneC := f.sendDone
 	for {
 		select {
+		case <-localClosedC:
+			localClosedC = nil
+			if reassembler.BufferedBytes() > 0 && abortTimer == nil {
+				resetAbortTimer(f.localAbortGrace())
+			}
 		case event := <-f.events:
 			frame := event.frame
 			// A pipelined HELLO_OK is session-scoped and carries flow 0, so it
@@ -1845,11 +1965,14 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 					return err
 				}
 				if len(out) > 0 {
-					if err := writeFull(f.inner, out); err != nil {
+					if err := deliverToInner(out); err != nil {
 						return err
 					}
-					f.observe(len(out), false)
-					f.bytesDown.Add(uint64(len(out)))
+				} else if f.localClosed.Load() && reassembler.BufferedBytes() > 0 && abortTimer == nil {
+					// Transport data is arriving but an earlier gap prevents any
+					// write to the application. This was the live leak: without a
+					// timer no operation remained that could discover its close.
+					resetAbortTimer(f.localAbortGrace())
 				}
 				lastAckSequence = f.acknowledgeArrival(reassembler, lastAckSequence)
 				if closed {
@@ -1877,37 +2000,24 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 				}
 				abort := frame.Header.Flags&protocol.FlagCloseAbort != 0
 				if abort {
-					// Preserve the abort intent if the FIN is buffered behind
-					// out-of-order data; the contiguous data path above will
-					// perform the actual final ACK and close.
-					f.remoteAbort.Store(true)
+					// A full close is cancellation, not an ordered half-close. The
+					// peer no longer wants bytes in either direction, so waiting
+					// for a missing request segment before stopping the response
+					// sender only preserves work that can never be consumed.
+					return f.acknowledgeRemoteFIN(ctx, frame.Header.Sequence, true)
 				}
 				out, closed, err := reassembler.Insert(multipath.Segment{Sequence: frame.Header.Sequence, Final: true})
 				if err != nil {
 					return err
 				}
 				if len(out) > 0 {
-					if err := writeFull(f.inner, out); err != nil {
+					if err := deliverToInner(out); err != nil {
 						return err
-					}
-					f.observe(len(out), false)
-					f.bytesDown.Add(uint64(len(out)))
-					if abortTimer != nil {
-						resetAbortTimer()
 					}
 				}
 				if closed {
 					if err := f.acknowledgeRemoteFIN(ctx, reassembler.NextSequence(), abort); err != nil {
 						return err
-					}
-					if abort {
-						f.remoteAbort.Store(true)
-						// The application has explicitly closed its full socket;
-						// no response bytes are still useful. Closing the inner
-						// connection releases a keep-alive destination and unblocks
-						// sendInner, which observes remoteAbort and exits cleanly.
-						_ = f.inner.Close()
-						return nil
 					}
 					remoteFin = true
 					select {
@@ -1942,11 +2052,18 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 					case f.finalAck <- struct{}{}:
 					default:
 					}
+					if f.localAbortSent.Load() {
+						// This acknowledgement covers the abort sequence and every
+						// source chunk before it. Tell run to retire the sender rather
+						// than waiting for a remote FIN that an aborted flow will not
+						// send.
+						return errLocalApplicationClose
+					}
 					if remoteFin {
 						return nil
 					}
 					if f.localClosed.Load() {
-						resetAbortTimer()
+						resetAbortTimer(f.localAbortGrace())
 					}
 				} else {
 					return errors.New("final acknowledgement sequence mismatch")
@@ -1981,29 +2098,30 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 				return nil
 			}
 			return errors.New("flow closed")
-		case <-abortTimerC:
-			if f.localAbortSent.CompareAndSwap(false, true) {
-				if len(f.healthyLanes()) == 0 {
-					// The peer has already closed its transport after ACKing our
-					// FIN. There is no lane on which to carry the escalation, and
-					// the application has no remaining reader; release locally.
-					f.closeAll()
-					return nil
-				}
-				if err := f.writeControl(ctx, protocol.Frame{Header: protocol.Header{
-					Version: protocol.Version, Type: protocol.TypeClose,
-					Flags:     protocol.FlagFin | protocol.FlagCloseAbort,
-					SessionID: f.sessionID, FlowID: f.flowID, Sequence: f.finSequence.Load(),
-					Class: protocol.Class(f.class.Load()),
-				}}, nil); err != nil {
-					if f.localClosed.Load() {
-						f.closeAll()
-						return nil
-					}
-					return err
-				}
+		case <-sendDoneC:
+			sendDoneC = nil
+			if f.localAbortSent.Load() {
+				return errLocalApplicationClose
 			}
-			return nil
+		case <-abortTimerC:
+			if f.localAbortSent.Load() {
+				// The abort write received a bounded drain window. Do not let a
+				// missing final ACK recreate the permanent flow leak.
+				f.closeAll()
+				return errLocalApplicationClose
+			}
+			if err := startLocalAbort(); err != nil {
+				// run may currently be inside a bounded lane-replacement wait
+				// rather than selecting worker results. Closing done is the
+				// wake-up that makes this a real termination source.
+				f.closeAll()
+				return errLocalApplicationClose
+			}
+			drainGrace := f.localAbortDrainGrace()
+			// Keep consuming acknowledgements briefly. A final ACK lets the
+			// scheduler release retained chunks cleanly; expiry is still a clean
+			// local cancellation and run will stop the sibling explicitly.
+			resetAbortTimer(drainGrace)
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/internal/pep/mpflow_writer_test.go
+++ b/internal/pep/mpflow_writer_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -28,6 +29,13 @@ type ackCaptureConn struct {
 	closed   chan struct{}
 	closeOne sync.Once
 }
+
+type writeFailConn struct {
+	net.Conn
+	err error
+}
+
+func (c *writeFailConn) Write([]byte) (int, error) { return 0, c.err }
 
 func newAckCaptureConn(delay time.Duration, fail error) *ackCaptureConn {
 	return &ackCaptureConn{frames: make(chan protocol.Frame, 16), delay: delay, fail: fail, closed: make(chan struct{})}
@@ -202,6 +210,268 @@ func TestFlowIdleTimeoutReleasesResources(t *testing.T) {
 	}
 	if got := registry.Snapshot(); got.FlowTimeouts != 1 || got.ActiveFlows != 0 {
 		t.Fatalf("timeout metrics = %+v, want one timeout and no active flows", got)
+	}
+}
+
+// A TCP EOF does not distinguish CloseWrite from Close: both tell the proxy
+// only that the application's send half is finished. A quiet peer therefore
+// must not be aborted merely because the local reader reached EOF. The abort
+// grace starts only once response traffic is stalled or the peer has
+// acknowledged the local FIN.
+func TestQuietLocalHalfCloseDoesNotArmAbort(t *testing.T) {
+	inner, peer := net.Pipe()
+	defer peer.Close()
+	flow := newMultipathFlow(context.Background(), inner, [16]byte{1}, 7, 1024,
+		protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
+	flow.abortGrace = 10 * time.Millisecond
+	flow.noteLocalClose(0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	err := flow.receiveInner(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("quiet half-close ended receive loop with %v, want context deadline", err)
+	}
+	if flow.localAbortSent.Load() {
+		t.Fatal("quiet half-close was escalated to a full-close abort")
+	}
+}
+
+func TestResponseProgressRenewsLocalHalfCloseGrace(t *testing.T) {
+	inner, application := net.Pipe()
+	defer application.Close()
+	flow := newMultipathFlow(context.Background(), inner, [16]byte{1}, 7, 1024,
+		protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
+	flow.abortGrace = 60 * time.Millisecond
+	flow.noteLocalClose(0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 140*time.Millisecond)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- flow.receiveInner(ctx) }()
+	for sequence := uint64(0); sequence < 4; sequence++ {
+		if sequence > 0 {
+			time.Sleep(35 * time.Millisecond)
+		}
+		flow.events <- inboundEvent{frame: protocol.Frame{Header: protocol.Header{
+			Version: protocol.Version, Type: protocol.TypeData,
+			SessionID: [16]byte{1}, FlowID: 7, Sequence: sequence,
+		}, Payload: []byte{'x'}}}
+		var got [1]byte
+		if _, err := io.ReadFull(application, got[:]); err != nil {
+			t.Fatalf("read response byte %d: %v", sequence, err)
+		}
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("progressing response ended receive loop with %v, want context deadline", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("receive loop did not honor its context")
+	}
+	if flow.localAbortSent.Load() {
+		t.Fatal("response progress was escalated to a full-close abort")
+	}
+}
+
+func TestFailedApplicationWriteSendsAbortImmediately(t *testing.T) {
+	pipe, peer := net.Pipe()
+	defer peer.Close()
+	outer := newAckCaptureConn(0, nil)
+	flow := newMultipathFlow(context.Background(), &writeFailConn{Conn: pipe, err: syscall.EPIPE},
+		[16]byte{1}, 7, 1024, protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
+	flow.abortDrainGrace = 20 * time.Millisecond
+	flow.lanes[0] = &mpLane{id: 0, fc: newFrameConn(outer, protocol.DefaultMaxPayload)}
+
+	result := make(chan error, 1)
+	go func() { result <- flow.receiveInner(context.Background()) }()
+	flow.events <- inboundEvent{frame: protocol.Frame{Header: protocol.Header{
+		Version: protocol.Version, Type: protocol.TypeData,
+		SessionID: [16]byte{1}, FlowID: 7, Sequence: 0,
+	}, Payload: []byte("response")}}
+	frame := waitAckFrame(t, outer)
+	if frame.Header.Type != protocol.TypeClose || frame.Header.Flags != protocol.FlagFin|protocol.FlagCloseAbort {
+		t.Fatalf("failed local write produced type=%d flags=%#x, want CLOSE FIN|CLOSE_ABORT",
+			frame.Header.Type, frame.Header.Flags)
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, errLocalApplicationClose) {
+			t.Fatalf("failed local write ended receive loop with %v, want local close", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("failed local write did not end after the abort drain")
+	}
+}
+
+// This is the live leak reduced to one deterministic flow. The application
+// closes after the peer has delivered only an out-of-order response segment.
+// The local sender is deliberately left with an unacknowledged request, so
+// neither the scheduler nor the remote-FIN path can end the flow for us.
+func TestLocalCloseAbortsStalledReceiveAndReleasesRun(t *testing.T) {
+	inner, application := net.Pipe()
+	outer, peer := net.Pipe()
+	defer application.Close()
+	defer peer.Close()
+
+	sessionID := [16]byte{1}
+	const flowID = uint64(7)
+	flow := newMultipathFlow(context.Background(), inner, sessionID, flowID, 1024,
+		protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
+	flow.abortGrace = 20 * time.Millisecond
+	flow.abortDrainGrace = 100 * time.Millisecond
+	if err := flow.addLane(&mpLane{id: 0, fc: newFrameConn(outer, protocol.DefaultMaxPayload)}); err != nil {
+		t.Fatal(err)
+	}
+
+	responseBuffered := make(chan struct{})
+	abortSeen := make(chan protocol.Frame, 1)
+	peerErr := make(chan error, 1)
+	go func() {
+		buffered := false
+		for {
+			frame, err := protocol.ReadFrame(peer, protocol.DefaultMaxPayload)
+			if err != nil {
+				peerErr <- err
+				return
+			}
+			switch frame.Header.Type {
+			case protocol.TypeData:
+				if buffered {
+					continue
+				}
+				buffered = true
+				// Sequence zero is intentionally absent. receiveInner holds
+				// this byte in its reassembler and cannot discover the closed
+				// application by attempting a write.
+				if err := protocol.WriteFrame(peer, protocol.Frame{Header: protocol.Header{
+					Version: protocol.Version, Type: protocol.TypeData,
+					SessionID: sessionID, FlowID: flowID, Sequence: 1,
+				}, Payload: []byte("stalled")}); err != nil {
+					peerErr <- err
+					return
+				}
+				close(responseBuffered)
+			case protocol.TypeClose:
+				if frame.Header.Flags&protocol.FlagCloseAbort == 0 {
+					peerErr <- errors.New("received ordinary FIN instead of abort")
+					return
+				}
+				if frame.Header.Sequence != uint64(len("request")) {
+					peerErr <- errors.New("abort did not carry the complete source sequence")
+					return
+				}
+				abortSeen <- frame
+				// Deliberately withhold the final ACK. The regression was a
+				// flow whose scheduler and receive loop both waited forever;
+				// cleanup must therefore be bounded even when the abort's
+				// completion signal is also absent.
+				return
+			}
+		}
+	}()
+
+	type runResult struct {
+		stats FlowStats
+		err   error
+	}
+	result := make(chan runResult, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		stats, err := flow.run(ctx)
+		result <- runResult{stats: stats, err: err}
+	}()
+	if _, err := application.Write([]byte("request")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-responseBuffered:
+	case err := <-peerErr:
+		t.Fatalf("peer failed before buffering response: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("peer did not send the stalled response segment")
+	}
+	_ = application.Close()
+
+	select {
+	case frame := <-abortSeen:
+		if frame.Header.Flags != protocol.FlagFin|protocol.FlagCloseAbort {
+			t.Fatalf("abort flags = %#x, want FIN|CLOSE_ABORT", frame.Header.Flags)
+		}
+	case err := <-peerErr:
+		t.Fatalf("peer failed before receiving abort: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("local close did not produce a bounded abort")
+	}
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatalf("locally aborted flow returned error: %v", got.err)
+		}
+		if got.stats.BytesSent != uint64(len("request")) {
+			t.Fatalf("sent bytes = %d, want %d", got.stats.BytesSent, len("request"))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flow remained stuck after the bounded abort drain")
+	}
+}
+
+// A full-close abort is cancellation, not an ordered half-close. In
+// particular, the peer's sender may have response chunks outstanding that the
+// vanished application will never acknowledge. Receiving the abort must stop
+// that scheduler and close the peer-side endpoint immediately.
+func TestRemoteAbortStopsUnacknowledgedSenderAndClosesInner(t *testing.T) {
+	inner, destination := net.Pipe()
+	defer destination.Close()
+	outer := newAckCaptureConn(0, nil)
+	sessionID := [16]byte{2}
+	const flowID = uint64(9)
+	flow := newMultipathFlow(context.Background(), inner, sessionID, flowID, 1024,
+		protocol.FlagAckDown, protocol.FlagAckUp, nil, nil)
+	if err := flow.addLane(&mpLane{id: 0, fc: newFrameConn(outer, protocol.DefaultMaxPayload)}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := flow.run(ctx)
+		result <- err
+	}()
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := destination.Write(bytes.Repeat([]byte("response"), 256))
+		writeDone <- err
+	}()
+	frame := waitAckFrame(t, outer)
+	if frame.Header.Type != protocol.TypeData {
+		t.Fatalf("first outbound frame type = %d, want DATA", frame.Header.Type)
+	}
+
+	flow.events <- inboundEvent{frame: protocol.Frame{Header: protocol.Header{
+		Version: protocol.Version, Type: protocol.TypeClose,
+		Flags:     protocol.FlagFin | protocol.FlagCloseAbort,
+		SessionID: sessionID, FlowID: flowID, Sequence: 0,
+	}}}
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("remote abort ended flow with error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("remote abort left the response scheduler outstanding")
+	}
+	select {
+	case <-writeDone:
+	case <-time.After(time.Second):
+		t.Fatal("remote abort did not release the destination writer")
+	}
+	_ = destination.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+	if _, err := destination.Write([]byte("still open?")); err == nil {
+		t.Fatal("destination connection remained writable after remote abort")
 	}
 }
 

--- a/internal/pep/stripedsend.go
+++ b/internal/pep/stripedsend.go
@@ -234,7 +234,10 @@ func (s *flowSource) Read(p []byte) (int, error) {
 			err = io.EOF
 		}
 		if errors.Is(err, io.EOF) {
-			s.flow.localClosed.Store(true)
+			// Publish the final source sequence at EOF, not later in
+			// sendFinal. A full application close may need to abort while
+			// unacknowledged source chunks still keep the scheduler alive.
+			s.flow.noteLocalClose(s.flow.bytesUp.Load())
 		}
 	}
 	return n, err
@@ -286,6 +289,11 @@ func (f *multipathFlow) sendInnerStriped(ctx context.Context) (err error) {
 
 	select {
 	case <-sched.Done():
+	case <-f.remoteAbortCh:
+		// A full-close marker says the peer no longer has an application
+		// reader. Outstanding response chunks can never be acknowledged and
+		// are no longer useful, so cancellation is the successful outcome.
+		return nil
 	case <-sendCtx.Done():
 		return sendCtx.Err()
 	case <-f.done:
@@ -300,6 +308,11 @@ func (f *multipathFlow) sendInnerStriped(ctx context.Context) (err error) {
 	if f.remoteAbort.Load() {
 		// The peer closed its full application socket; a local read error is a
 		// consequence of that, not a transport failure.
+		return nil
+	}
+	if f.localAbortSent.Load() {
+		// receiveInner already sent the stronger FIN|CLOSE_ABORT marker. Do
+		// not follow it with an ordinary FIN for the same sequence.
 		return nil
 	}
 	return f.sendFinal(ctx, sched.Stats().SourceBytes)
@@ -496,8 +509,7 @@ func (f *multipathFlow) sendChunk(ctx context.Context, lane *mpLane, chunk *stri
 // sendFinal closes the outbound direction once every byte has been
 // acknowledged, and waits for the peer's final acknowledgement.
 func (f *multipathFlow) sendFinal(ctx context.Context, sequence uint64) error {
-	f.localClosed.Store(true)
-	f.sendSequence(sequence)
+	f.noteLocalClose(sequence)
 	fin := protocol.Frame{Header: protocol.Header{
 		Version: protocol.Version, Type: protocol.TypeClose, Flags: protocol.FlagFin,
 		SessionID: f.sessionID, FlowID: f.flowID, Sequence: sequence, Class: protocol.Class(f.class.Load()),


### PR DESCRIPTION
## Root cause

A local application close could leave both flow workers alive: the sender waited on unacknowledged scheduler chunks, while the receiver held out-of-order response data and never attempted the socket write that would reveal the missing reader. The abort timer was never armed on that path, and `run` could also be inside a 45-second lane-replacement wait rather than selecting worker results.

## Fix

- publish local EOF and its final source sequence to the receive worker without treating every TCP EOF as a full close
- bound stalled response delivery, renew the grace on successful writes, and escalate failed application writes immediately
- treat `CLOSE_ABORT` as cancellation at the peer, stopping response scheduling even across a reassembly gap
- give the abort ACK a bounded drain and wake lane-replacement waits through the flow `done` signal
- keep user cancellation out of failed-flow accounting regardless of worker result order

## Verification

- deterministic regressions cover quiet and progressing half-closes, failed application writes, stalled reassembly without an abort ACK, and peer cancellation with outstanding data
- focused regressions pass under `go test -race`
- `go test ./...` and `go vet ./...` pass
- all six Linux/macOS/Windows amd64/arm64 CI build targets compile locally
- original live reproduction: 14 back-to-back 20-second aborts, 5.50 GiB moved at 110.6–210.1 Mbit/s; final accounting 14 started / 13 completed / 1 failed / 0 active / 0 lanes, with no origin connection retained

The second commit updates the protocol, deployment guidance, README status, and investigation record.