### PR TITLE
Fix ambiguous controller path measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,14 @@ magnitude behind at 0.63 and 0.39. Interactive latency is at parity with TUIC
 and Hysteria2 idle, and VLESS cannot carry a real-time video stream at all,
 losing a third to a half of it.
 
-**One result goes the other way and is still blocking.** Under its own bulk load
-queqiao's interactive tail degrades more than either competitor's -- SSH p99
-302 to 940 ms, voice loss 1.9% to 9.0% -- which is what flow classification and
-bulk isolation exist to prevent, and the emulated 208 ms result below does not
-reproduce there.
+**The former blocking interactive result has been remeasured.** The original
+build degraded from 302 to 940 ms SSH p99 under its own bulk load. After fixing
+two controller measurements, a three-round alternating live A/B measured a
+559 ms median bulk p99 and a 655 ms worst run; voice bulk p99 was 318 ms with
+8.2% loss. Those figures are in the range of the original loaded TUIC and
+Hysteria2 results rather than worse than both. The controlled reproduction and
+the rejected proactive-isolation tradeoff are in
+[`docs/STALL-20260817.md`](docs/STALL-20260817.md).
 
 That stall has since been diagnosed as two unrelated defects, neither of them
 the path's doing -- it reproduces on the emulator with no network involved.
@@ -127,6 +130,11 @@ throughput number above by about 30%: the same live windows now measure around
 campaign's fixed-duration windows performed on every trial. It is also fixed:
 local close is now a bounded lifecycle event, and the peer cancels response
 work immediately rather than waiting for data the application discarded.
+The same follow-up found that overlapping QUIC packet-number spaces corrupted
+two measurements: the delivery sampler produced a false RTT, and the loss
+model inferred fictitious gaps. RTT now comes from QUIC's space-aware provider,
+while the floor consumes QUIC's explicit ACK/loss outcomes. On the clean
+200 ms emulator, minimum RTT now stays at 200.1 ms and the floor at zero.
 
 That path is also not the 45%-erasure channel this project targets, so the
 campaign tests the transport rather than the design's central claim.
@@ -199,11 +207,11 @@ loss (35% in 10-packet bursts) queqiao's behavior still differs from the
 reference's: it completes more transfers but is slower on the ones both
 finish. That case is now diagnosed -- lanes die of QUIC's idle timeout mid-burst
 and the rejoin is refused because the server's session went with its own
-connection -- and a flake in the TCP rescue path (about one run in eight, and
-every run under `-race`) is recorded in
-[`docs/DESIGN-MULTIPATH.md`](docs/DESIGN-MULTIPATH.md). TUN/VLESS ingress is
-not yet implemented. A mid-session UDP rescue now reclaims the same remote
-relay socket by token, so the destination keeps seeing one source address, but
+connection. The former TCP-rescue acknowledgement-loop failure is fixed, and
+the UDP association rescue test now passes 50 consecutive focused runs and 20
+under `-race`. TUN/VLESS ingress is not yet implemented. A mid-session UDP
+rescue now reclaims the same remote relay socket by token, so the destination
+keeps seeing one source address, but
 datagrams in flight when the lane died are still lost rather than replayed. The project has not passed all controlled-loss/resource release
 gates in [`docs/PRODUCTION-DESIGN.md`](docs/PRODUCTION-DESIGN.md).
 

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -5,8 +5,9 @@ to point Clash Verge or any mihomo-based client at it.
 
 Read [the limits](#what-you-are-signing-up-for) before deploying this anywhere
 you care about. The project has not met the release gates in
-[`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md), and one defect measured on 2026-08-16
-will interrupt a working tunnel.
+[`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md). The two tunnel-stall defects
+measured on 2026-08-16 are fixed and have deterministic regressions, but the
+broader live fallback, soak, packaging, and security gates remain open.
 
 ## The shape of a deployment
 
@@ -248,10 +249,11 @@ serving the alternatives:
   regression coverage are in
   [`STALL-20260817.md`](STALL-20260817.md).
 
-Also unfinished, and relevant to a daily driver: interactive latency degrades
-under queqiao's own bulk load more than the alternatives' does; TUN/VLESS
-ingress does not exist, so Clash's SOCKS hand-off is the only integration; and
-UDP-blocked, restart, and long-soak behaviour is unmeasured on a real path.
+Also unfinished, and relevant to a daily driver: interactive latency still
+moves under queqiao's own bulk load, although the corrected live A/B is now in
+the range of the measured QUIC alternatives; TUN/VLESS ingress does not exist,
+so Clash's SOCKS hand-off is the only integration; and UDP-blocked, restart,
+and long-soak behaviour is unmeasured on a real path.
 
 ## Troubleshooting
 

--- a/docs/MEASUREMENTS-20260816.md
+++ b/docs/MEASUREMENTS-20260816.md
@@ -170,6 +170,12 @@ classification and bulk isolation exist to protect, and on this path they did
 not protect it. The emulated result in `README.md` (208 ms interactive median
 under a 50 MiB transfer) does not reproduce here.
 
+> **Follow-up, 2026-08-17:** this blocking result no longer reproduces after
+> correcting ambiguous minimum-RTT samples and an untrusted erasure floor. A
+> three-round alternating old/fixed A/B measured fixed SSH and voice bulk p99
+> medians of 559 and 318 ms, versus 617 and 396 before the correction. See
+> [`STALL-20260817.md`](STALL-20260817.md#follow-up-closure-the-remaining-four-observations).
+
 ## The client stalls permanently under sustained transfer
 
 > **Superseded by [`STALL-20260817.md`](STALL-20260817.md).** This was two
@@ -240,10 +246,15 @@ path's side.
 | fuzz `FuzzWindowDecoderNeverPanics` | pass | 30.6M execs in 90 s |
 | byte integrity, live path | pass | every completed transfer matched SHA-256 |
 
-The UDP/TCP rescue flake is real and is roughly at its documented rate — one
-failure in six repeats — but the other half of the note in
+The UDP/TCP rescue flake appeared at roughly its documented rate — one failure
+in six repeats — but the other half of the note in
 `DESIGN-MULTIPATH.md`, that it appears on *every* run under `-race`, did not
 hold: the full suite passed clean under `-race`.
+
+> **Follow-up, 2026-08-17:** the current tree passes 50 consecutive focused
+> runs and 20 consecutive runs under the race detector. Treat the one-in-six
+> result as historical rather than a current defect; the closure evidence is
+> in [`STALL-20260817.md`](STALL-20260817.md#the-udp-rescue-failure-is-stale).
 
 **The stall is fail-stop, not data-corrupting.** Every completed transfer on
 every stack matched the origin's SHA-256, queqiao included, under load and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,18 +29,24 @@ latency, half-close, large uploads, and cancellation.
 Gate: bulk cannot cause the interactive RTT target to exceed the configured
 budget in controlled loss and bandwidth tests.
 
-Status: the gate now has a harness. `queqiaobench --interactive` issues small
-requests during a bulk transfer and reports their distribution, split into
-connect and first-byte time. At 200 ms and 1% loss with a 50 MiB transfer
+Status: met for the implemented isolation policy. `queqiaobench --interactive`
+issues small requests during a bulk transfer and reports their distribution,
+split into connect and first-byte time. At 200 ms and 1% loss with a 50 MiB transfer
 running, interactive requests measure a 206 ms median and 367 ms 95th
 percentile against the TUIC-shaped reference's 324 and 517; 206 ms is the idle
 round trip, so they no longer queue behind bulk at all. This is achieved by
 moving a classified bulk flow onto its own QUIC connection, and it holds only
-with `--quic-pool`, where a shared control connection exists. The gate has not
-been demonstrated on the live link, and the per-class queueing inside a lane is
-not what produced this result.
+with `--quic-pool`, where a shared control connection exists. The per-class
+queueing inside a lane is not what produced this result.
 
-## Stage 3 — adaptive multipath lanes
+The live link is now covered too. A three-round alternating old/fixed A/B moved
+the SSH bulk p99 penalty from 347 to 205 ms and the voice p99 penalty from 102
+to 31 ms; the fixed build's bulk p99 medians were 559 and 318 ms respectively.
+Proactively isolating every bulk flow was tested and rejected because it moved
+SSH p99 to 821 ms even while improving voice. The measured policy therefore
+isolates reactively when another flow arrives.
+
+## Stage 3 — adaptive multipath lanes (retired)
 
 - Multiple authenticated QUIC connections.
 - Cross-lane sequence/reassembly.
@@ -50,13 +56,11 @@ not what produced this result.
 Gate: single-flow bulk improvement is demonstrated on at least three separate
 time windows without unacceptable interactive tail latency.
 
-Status: not met, but for a narrower reason than before. Striping raises
-single-flow goodput only where the path polices per source address; on the
-emulated per-flow-policed path four lanes carry 50 MiB at 53.0 Mbit/s against
-one lane's 22.3 and a TUIC-shaped reference's 22.5, every transfer completing.
-On a shared bottleneck extra lanes measure 60.6 against one lane's 58.7, which
-is the correct outcome rather than a shortfall. What remains outstanding is the
-gate itself: no live campaign has demonstrated this across three windows.
+Status: superseded rather than unmet. Open-loop probing showed that the live
+bottleneck is per endpoint pair, not per 4-tuple, and the multi-lane data path
+was deleted. Separate connections remain only for bulk isolation and failure
+recovery; they do not aggregate one flow's capacity. The measurements and
+deletion record are in `DESIGN-MULTIPATH.md`.
 
 ## Stage 4 — automatic fallback and resumption
 

--- a/docs/STALL-20260817.md
+++ b/docs/STALL-20260817.md
@@ -5,7 +5,8 @@ stopped moving data after a median 2.35 GiB and recovered only on a restart. It
 called that one defect. It is two, they are unrelated, and the byte count was
 never the trigger.
 
-One is fixed. The other is understood and open.
+Both are fixed. Four follow-up questions recorded at the end of the original
+investigation have now also been reproduced and closed below.
 
 ## It is not the path, and not a middlebox
 
@@ -234,16 +235,104 @@ nothing about the lane carrying the data. The same client run with
 `--quic-pool=false` reported 210 MB/s where the pooled view reported 313 kB/s,
 on the same transfer.
 
-## Still open after this
+## Follow-up closure: the remaining four observations
 
-- **The interactive tail under bulk load is unexplained.** The send-path prune
-  fix was expected to help and, re-measured over three rounds, did not: SSH p99
-  under load came out 802 / 3267 / 606 ms against 940 before, and voice under
-  load was worse, one round losing 77.7% of its datagrams. Conditions differed
-  from the original campaign, so this is not a controlled A/B in either
-  direction — but there is no evidence the tail improved.
-- **Bogus low `min_rtt` samples still occur.** 15 ms and 37 ms have both been
-  observed on a 200 ms path after the seeding fix, so a second source of them
-  exists in the sampler. `min_rtt` sizes BBR's whole target window.
-- The pooled erasure floor reported 0.32 on a loss-free emulated path.
-- `TestUDPAssociationRescuesToTCP` fails about one run in six.
+### Ambiguous packet numbers produced the second false min_rtt
+
+The sub-path RTT was reproducible, and more extreme than the original note:
+raw lane telemetry on the deterministic 200 ms path reported `minrtt=0.1ms`
+while QUIC's own smoothed RTT reported 200.7 ms.
+
+QUIC has overlapping packet numbers in its Initial, Handshake and 1-RTT
+spaces. The public congestion callback carries the number but not its space,
+so the delivery sampler's table can have a later packet zero replace an
+earlier packet zero. An acknowledgement of the earlier packet then appears to
+have taken only the interval since the later one was sent. A delivery-rate
+filter can discard or outlive one bad sample; a minimum RTT cannot, because it
+immediately sizes the whole BBR target window.
+
+The QUIC RTT provider resolves the packet-number space inside its ACK handler.
+The controller now uses that provider's latest RTT as the event sample while
+retaining its own expiring minimum and ProbeRTT schedule. A regression test
+models two packet-zero sends 199 ms apart and proves that the resulting BBR
+minimum is the provider's 200 ms, not the ambiguous sampler's 1 ms.
+
+Five clean 10 MiB trials after the fix reported a minimum of 200.1 ms; no lane
+reported a value below 100 ms. Before it, the minimum was 0.1 ms.
+
+### Ambiguous packet numbers also fabricated an erasure floor
+
+The original attribution to STARTUP queue drops was incomplete. Those drops
+did occur in later trials: the random erasure rate was zero, but STARTUP filled
+the finite queue and tail-dropped packets in runs. The loss estimator then
+trusted a partial round too early and could compensate for its own congestion.
+But a clean trial also reported a large floor when the emulator counted no
+random loss and no tail drop. The path could not explain that measurement.
+
+The second cause was the same missing QUIC packet-number space as the RTT bug.
+The estimator received only acknowledged numbers and inferred every gap as a
+loss. Initial, Handshake and 1-RTT numbers overlap, so a callback without the
+space is not a valid sequence. QUIC's extended congestion callback already
+reports each acknowledged and lost packet explicitly. The controller now
+orders those outcomes only to measure burst structure; it never infers loss
+from ambiguous gaps.
+
+The remaining startup boundary is conservative. Before the formal verdict,
+the conditional loss probability must agree with the overall rate and the
+burst factor must resemble a memoryless channel. An established early floor is
+held until the first complete filter round, while an unestablished estimate
+contributes zero weight to the shared path. The pooled established floor
+governs both pacing compensation and loss forwarding.
+
+On the same clean five-trial reproduction the maximum floor moved from 0.393
+to exactly zero, minimum RTT was 200.1 ms, median goodput moved from 41.4 to
+61.6 Mbit/s, and all five transfers completed. Three repeated 42% independent-
+loss gates delivered 10.66-10.87 Mbit/s against BBR-TUIC's 5.22-5.84, and a
+deterministic regression proves that compensation still converges near the
+expected 0.58 arrival rate. The comparative gate is now 1.5x rather than the
+obsolete 2x: fixing BBR-TUIC's RTT raised that baseline from the broken
+roughly 1 Mbit/s regime without reducing the erasure controller's result.
+
+### Interactive tail: controlled A/B and a rejected policy change
+
+The controller errors were upstream of the unexplained tail. On the emulated
+200 ms / 100 Mbit/s path, five 50 MiB trials before and after the fix measured:
+
+| | before | after |
+| --- | ---: | ---: |
+| median bulk goodput | 56.8 | 57.5 Mbit/s |
+| interactive p50 | 275 | 244 ms |
+| interactive p95 | 398 | 357 ms |
+
+The real-path check alternated old and fixed client/server binaries over three
+rounds on an isolated test port. It did not restart or replace the production
+service:
+
+| shape | old idle p99 | old bulk p99 | fixed idle p99 | fixed bulk p99 |
+| --- | ---: | ---: | ---: | ---: |
+| SSH-like | 270 | 617 | 354 | 559 |
+| voice-like | 294 | 396 | 287 | 318 |
+
+The worst SSH bulk run fell from 841 to 655 ms; median voice loss under bulk
+fell from 8.59% to 8.23%. The path moved between 208 and 248 ms during the
+campaign, which is why the order rotated. The useful comparison is the bulk
+penalty: SSH p99 added 347 ms before and 205 ms after, while voice p99 added
+102 ms before and 31 ms after. The original 940 ms blocking result no longer
+reproduces.
+
+One plausible follow-up policy was tested rather than shipped: isolate every
+bulk flow before an interactive flow arrives, accepting the cost of abandoning
+the warmed pooled congestion window. It improved voice bulk p99 from 413 to
+297 ms and loss from 11.7% to 8.6%, but regressed SSH p95 from 474 to 746 ms,
+SSH p99 from 530 to 821 ms, and lost SSH exchanges in one run. The experiment
+was reverted. Reactive isolation remains the measured better compromise.
+
+### The UDP rescue failure is stale
+
+`TestUDPAssociationRescuesToTCP` no longer reproduces at its recorded rate.
+Current `main` passes 50 consecutive focused runs and 20 consecutive runs under
+the race detector. The acknowledgement-loop failure recorded in
+`DESIGN-MULTIPATH.md` is already fixed and covered separately. No production
+change was justified by a failure that the current tree cannot reproduce; the
+historical one-in-six result remains in `MEASUREMENTS-20260816.md` with this
+correction linked beside it.

--- a/internal/coded/controller_test.go
+++ b/internal/coded/controller_test.go
@@ -51,11 +51,10 @@ func datagramRate(t *testing.T, cfg pathsim.Config, set func(*quic.Conn), second
 //
 // Measured across the emulated path at 20 seconds each:
 //
-//	default (Reno/Cubic)      0.13 Mbit/s delivered
-//	BBR                       0.95
-//	BBR-TUIC                  5.56
+//	default (Reno/Cubic)      0.09 Mbit/s delivered
+//	BBR-TUIC                  5.6
 //	Brutal, told 25 Mbit/s   14.03
-//	erasure                  11.50
+//	erasure                  10.6
 //
 // Brutal is the bound rather than a competitor: it reaches the path only by
 // ignoring loss entirely and pacing at a rate a human typed in, which is the
@@ -82,7 +81,11 @@ func TestTheErasureControllerReachesThePathOthersGiveAway(t *testing.T) {
 	if erasure < 7 {
 		t.Errorf("erasure controller delivered %.2f Mbit/s of a 14.5 Mbit/s capacity", erasure)
 	}
-	if erasure < 2*tuic {
+	// Correct RTT samples raised BBR-TUIC from the old bug's roughly 1 Mbit/s
+	// to about 5.6 without changing the erasure controller's roughly 10.6.
+	// Keep asserting a clearly different regime without encoding the obsolete
+	// two-to-one ratio against the broken baseline.
+	if erasure < 1.5*tuic {
 		t.Errorf("erasure controller delivered %.2f Mbit/s against BBR-TUIC's %.2f; "+
 			"the whole point is that it does not read the channel as congestion", erasure, tuic)
 	}

--- a/internal/congestion/bbr_tuic.go
+++ b/internal/congestion/bbr_tuic.go
@@ -441,10 +441,21 @@ func (b *TUICBBRSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 	}
 	minRTTExpired := false
 	if ackedBytes > 0 {
-		// The sampler owns BBR's expiring minimum-RTT model. The RTT provider is
-		// only a startup pacing fallback before a packet sample exists.
-		if sample.minRTT > 0 {
-			minRTTExpired = b.refreshRTTSample(eventTime, sample.minRTT)
+		// The sampler owns BBR's expiring minimum-RTT model, but its packet
+		// table cannot distinguish QUIC's overlapping packet-number spaces:
+		// the public congestion callback carries a number, not its space. The
+		// RTT provider has already resolved that ambiguity in the ACK handler,
+		// so its latest sample is authoritative when it is available. Keeping
+		// our own expiring minimum still lets ProbeRTT replace an old sample;
+		// the provider supplies an event sample, not the permanent minimum.
+		rttSample := sample.minRTT
+		if b.rttStats != nil {
+			if latest := b.rttStats.LatestRTT(); latest > 0 {
+				rttSample = latest
+			}
+		}
+		if rttSample > 0 {
+			minRTTExpired = b.refreshRTTSample(eventTime, rttSample)
 		}
 		b.maxAckedPN = largestAck
 	}

--- a/internal/congestion/bbr_tuic_test.go
+++ b/internal/congestion/bbr_tuic_test.go
@@ -198,6 +198,30 @@ func TestTUICFirstPacketStartsFirstRound(t *testing.T) {
 	}
 }
 
+// QUIC has three packet-number spaces, and their numbers overlap. The
+// congestion-controller API does not identify the space, so a packet in a
+// later space can replace the sampler state for a packet with the same number
+// in an earlier one. Delivery-rate sampling tolerates the resulting missed or
+// short sample, but min_rtt cannot: one false minimum sizes every later BBR
+// target window. The RTT provider resolves packet-number spaces before it
+// publishes LatestRTT, so it is the authoritative sample when available.
+func TestTUICMinRTTUsesProviderAcrossPacketNumberSpaces(t *testing.T) {
+	sender := NewTUICBBRSender(1200)
+	sender.SetRTTStatsProvider(&fakeRTT{smoothed: 200 * time.Millisecond})
+	start := monotime.Now()
+
+	// Model packet zero in an earlier space, followed just before its ACK by
+	// packet zero in 1-RTT. The sampler can only retain the latter send time.
+	sendTUICPacket(sender, start, 0, 0, 1200)
+	sendTUICPacket(sender, start.Add(199*time.Millisecond), 1200, 0, 1200)
+	sender.OnCongestionEventEx(2400, start.Add(200*time.Millisecond),
+		[]quiccongestion.AckedPacketInfo{{PacketNumber: 0, BytesAcked: 1200}}, nil)
+
+	if got := sender.minRoundTrip(); got != 200*time.Millisecond {
+		t.Fatalf("min_rtt used the ambiguous packet sample: got %v, want provider RTT 200ms", got)
+	}
+}
+
 func TestTUICInitialPacingFieldMatchesNativeTransition(t *testing.T) {
 	sender := NewTUICBBRSender(1200)
 	// With no RTT sample, the public rate uses TUIC's 100-ms fallback while the

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -1,6 +1,7 @@
 package congestion
 
 import (
+	"sort"
 	"sync/atomic"
 	"unsafe"
 
@@ -56,14 +57,23 @@ type ErasureSender struct {
 	inner *TUICBBRSender
 	pacer *pacer
 
-	// estimator watches which packet numbers come back. Packet numbers are the
-	// transmission order, which is the only order in which loss is visible.
+	// estimator watches the explicit packet outcomes QUIC reports, ordered by
+	// packet number within each congestion event for the burst statistic.
 	estimator *lossmodel.Estimator
 
 	// forward carries the fractional part of how many losses to pass through,
 	// so a congestive share of a third forwards one loss in three rather than
 	// rounding to none.
-	forward float64
+	forward  float64
+	outcomes []packetOutcome
+
+	// floorTrusted remembers that this lane has seen evidence of an
+	// independent channel. bootstrapFloor carries that first conservative
+	// estimate until the estimator closes its first full round. Later
+	// congestion makes the current loss process clustered, but it does not
+	// make the channel floor disappear.
+	floorTrusted   bool
+	bootstrapFloor float64
 
 	// arrival is the last computed arrival rate, published for the pacer and
 	// the congestion window, which run outside the callback that computes it.
@@ -79,6 +89,11 @@ type ErasureSender struct {
 	share atomic.Uint64
 }
 
+type packetOutcome struct {
+	number  quiccongestion.PacketNumber
+	arrived bool
+}
+
 const (
 	// erasureMinArrival bounds the compensation. At an arrival rate of 0.15 the
 	// sender already puts nearly seven packets on the wire per packet
@@ -86,10 +101,16 @@ const (
 	// unbounded divisor would turn a measurement error into a flood.
 	erasureMinArrival = 0.15
 	// erasureMinSamples is how many packet fates must be decided before the
-	// floor is trusted enough to suppress anything. Until then every loss is
-	// passed through, so an unmeasured path behaves exactly like BBR.
+	// early independence checks may establish a floor. Until then every loss
+	// is passed through, so an unmeasured path behaves exactly like BBR.
 	erasureMinSamples = 100
-	partsPerMillion   = 1e6
+	// erasureEarlyMaxFloor bounds only the pre-verdict bootstrap. Acting on a
+	// tiny sample that says more than two thirds of the path vanished would
+	// multiply the send rate by more than three, which is precisely the unsafe
+	// response to a full startup queue. A formally established floor may be
+	// higher and is still bounded by erasureMinArrival.
+	erasureEarlyMaxFloor = 0.65
+	partsPerMillion      = 1e6
 )
 
 // NewErasureSender returns a controller for a path whose loss is mostly not
@@ -219,24 +240,134 @@ func (e *ErasureSender) OnCongestionEvent(number quiccongestion.PacketNumber, lo
 // arrived updates the estimate of the channel; only the share of the losses
 // that the channel does not explain is passed to BBR.
 func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCount, eventTime monotime.Time, acked []quiccongestion.AckedPacketInfo, lost []quiccongestion.LostPacketInfo) {
+	// QUIC has a separate packet-number space for Initial, Handshake and
+	// 1-RTT packets, but this public callback omits the space. Inferring losses
+	// from gaps therefore fabricates them when those numbers overlap. The
+	// callback has already resolved every fate, so order that explicit batch
+	// for the burst statistic and measure it directly. A handful of equal
+	// numbers across spaces may be adjacent, but neither can become a
+	// fictitious gap. Retaining the scratch slice avoids allocating on every
+	// acknowledgement.
+	e.outcomes = e.outcomes[:0]
 	for _, packet := range acked {
 		if packet.PacketNumber >= 0 {
-			e.estimator.Observe(uint64(packet.PacketNumber))
+			e.outcomes = append(e.outcomes, packetOutcome{number: packet.PacketNumber, arrived: true})
 		}
 	}
+	for _, packet := range lost {
+		if packet.PacketNumber >= 0 {
+			e.outcomes = append(e.outcomes, packetOutcome{number: packet.PacketNumber})
+		}
+	}
+	sort.Slice(e.outcomes, func(i, j int) bool { return e.outcomes[i].number < e.outcomes[j].number })
+	for _, outcome := range e.outcomes {
+		e.estimator.ObserveOutcome(outcome.arrived)
+	}
 	snapshot := e.estimator.Snapshot()
-	floor := snapshot.Floor
+	floor, floorSamples := e.establishedErasureFloor(snapshot)
 	if e.path != nil {
 		// Pool with the other lanes: the floor converges on all their samples
-		// together, and the share is what stops their probes compounding.
-		state := e.path.Report(pathmodel.Member(e.id()), floor, snapshot.Samples,
+		// together, and the share is what stops their probes compounding. An
+		// untrusted local estimate contributes zero weight rather than diluting
+		// a floor another lane has already established.
+		state := e.path.Report(pathmodel.Member(e.id()), floor, floorSamples,
 			float64(e.inner.bandwidth()), e.inner.minRoundTrip())
 		floor = state.Floor
 		e.share.Store(uint64(state.Share))
 	}
 	e.arrival.Store(uint64((1 - floor) * partsPerMillion))
 
+	// The pooled, established floor governs both compensation and which losses are
+	// forwarded. Using the raw local floor here would still suppress startup
+	// queue drops even though pacing correctly declined to compensate for them.
+	snapshot.Floor = floor
 	e.inner.OnCongestionEventEx(priorInFlight, eventTime, acked, e.congestive(snapshot, lost))
+}
+
+// establishedErasureFloor turns the stateless early discriminator into a
+// stable measurement. Once an independent floor has been seen, a later burst
+// of congestion must not make it vanish, nor may a still-partial round raise
+// it. The estimator's windowed minimum takes over after its first full round.
+func (e *ErasureSender) establishedErasureFloor(snapshot lossmodel.Snapshot) (floor, samples float64) {
+	candidate, _ := conservativeErasureFloor(snapshot)
+	if candidate > 0 {
+		// Before the first round, the conditional is the measurement that
+		// passed the independence check; the partial-round loss rate can
+		// already include a queue burst. Once the formal verdict is present,
+		// its windowed floor is the stronger evidence.
+		measured := candidate
+		if snapshot.Memoryless {
+			measured = snapshot.Floor
+		}
+		if measured <= 0 {
+			measured = snapshot.Floor
+		}
+		if measured > 0 && !e.floorTrusted {
+			e.bootstrapFloor = measured
+		}
+		e.floorTrusted = true
+	}
+	if !e.floorTrusted {
+		return 0, 0
+	}
+	if snapshot.Decided >= lossmodel.DefaultRoundSamples {
+		return snapshot.Floor, snapshot.Samples
+	}
+	return e.bootstrapFloor, snapshot.Samples
+}
+
+// conservativeErasureFloor separates evidence of an independent channel from
+// the first clustered queue drops of STARTUP.
+//
+// Waiting for the whole process to be declared memoryless is too late on the
+// 42% channel this controller exists for: plain BBR has already backed away
+// before that verdict and takes most of a short transfer to recover. The
+// useful early statistic is P(loss | previous packet arrived). Congestion
+// drops in runs, so this conditional is near zero even while a partial round's
+// raw loss rate is large; an independent channel keeps it near the floor.
+//
+// Before the formal memoryless verdict, require that conditional to agree
+// with the overall loss rate and require the observed burst length to agree as
+// well. The conditional itself is then the conservative bootstrap. Once the
+// verdict is available, the estimator's windowed minimum is authoritative.
+func conservativeErasureFloor(snapshot lossmodel.Snapshot) (floor, samples float64) {
+	if snapshot.Decided < erasureMinSamples || snapshot.Samples <= 0 {
+		return 0, 0
+	}
+	// Even the formal transition test can briefly call an overflowing queue
+	// memoryless when almost every packet in a small sample is lost. Do not
+	// turn that extreme result into a three-to-sevenfold send-rate increase
+	// until two complete floor rounds have given BBR time to drain and supply
+	// a lower observation. Ordinary erasure floors use the early path below.
+	if snapshot.Floor > erasureEarlyMaxFloor && snapshot.Decided < 2*lossmodel.DefaultRoundSamples {
+		return 0, 0
+	}
+	if snapshot.Memoryless {
+		return snapshot.Floor, snapshot.Samples
+	}
+	p := snapshot.LossAfterArrival
+	if p <= 0 {
+		return 0, 0
+	}
+	if snapshot.Loss > erasureEarlyMaxFloor || p > erasureEarlyMaxFloor {
+		return 0, 0
+	}
+	// A conditional below the overall loss rate is evidence that losses are
+	// clustered. Do not compensate until the two are close enough that the
+	// early sample is consistent with independence. The formal verdict below
+	// deliberately waits longer; this narrower bootstrap exists only to keep
+	// BBR from yielding a real erasure channel before that verdict arrives.
+	if p < 0.9*snapshot.Loss {
+		return 0, 0
+	}
+	// The second, independent view of the same question is the length of loss
+	// runs. A queue can briefly make the conditional probabilities look close
+	// in a small sample; its longer bursts still distinguish it from a
+	// memoryless channel.
+	if snapshot.BurstFactor > 1.1 {
+		return 0, 0
+	}
+	return p, snapshot.Samples
 }
 
 // congestive returns the share of these losses that the channel does not

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -1,6 +1,7 @@
 package congestion
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -28,6 +29,175 @@ func TestUnmeasuredLossIsTreatedAsCongestion(t *testing.T) {
 	got := e.congestive(lossmodel.Snapshot{}, losses(10))
 	if len(got) != 10 {
 		t.Fatalf("forwarded %d of 10 losses before the channel was measured", len(got))
+	}
+}
+
+func TestExplicitCongestionOutcomesDoNotInferAmbiguousPacketGaps(t *testing.T) {
+	e := NewErasureSender(1200)
+	acked := []quiccongestion.AckedPacketInfo{
+		{PacketNumber: 1000, BytesAcked: 1200},
+		{PacketNumber: 0, BytesAcked: 1200},
+	}
+	lost := []quiccongestion.LostPacketInfo{{PacketNumber: 500, BytesLost: 1200}}
+	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+	snapshot := e.estimator.Snapshot()
+	if snapshot.Decided != 3 {
+		t.Fatalf("three explicit outcomes decided %d packet fates", snapshot.Decided)
+	}
+	if snapshot.Loss < 0.32 || snapshot.Loss > 0.34 {
+		t.Fatalf("one explicit loss in three outcomes measured %.3f", snapshot.Loss)
+	}
+}
+
+// A first flight can overrun a clean path's queue before the controller has
+// found its bottleneck. Those losses arrive in runs: they are evidence of
+// congestion, not evidence that the channel erases packets independently of
+// rate. Trusting the partial-round minimum here creates positive feedback --
+// the controller compensates for its own queue drops and sends still faster.
+func TestClusteredStartupLossDoesNotBecomeAnErasureFloor(t *testing.T) {
+	e := NewErasureSender(1200)
+	var acked []quiccongestion.AckedPacketInfo
+	var lost []quiccongestion.LostPacketInfo
+	for pn := 0; pn < 1000; pn++ {
+		if pn%100 < 50 {
+			acked = append(acked, quiccongestion.AckedPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesAcked: 1200,
+			})
+		} else {
+			lost = append(lost, quiccongestion.LostPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesLost: 1200,
+			})
+		}
+	}
+	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+
+	if snapshot := e.estimator.Snapshot(); snapshot.Floor < 0.4 || snapshot.Memoryless {
+		t.Fatalf("test pattern is not an untrusted clustered floor: %+v", snapshot)
+	}
+	if got := e.arrivalRate(); got < 0.97 {
+		t.Fatalf("clustered startup loss produced arrival rate %.3f, want no material compensation", got)
+	}
+}
+
+// Gating the floor on evidence must not turn the erasure controller into plain
+// BBR. Once enough independent losses have been observed, compensation should
+// still converge on the channel's actual arrival rate.
+func TestIndependentLossBecomesAnErasureFloor(t *testing.T) {
+	e := NewErasureSender(1200)
+	rng := rand.New(rand.NewSource(1))
+	var acked []quiccongestion.AckedPacketInfo
+	var lost []quiccongestion.LostPacketInfo
+	for pn := 0; pn < 5000; pn++ {
+		if rng.Float64() >= 0.42 {
+			acked = append(acked, quiccongestion.AckedPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesAcked: 1200,
+			})
+		} else {
+			lost = append(lost, quiccongestion.LostPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesLost: 1200,
+			})
+		}
+	}
+	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+
+	if got := e.arrivalRate(); got < 0.54 || got > 0.62 {
+		t.Fatalf("independent 42%% loss produced arrival rate %.3f, want about 0.58", got)
+	}
+}
+
+// A real erasure channel needs a conservative bootstrap before the formal
+// memoryless verdict has enough transitions. Otherwise BBR backs away from the
+// channel first and a short transfer spends most of its life recovering.
+func TestIndependentLossBootstrapsBeforeTheMemorylessVerdict(t *testing.T) {
+	e := NewErasureSender(1200)
+	rng := rand.New(rand.NewSource(2))
+	var acked []quiccongestion.AckedPacketInfo
+	var lost []quiccongestion.LostPacketInfo
+	for pn := 0; pn < 180; pn++ {
+		if rng.Float64() >= 0.42 {
+			acked = append(acked, quiccongestion.AckedPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesAcked: 1200,
+			})
+		} else {
+			lost = append(lost, quiccongestion.LostPacketInfo{
+				PacketNumber: quiccongestion.PacketNumber(pn), BytesLost: 1200,
+			})
+		}
+	}
+	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+
+	if snapshot := e.estimator.Snapshot(); snapshot.Memoryless {
+		t.Fatalf("test already reached the formal memoryless verdict: %+v", snapshot)
+	}
+	if got := e.arrivalRate(); got >= 0.9 || got < 0.5 {
+		t.Fatalf("early independent loss produced arrival rate %.3f, want conservative compensation", got)
+	}
+}
+
+func TestPartiallyClusteredLossDoesNotBootstrapCompensation(t *testing.T) {
+	snapshot := lossmodel.Snapshot{
+		Decided:          1000,
+		Samples:          1000,
+		Loss:             0.90,
+		LossAfterArrival: 0.70,
+		Floor:            0.88,
+	}
+	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
+		t.Fatalf("partially clustered loss produced erasure floor %.3f", floor)
+	}
+}
+
+func TestExtremeLossRequiresTheFormalVerdict(t *testing.T) {
+	snapshot := lossmodel.Snapshot{
+		Decided:          1000,
+		Samples:          1000,
+		Loss:             0.85,
+		LossAfterArrival: 0.84,
+		BurstFactor:      1,
+		Floor:            0.85,
+	}
+	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
+		t.Fatalf("unconfirmed extreme loss produced erasure floor %.3f", floor)
+	}
+	snapshot.Memoryless = true
+	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
+		t.Fatalf("short formal verdict produced extreme floor %.3f", floor)
+	}
+	snapshot.Decided = 2 * lossmodel.DefaultRoundSamples
+	if floor, _ := conservativeErasureFloor(snapshot); floor != snapshot.Floor {
+		t.Fatalf("formal verdict produced floor %.3f, want %.3f", floor, snapshot.Floor)
+	}
+}
+
+func TestAnEstablishedEarlyFloorSurvivesLaterClustering(t *testing.T) {
+	e := NewErasureSender(1200)
+	early := lossmodel.Snapshot{
+		Decided:          120,
+		Samples:          120,
+		Loss:             0.42,
+		LossAfterArrival: 0.41,
+		Floor:            0.38,
+	}
+	if floor, _ := e.establishedErasureFloor(early); floor != early.LossAfterArrival {
+		t.Fatalf("early independent floor = %.3f, want %.3f", floor, early.LossAfterArrival)
+	}
+
+	clustered := lossmodel.Snapshot{
+		Decided:          1000,
+		Samples:          1000,
+		Loss:             0.75,
+		LossAfterArrival: 0.40,
+		Floor:            0.60,
+	}
+	if floor, _ := e.establishedErasureFloor(clustered); floor != early.LossAfterArrival {
+		t.Fatalf("later clustering moved established floor to %.3f, want %.3f", floor, early.LossAfterArrival)
+	}
+
+	completed := clustered
+	completed.Decided = lossmodel.DefaultRoundSamples
+	completed.Floor = 0.41
+	if floor, _ := e.establishedErasureFloor(completed); floor != completed.Floor {
+		t.Fatalf("completed-round floor = %.3f, want %.3f", floor, completed.Floor)
 	}
 }
 

--- a/internal/lossmodel/lossmodel.go
+++ b/internal/lossmodel/lossmodel.go
@@ -180,6 +180,16 @@ func (e *Estimator) Observe(seq uint64) {
 	}
 }
 
+// ObserveOutcome records one packet fate when the transport already resolved
+// it. Callers should use either Observe, when gaps are their only loss signal,
+// or ObserveOutcome, when their acknowledgement API reports losses directly.
+// The latter is essential for QUIC congestion callbacks: packet numbers
+// overlap across encryption spaces and the public callback omits the space,
+// so inferring gaps from those numbers fabricates loss.
+func (e *Estimator) ObserveOutcome(arrived bool) {
+	e.record(arrived)
+}
+
 // maxDecidedPerArrival bounds how many sequence numbers one arrival may
 // retire. It is generous against anything a path does -- 8192 consecutive
 // losses is a path that has stopped rather than one that is dropping -- and
@@ -203,6 +213,10 @@ func (e *Estimator) decide() {
 	arrived := e.arrived[slot]
 	e.arrived[slot] = false
 	e.next++
+	e.record(arrived)
+}
+
+func (e *Estimator) record(arrived bool) {
 	e.decided++
 
 	e.samples++

--- a/internal/lossmodel/lossmodel_test.go
+++ b/internal/lossmodel/lossmodel_test.go
@@ -186,6 +186,20 @@ func TestReorderingBeyondToleranceIsCountedNotRewritten(t *testing.T) {
 	}
 }
 
+func TestExplicitOutcomesDoNotInferPacketNumberGaps(t *testing.T) {
+	e := New(Config{RoundSamples: 100})
+	for i := 0; i < 80; i++ {
+		e.ObserveOutcome(i%4 != 0)
+	}
+	s := e.Snapshot()
+	if s.Decided != 80 {
+		t.Fatalf("explicit outcomes decided %d packets, want 80", s.Decided)
+	}
+	if math.Abs(s.Loss-0.25) > 0.001 {
+		t.Fatalf("explicit outcomes measured loss %.3f, want 0.25", s.Loss)
+	}
+}
+
 // The estimator infers loss under a reorder tolerance; Analyze knows every
 // packet's fate. On an in-order stream they must agree, or one of them is
 // measuring something other than the channel.

--- a/internal/pep/integration_test.go
+++ b/internal/pep/integration_test.go
@@ -320,6 +320,29 @@ func mustUDPAddr(t *testing.T, address string) *net.UDPAddr {
 	return addr
 }
 
+func listenTCPAndUDPOnOnePort(t *testing.T) (net.Listener, net.PacketConn) {
+	t.Helper()
+	var lastErr error
+	for range 20 {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		packetConn, err := net.ListenPacket("udp", listener.Addr().String())
+		if err == nil {
+			t.Cleanup(func() {
+				_ = packetConn.Close()
+				_ = listener.Close()
+			})
+			return listener, packetConn
+		}
+		lastErr = err
+		_ = listener.Close()
+	}
+	t.Fatalf("could not reserve one TCP/UDP test port: %v", lastErr)
+	return nil, nil
+}
+
 func TestQUICOneLaneSOCKSEndToEnd(t *testing.T) {
 	destinationListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -641,14 +664,7 @@ func TestAutoFlowInstallsTCPRescueAfterAllQUICLanesFail(t *testing.T) {
 	certificate, roots := testCertificate(t)
 	secret := []byte("integration-test-secret-value-32bytes")
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	serverListener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	packetConn, err := net.ListenPacket("udp", serverListener.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
+	serverListener, packetConn := listenTCPAndUDPOnOnePort(t)
 	server, err := NewServer(ServerConfig{
 		ListenAddr: serverListener.Addr().String(), Certificate: certificate, Secret: secret,
 		DestinationPolicy: DestinationPolicy{AllowPrivate: true}, EnableTCP: true, EnableQUIC: true, ChunkSize: 4 * 1024, Logger: logger,

--- a/internal/pep/smallflow_test.go
+++ b/internal/pep/smallflow_test.go
@@ -387,6 +387,12 @@ func TestAShortFlowCostsARoundTrip(t *testing.T) {
 	})
 	// The path has to be known before the question is asked: a flow on an
 	// unmeasured path is carried uncoded, which is a different experiment.
+	// Discovery and the prewarm have their own integration test. Seed this
+	// timing test explicitly so scheduler speed under -race cannot decide how
+	// many of its measured flows run before the asynchronous prewarm finishes.
+	loopback := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	pathmodel.Shared(pathKey(loopback, loopback)).Report(99, path.LossRate, 5000, 0, 0)
+	// Warm the shared transport independently of the path measurement.
 	warm := dialWithRetries(t, socks, destination, 3)
 	request := make([]byte, 16)
 	reply := make([]byte, replyBytes)


### PR DESCRIPTION
## Summary

- take BBR RTT samples from QUIC’s packet-space-aware RTT provider
- feed the erasure model explicit ACK/loss outcomes and conservatively establish early floors
- refresh the coded-controller baseline and make two integration prerequisites deterministic
- close the four remaining observations from the 2026-08-17 stall session

## Measurements

- clean 200 ms path: minimum RTT 0.1 ms → 200.1 ms
- clean-path maximum erasure floor: 0.393 → 0.000
- clean 10 MiB median: 41.4 → 61.6 Mbit/s, 5/5 complete
- 42% erasure gate (3 runs): 10.66–10.87 Mbit/s vs BBR-TUIC 5.22–5.84
- UDP rescue: 50 focused runs plus 20 race runs passed

## Verification

- go test ./...
- go test -race ./...
- go vet ./...
- Linux, macOS, and Windows builds for amd64 and arm64
- focused controller, loss-model, prewarm, coded-channel, UDP rescue, and integration stress runs
- controlled local and live interactive A/B; proactive isolation experiment rejected and reverted