### PR TITLE
Harden releases and fallback verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,26 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -short -timeout 20m ./...
+
+  # Exercise the actual release path, including embedded version metadata and
+  # deterministic archive creation. One target is enough here; release.yml
+  # packages the complete six-target matrix.
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: package smoke test
+        run: |
+          build_date=$(git show -s --format=%cI HEAD)
+          go run ./cmd/queqiaopack \
+            --version v0.0.0-ci --commit "${GITHUB_SHA}" \
+            --build-date "$build_date" --targets linux/amd64 \
+            --output dist
+          cd dist
+          sha256sum -c SHA256SUMS
+          tar -xzf queqiaod_v0.0.0-ci_linux_amd64.tar.gz
+          ./queqiaod_v0.0.0-ci_linux_amd64/queqiaod --version |
+            grep -F "queqiaod v0.0.0-ci commit=${GITHUB_SHA}"

--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -37,6 +37,35 @@ jobs:
           go-version-file: go.mod
       - run: go test -race -timeout 110m ./...
 
+  # Reachability-aware scanning against Go's official vulnerability database.
+  # The tool version is pinned so a scanner release cannot change a campaign
+  # underneath us; the database intentionally remains current.
+  vulnerability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
+
+  fallback-soak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: ./scripts/fallback_soak.sh --runs 20 --race-runs 5 --output-dir fallback-soak
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: fallback-soak-${{ github.run_id }}
+          path: fallback-soak/
+          if-no-files-found: warn
+
   # Every fuzz target, discovered rather than listed, so a target added later
   # is smoke-tested without anyone remembering to add it here. This is a
   # crash check, not a campaign: 60 s each finds a panic on a malformed frame

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Existing v-prefixed tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Resolve immutable release inputs
+        id: release
+        env:
+          REQUESTED_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+        run: |
+          case "$REQUESTED_VERSION" in
+            v*) ;;
+            *) echo "version must name an existing v-prefixed tag" >&2; exit 1 ;;
+          esac
+          git rev-parse --verify "refs/tags/${REQUESTED_VERSION}"
+          commit=$(git rev-list -n 1 "$REQUESTED_VERSION")
+          build_date=$(git show -s --format=%cI "$commit")
+          {
+            echo "version=$REQUESTED_VERSION"
+            echo "commit=$commit"
+            echo "build_date=$build_date"
+          } >> "$GITHUB_OUTPUT"
+      - name: Test
+        run: go test -short -timeout 20m ./...
+      - name: Scan reachable dependencies
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
+      - name: Build release archives
+        run: |
+          go run ./cmd/queqiaopack \
+            --version '${{ steps.release.outputs.version }}' \
+            --commit '${{ steps.release.outputs.commit }}' \
+            --build-date '${{ steps.release.outputs.build_date }}' \
+            --output dist
+          cd dist
+          sha256sum -c SHA256SUMS
+      - uses: actions/upload-artifact@v4
+        with:
+          name: queqiaod-${{ steps.release.outputs.version }}
+          path: dist/
+          if-no-files-found: error
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: gh release create "$VERSION" dist/* --verify-tag --generate-notes

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ it. The short version is that queqiao is not a protocol Clash speaks --
 and Clash forwards to it as a `socks5` node. Templates are in
 [`deploy/`](deploy).
 
+Tagged releases contain deterministic Linux, macOS, and Windows archives for
+amd64 and arm64, embedded build provenance, and SHA-256 checksums.
+[`docs/RELEASING.md`](docs/RELEASING.md) covers verification, atomic install,
+and rollback.
+
 Two things in that document decide whether a deployment works at all. The
 client must be started with `--local-address if:en0`, because Clash's TUN mode
 would otherwise capture queqiao's own outer connection and carry it through the

--- a/cmd/queqiaobench/main.go
+++ b/cmd/queqiaobench/main.go
@@ -157,11 +157,23 @@ func run(args []string) error {
 		humanBytes(opts.bytes), opts.congestion)
 	fmt.Printf("stack\tflows\ttrial\tseconds\tmbits_per_sec\tcomplete\tnote\n")
 
+	report := Report{
+		SchemaVersion: 1,
+		Source:        describeSource(),
+		Arguments:     append([]string(nil), args...),
+		Path:          describePath(opts, pathCfg),
+	}
 	if opts.contend != "" {
-		return measureContention(opts, pathCfg, origin)
+		report.Contention, err = measureContention(opts, pathCfg, origin)
+		if err != nil {
+			return err
+		}
+		if opts.jsonOut != "" {
+			return writeReport(opts.jsonOut, report)
+		}
+		return nil
 	}
 
-	report := Report{Path: describePath(opts, pathCfg)}
 	for _, stack := range strings.Split(opts.stacks, ",") {
 		stack = strings.TrimSpace(stack)
 		if stack == "" {
@@ -186,7 +198,8 @@ func run(args []string) error {
 	printSummary(report.Summary)
 
 	if opts.latency {
-		if err := measureLatency(opts, pathCfg, origin); err != nil {
+		report.Latency, err = measureLatency(opts, pathCfg, origin)
+		if err != nil {
 			return err
 		}
 	}
@@ -376,8 +389,9 @@ func summarizeProbes(samples []requestStages) string {
 		quantile(connect, 0.95), quantile(first, 0.95))
 }
 
-func measureLatency(opts options, pathCfg pathsim.Config, origin *origin) error {
+func measureLatency(opts options, pathCfg pathsim.Config, origin *origin) ([]LatencyRecord, error) {
 	fmt.Printf("\nstack\ttrial\tconnect_ms\trequest_ms\tnote\n")
+	var records []LatencyRecord
 	for _, stack := range strings.Split(opts.stacks, ",") {
 		stack = strings.TrimSpace(stack)
 		if stack == "" {
@@ -390,6 +404,7 @@ func measureLatency(opts options, pathCfg pathsim.Config, origin *origin) error 
 			harness, err := startStack(ctx, stack, opts, cfg)
 			if err != nil {
 				fmt.Printf("%s\t%d\t\t\tsetup: %v\n", stack, trial, err)
+				records = append(records, LatencyRecord{Stack: stack, Trial: trial, Note: "setup: " + err.Error()})
 				cancel()
 				continue
 			}
@@ -407,12 +422,18 @@ func measureLatency(opts options, pathCfg pathsim.Config, origin *origin) error 
 			} else if warmErr != nil {
 				note = "warm: " + warmErr.Error()
 			}
-			fmt.Printf("%s\t%d\t%.1f\t%.1f\t%s\n", stack, trial, float64(cold.Microseconds())/1000, float64(warm.Microseconds())/1000, note)
+			coldMillis := round3(float64(cold.Microseconds()) / 1000)
+			warmMillis := round3(float64(warm.Microseconds()) / 1000)
+			fmt.Printf("%s\t%d\t%.1f\t%.1f\t%s\n", stack, trial, coldMillis, warmMillis, note)
+			records = append(records, LatencyRecord{
+				Stack: stack, Trial: trial, ColdMillis: coldMillis, WarmMillis: warmMillis,
+				Complete: note == "", Note: note,
+			})
 			harness.Close()
 			cancel()
 		}
 	}
-	return nil
+	return records, nil
 }
 
 // ---------------------------------------------------------------- harness ---
@@ -987,10 +1008,10 @@ func startTCPStack(ctx context.Context, kind extproxy.Kind, opts options, pathCf
 // answers which is faster alone. Both flows start together and are given the
 // same object, so the share is read directly off the goodput and the slower one
 // is still carrying traffic while the faster one finishes.
-func measureContention(opts options, pathCfg pathsim.Config, origin *origin) error {
+func measureContention(opts options, pathCfg pathsim.Config, origin *origin) ([]ContentionRecord, error) {
 	stacks := strings.Split(opts.contend, ",")
 	if len(stacks) != 2 {
-		return errors.New("--contend needs exactly two stacks")
+		return nil, errors.New("--contend needs exactly two stacks")
 	}
 	for i := range stacks {
 		stacks[i] = strings.TrimSpace(stacks[i])
@@ -998,6 +1019,7 @@ func measureContention(opts options, pathCfg pathsim.Config, origin *origin) err
 	fmt.Printf("# contention on one shared bottleneck: %s vs %s\n", stacks[0], stacks[1])
 	fmt.Printf("trial\t%s\t%s\tshare_%s\tratio\n", stacks[0], stacks[1], stacks[0])
 	var shares []float64
+	var records []ContentionRecord
 	for trial := 1; trial <= opts.trials; trial++ {
 		cfg := pathCfg
 		cfg.Seed = pathCfg.Seed + int64(trial)*1000
@@ -1005,23 +1027,25 @@ func measureContention(opts options, pathCfg pathsim.Config, origin *origin) err
 
 		ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
 		harnesses := make([]*harness, len(stacks))
-		failed := false
+		failure := ""
 		for i, stack := range stacks {
 			h, err := startStackOn(ctx, stack, opts, cfg, shared)
 			if err != nil {
 				fmt.Printf("%d\tsetup %s: %v\n", trial, stack, err)
-				failed = true
+				failure = fmt.Sprintf("setup %s: %v", stack, err)
 				break
 			}
 			harnesses[i] = h
 			if err := warmUp(ctx, h.socks, origin); err != nil {
 				fmt.Printf("%d\twarmup %s: %v\n", trial, stack, err)
-				failed = true
+				failure = fmt.Sprintf("warmup %s: %v", stack, err)
 				break
 			}
 		}
-		if !failed {
+		record := ContentionRecord{Trial: trial, StackA: stacks[0], StackB: stacks[1], Note: failure}
+		if failure == "" {
 			rates := make([]float64, len(stacks))
+			transferErrors := make([]error, len(stacks))
 			var wg sync.WaitGroup
 			for i := range stacks {
 				wg.Add(1)
@@ -1032,6 +1056,10 @@ func measureContention(opts options, pathCfg pathsim.Config, origin *origin) err
 					elapsed := time.Since(started)
 					if err == nil && n == opts.bytes && elapsed > 0 {
 						rates[i] = float64(n) * 8 / elapsed.Seconds() / 1e6
+					} else if err != nil {
+						transferErrors[i] = err
+					} else {
+						transferErrors[i] = fmt.Errorf("received %d of %d bytes", n, opts.bytes)
 					}
 				}(i)
 			}
@@ -1044,9 +1072,17 @@ func measureContention(opts options, pathCfg pathsim.Config, origin *origin) err
 			if rates[1] > 0 {
 				ratio = rates[0] / rates[1]
 			}
-			shares = append(shares, share)
+			record.MbitsA, record.MbitsB = round3(rates[0]), round3(rates[1])
+			record.ShareA, record.RatioAToB = round3(share), round3(ratio)
+			if transferErrors[0] == nil && transferErrors[1] == nil {
+				record.Complete = true
+				shares = append(shares, share)
+			} else {
+				record.Note = fmt.Sprintf("%s: %v; %s: %v", stacks[0], transferErrors[0], stacks[1], transferErrors[1])
+			}
 			fmt.Printf("%d\t%.2f\t%.2f\t%.3f\t%.2f\n", trial, rates[0], rates[1], share, ratio)
 		}
+		records = append(records, record)
 		for _, h := range harnesses {
 			if h != nil {
 				h.Close()
@@ -1059,5 +1095,5 @@ func measureContention(opts options, pathCfg pathsim.Config, origin *origin) err
 		fmt.Printf("\nmedian share of the bottleneck taken by %s: %.3f (0.5 is an even split)\n",
 			stacks[0], shares[len(shares)/2])
 	}
-	return nil
+	return records, nil
 }

--- a/cmd/queqiaobench/report.go
+++ b/cmd/queqiaobench/report.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"os/exec"
+	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -15,9 +18,36 @@ import (
 // shape is deliberately stable: results are only useful for tracking a
 // transport across commits if they can be diffed, and a text table cannot be.
 type Report struct {
-	Path    PathReport    `json:"path"`
-	Trials  []TrialRecord `json:"trials"`
-	Summary []CellSummary `json:"summary"`
+	SchemaVersion int                `json:"schema_version"`
+	Source        SourceReport       `json:"source"`
+	Arguments     []string           `json:"arguments"`
+	Path          PathReport         `json:"path"`
+	Trials        []TrialRecord      `json:"trials"`
+	Summary       []CellSummary      `json:"summary"`
+	Latency       []LatencyRecord    `json:"latency,omitempty"`
+	Contention    []ContentionRecord `json:"contention,omitempty"`
+}
+
+// SourceReport makes a result attributable to the exact tree and toolchain
+// that produced it. Arguments and the seeded PathReport supply the other half
+// of reproducibility: what that binary was asked to measure.
+type SourceReport struct {
+	Revision   string         `json:"revision,omitempty"`
+	CommitTime string         `json:"commit_time,omitempty"`
+	Modified   bool           `json:"modified"`
+	GoVersion  string         `json:"go_version"`
+	GOOS       string         `json:"goos"`
+	GOARCH     string         `json:"goarch"`
+	Module     string         `json:"module,omitempty"`
+	Version    string         `json:"version,omitempty"`
+	Modules    []ModuleReport `json:"modules,omitempty"`
+}
+
+type ModuleReport struct {
+	Path    string `json:"path"`
+	Version string `json:"version,omitempty"`
+	Sum     string `json:"sum,omitempty"`
+	Replace string `json:"replace,omitempty"`
 }
 
 type PathReport struct {
@@ -26,6 +56,7 @@ type PathReport struct {
 	UpstreamLossPercent float64 `json:"upstream_loss_percent,omitempty"`
 	LossBurstPackets    float64 `json:"loss_burst_packets,omitempty"`
 	JitterMillis        float64 `json:"jitter_ms,omitempty"`
+	WanderMillis        float64 `json:"delay_wander_ms,omitempty"`
 	RateMbits           float64 `json:"rate_mbits"`
 	PerFlowMbits        float64 `json:"per_flow_mbits,omitempty"`
 	QueueBytes          int     `json:"queue_bytes"`
@@ -45,6 +76,27 @@ type TrialRecord struct {
 	Complete    bool               `json:"complete"`
 	Note        string             `json:"note,omitempty"`
 	Interactive *InteractiveReport `json:"interactive,omitempty"`
+}
+
+type LatencyRecord struct {
+	Stack      string  `json:"stack"`
+	Trial      int     `json:"trial"`
+	ColdMillis float64 `json:"cold_ms"`
+	WarmMillis float64 `json:"warm_ms"`
+	Complete   bool    `json:"complete"`
+	Note       string  `json:"note,omitempty"`
+}
+
+type ContentionRecord struct {
+	Trial     int     `json:"trial"`
+	StackA    string  `json:"stack_a"`
+	StackB    string  `json:"stack_b"`
+	MbitsA    float64 `json:"mbits_a"`
+	MbitsB    float64 `json:"mbits_b"`
+	ShareA    float64 `json:"share_a"`
+	RatioAToB float64 `json:"ratio_a_to_b"`
+	Complete  bool    `json:"complete"`
+	Note      string  `json:"note,omitempty"`
 }
 
 // InteractiveReport records latency of small requests issued while the bulk
@@ -93,12 +145,57 @@ func describePath(opts options, cfg pathsim.Config) PathReport {
 	return PathReport{
 		RTTMillis: opts.rttMillis, LossPercent: opts.lossPercent,
 		UpstreamLossPercent: opts.lossUp, LossBurstPackets: opts.lossBurst,
-		JitterMillis: opts.jitterMillis,
-		RateMbits:    opts.rateMbits, PerFlowMbits: opts.perFlowMbits,
+		JitterMillis: opts.jitterMillis, WanderMillis: opts.wanderMillis,
+		RateMbits: opts.rateMbits, PerFlowMbits: opts.perFlowMbits,
 		QueueBytes: cfg.QueueBytes, Seed: opts.seed, ObjectBytes: opts.bytes,
 		Congestion: opts.congestion,
 		ChunkSize:  opts.chunkSize, QUICPool: opts.quicPool,
 	}
+}
+
+func describeSource() SourceReport {
+	report := SourceReport{GoVersion: runtime.Version(), GOOS: runtime.GOOS, GOARCH: runtime.GOARCH}
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		report.Module, report.Version = info.Main.Path, info.Main.Version
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				report.Revision = setting.Value
+			case "vcs.time":
+				report.CommitTime = setting.Value
+			case "vcs.modified":
+				report.Modified = setting.Value == "true"
+			}
+		}
+		for _, dependency := range info.Deps {
+			module := ModuleReport{Path: dependency.Path, Version: dependency.Version, Sum: dependency.Sum}
+			if dependency.Replace != nil {
+				module.Replace = dependency.Replace.Path
+				if dependency.Replace.Version != "" {
+					module.Replace += "@" + dependency.Replace.Version
+				}
+			}
+			report.Modules = append(report.Modules, module)
+		}
+	}
+	// `go run` currently omits VCS build settings even in a checkout, and it is
+	// how the documented harness is invoked. Ask that checkout directly rather
+	// than silently emitting an unattributed report. A standalone installed
+	// binary still uses the immutable settings embedded by `go build` above.
+	if report.Revision == "" {
+		if output, err := exec.Command("git", "rev-parse", "HEAD").Output(); err == nil {
+			report.Revision = strings.TrimSpace(string(output))
+		}
+		if output, err := exec.Command("git", "show", "-s", "--format=%cI", "HEAD").Output(); err == nil {
+			report.CommitTime = strings.TrimSpace(string(output))
+		}
+		if output, err := exec.Command("git", "status", "--porcelain=v1", "--untracked-files=normal").Output(); err == nil {
+			report.Modified = len(output) != 0
+		}
+	}
+	sort.Slice(report.Modules, func(i, j int) bool { return report.Modules[i].Path < report.Modules[j].Path })
+	return report
 }
 
 func summarize(trials []TrialRecord) []CellSummary {

--- a/cmd/queqiaobench/report_test.go
+++ b/cmd/queqiaobench/report_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -93,8 +95,11 @@ func TestGatePassesAtParity(t *testing.T) {
 
 func TestReportRoundTripsAsJSON(t *testing.T) {
 	report := Report{
-		Path:   PathReport{RTTMillis: 200, LossPercent: 1, RateMbits: 100},
-		Trials: []TrialRecord{trial("queqiao", 1, 10, true)},
+		SchemaVersion: 1,
+		Arguments:     []string{"--rtt", "200", "--seed", "7"},
+		Path:          PathReport{RTTMillis: 200, LossPercent: 1, RateMbits: 100, Seed: 7},
+		Trials:        []TrialRecord{trial("queqiao", 1, 10, true)},
+		Latency:       []LatencyRecord{{Stack: "queqiao", Trial: 1, ColdMillis: 210, WarmMillis: 201, Complete: true}},
 	}
 	report.Summary = summarize(report.Trials)
 	path := filepath.Join(t.TempDir(), "report.json")
@@ -103,6 +108,27 @@ func TestReportRoundTripsAsJSON(t *testing.T) {
 	}
 	if err := writeReport(path, report); err != nil {
 		t.Fatalf("rewriting an existing report: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Report
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.SchemaVersion != 1 || decoded.Path.Seed != 7 || len(decoded.Latency) != 1 {
+		t.Fatalf("report lost reproducibility fields: %+v", decoded)
+	}
+}
+
+func TestSourceProvenanceNamesTheCheckout(t *testing.T) {
+	source := describeSource()
+	if source.Revision == "" || source.CommitTime == "" {
+		t.Fatalf("source provenance does not identify the checkout: %+v", source)
+	}
+	if source.GoVersion == "" || source.GOOS == "" || source.GOARCH == "" {
+		t.Fatalf("source provenance does not identify the toolchain: %+v", source)
 	}
 }
 

--- a/cmd/queqiaopack/main.go
+++ b/cmd/queqiaopack/main.go
@@ -1,0 +1,383 @@
+// Command queqiaopack builds the distributable queqiaod archives.
+//
+// It deliberately owns archive creation instead of delegating it to the host's
+// tar and zip programs. That gives every file a fixed timestamp, owner, mode,
+// and order, so identical source and metadata produce identical artifacts.
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+var defaultTargets = []target{
+	{goos: "linux", goarch: "amd64"},
+	{goos: "linux", goarch: "arm64"},
+	{goos: "darwin", goarch: "amd64"},
+	{goos: "darwin", goarch: "arm64"},
+	{goos: "windows", goarch: "amd64"},
+	{goos: "windows", goarch: "arm64"},
+}
+
+var safeMetadata = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+~-]*$`)
+
+type target struct {
+	goos   string
+	goarch string
+}
+
+func (t target) String() string { return t.goos + "/" + t.goarch }
+
+type config struct {
+	repoRoot  string
+	outputDir string
+	version   string
+	commit    string
+	buildDate time.Time
+	targets   []target
+}
+
+type archiveFile struct {
+	name string
+	mode int64
+	data []byte
+}
+
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "queqiaopack: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("queqiaopack", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var cfg config
+	var buildDate, targets string
+	fs.StringVar(&cfg.repoRoot, "repo", ".", "repository root")
+	fs.StringVar(&cfg.outputDir, "output", "dist", "new output directory (must not already exist)")
+	fs.StringVar(&cfg.version, "version", "", "release version, for example v0.1.0")
+	fs.StringVar(&cfg.commit, "commit", "", "source commit")
+	fs.StringVar(&buildDate, "build-date", "", "source commit time in RFC3339 form")
+	fs.StringVar(&targets, "targets", targetList(defaultTargets), "comma-separated GOOS/GOARCH targets")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	if buildDate == "" {
+		return errors.New("--build-date is required")
+	}
+	parsedDate, err := time.Parse(time.RFC3339, buildDate)
+	if err != nil {
+		return fmt.Errorf("parse --build-date: %w", err)
+	}
+	cfg.buildDate = parsedDate.UTC()
+	cfg.targets, err = parseTargets(targets)
+	if err != nil {
+		return err
+	}
+	return packageRelease(ctx, cfg)
+}
+
+func packageRelease(ctx context.Context, cfg config) error {
+	if !safeMetadata.MatchString(cfg.version) {
+		return errors.New("--version is required and may contain only release-safe characters")
+	}
+	if !safeMetadata.MatchString(cfg.commit) {
+		return errors.New("--commit is required and may contain only release-safe characters")
+	}
+	if cfg.buildDate.IsZero() {
+		return errors.New("--build-date is required")
+	}
+	if cfg.buildDate.Year() < 1980 {
+		return errors.New("--build-date must be 1980 or later for ZIP compatibility")
+	}
+	if len(cfg.targets) == 0 {
+		return errors.New("at least one target is required")
+	}
+
+	repoRoot, err := filepath.Abs(cfg.repoRoot)
+	if err != nil {
+		return fmt.Errorf("resolve repository root: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "go.mod")); err != nil {
+		return fmt.Errorf("repository root %q has no go.mod: %w", repoRoot, err)
+	}
+	outputDir, err := filepath.Abs(cfg.outputDir)
+	if err != nil {
+		return fmt.Errorf("resolve output directory: %w", err)
+	}
+	if _, err := os.Lstat(outputDir); err == nil {
+		return fmt.Errorf("output directory %q already exists", outputDir)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect output directory: %w", err)
+	}
+	outputParent := filepath.Dir(outputDir)
+	if err := os.MkdirAll(outputParent, 0o755); err != nil {
+		return fmt.Errorf("create output parent: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(outputParent, ".queqiaopack-")
+	if err != nil {
+		return fmt.Errorf("create temporary package directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+	resultDir := filepath.Join(tempDir, "result")
+	if err := os.Mkdir(resultDir, 0o755); err != nil {
+		return err
+	}
+
+	documents, err := readDistributionFiles(repoRoot)
+	if err != nil {
+		return err
+	}
+	checksums := make(map[string][sha256.Size]byte, len(cfg.targets))
+	for _, target := range cfg.targets {
+		archiveName, sum, err := buildTarget(ctx, repoRoot, tempDir, resultDir, cfg, target, documents)
+		if err != nil {
+			return err
+		}
+		checksums[archiveName] = sum
+	}
+	if err := writeChecksums(filepath.Join(resultDir, "SHA256SUMS"), checksums); err != nil {
+		return err
+	}
+	if err := os.Rename(resultDir, outputDir); err != nil {
+		return fmt.Errorf("publish package directory: %w", err)
+	}
+	fmt.Printf("wrote %d release archives and SHA256SUMS to %s\n", len(cfg.targets), outputDir)
+	return nil
+}
+
+func buildTarget(ctx context.Context, repoRoot, tempDir, resultDir string, cfg config, target target, documents []archiveFile) (string, [sha256.Size]byte, error) {
+	packageBase := fmt.Sprintf("queqiaod_%s_%s_%s", cfg.version, target.goos, target.goarch)
+	binaryName := "queqiaod"
+	if target.goos == "windows" {
+		binaryName += ".exe"
+	}
+	buildDir := filepath.Join(tempDir, "build", target.goos+"-"+target.goarch)
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		return "", [sha256.Size]byte{}, err
+	}
+	binaryPath := filepath.Join(buildDir, binaryName)
+	ldflags := strings.Join([]string{
+		"-s", "-w",
+		"-X=main.version=" + cfg.version,
+		"-X=main.commit=" + cfg.commit,
+		"-X=main.buildDate=" + cfg.buildDate.Format(time.RFC3339),
+	}, " ")
+	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-buildvcs=false", "-ldflags", ldflags, "-o", binaryPath, "./cmd/queqiaod")
+	cmd.Dir = repoRoot
+	cmd.Env = withEnv(os.Environ(), map[string]string{
+		"CGO_ENABLED": "0",
+		"GOOS":        target.goos,
+		"GOARCH":      target.goarch,
+	})
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", [sha256.Size]byte{}, fmt.Errorf("build %s: %w\n%s", target, err, output)
+	}
+	binary, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return "", [sha256.Size]byte{}, fmt.Errorf("read %s binary: %w", target, err)
+	}
+	binarySum := sha256.Sum256(binary)
+	files := make([]archiveFile, 0, len(documents)+2)
+	files = append(files, archiveFile{name: binaryName, mode: 0o755, data: binary})
+	files = append(files, documents...)
+	files = append(files, archiveFile{
+		name: "BUILDINFO",
+		mode: 0o644,
+		data: []byte(fmt.Sprintf(
+			"version=%s\ncommit=%s\nbuild_date=%s\ntarget=%s\ngo=%s\nbinary_sha256=%x\n",
+			cfg.version, cfg.commit, cfg.buildDate.Format(time.RFC3339), target, runtime.Version(), binarySum,
+		)),
+	})
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+
+	extension := ".tar.gz"
+	if target.goos == "windows" {
+		extension = ".zip"
+	}
+	archiveName := packageBase + extension
+	archivePath := filepath.Join(resultDir, archiveName)
+	if target.goos == "windows" {
+		err = writeZip(archivePath, packageBase, files, cfg.buildDate)
+	} else {
+		err = writeTarGzip(archivePath, packageBase, files, cfg.buildDate)
+	}
+	if err != nil {
+		return "", [sha256.Size]byte{}, fmt.Errorf("archive %s: %w", target, err)
+	}
+	archive, err := os.ReadFile(archivePath)
+	if err != nil {
+		return "", [sha256.Size]byte{}, err
+	}
+	return archiveName, sha256.Sum256(archive), nil
+}
+
+func readDistributionFiles(repoRoot string) ([]archiveFile, error) {
+	names := []string{
+		"LICENSE",
+		"README.md",
+		"docs/DEPLOYING.md",
+		"docs/RELEASING.md",
+		"deploy/clash-queqiao.yaml",
+		"deploy/me.01.queqiao.client.plist",
+		"deploy/queqiaod.service",
+	}
+	files := make([]archiveFile, 0, len(names))
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(name)))
+		if err != nil {
+			return nil, fmt.Errorf("read distribution file %s: %w", name, err)
+		}
+		files = append(files, archiveFile{name: name, mode: 0o644, data: data})
+	}
+	return files, nil
+}
+
+func writeTarGzip(path, root string, files []archiveFile, modTime time.Time) (returnErr error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); returnErr == nil && err != nil {
+			returnErr = err
+		}
+	}()
+	gz, err := gzip.NewWriterLevel(file, gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+	gz.Header.ModTime = modTime
+	gz.Header.OS = 255
+	tw := tar.NewWriter(gz)
+	for _, entry := range files {
+		header := &tar.Header{
+			Name:    root + "/" + entry.name,
+			Mode:    entry.mode,
+			Size:    int64(len(entry.data)),
+			ModTime: modTime,
+			Format:  tar.FormatGNU,
+		}
+		if err := tw.WriteHeader(header); err != nil {
+			return err
+		}
+		if _, err := tw.Write(entry.data); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+func writeZip(path, root string, files []archiveFile, modTime time.Time) (returnErr error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); returnErr == nil && err != nil {
+			returnErr = err
+		}
+	}()
+	zw := zip.NewWriter(file)
+	for _, entry := range files {
+		header := &zip.FileHeader{Name: root + "/" + entry.name, Method: zip.Deflate}
+		header.SetMode(os.FileMode(entry.mode))
+		header.SetModTime(modTime)
+		writer, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(entry.data); err != nil {
+			return err
+		}
+	}
+	return zw.Close()
+}
+
+func writeChecksums(path string, checksums map[string][sha256.Size]byte) error {
+	names := make([]string, 0, len(checksums))
+	for name := range checksums {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var output strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&output, "%x  %s\n", checksums[name], name)
+	}
+	if err := os.WriteFile(path, []byte(output.String()), 0o644); err != nil {
+		return fmt.Errorf("write SHA256SUMS: %w", err)
+	}
+	return nil
+}
+
+func parseTargets(value string) ([]target, error) {
+	seen := make(map[string]bool)
+	var targets []target
+	for _, raw := range strings.Split(value, ",") {
+		parts := strings.Split(strings.TrimSpace(raw), "/")
+		if len(parts) != 2 || !safeMetadata.MatchString(parts[0]) || !safeMetadata.MatchString(parts[1]) {
+			return nil, fmt.Errorf("invalid target %q; want GOOS/GOARCH", raw)
+		}
+		target := target{goos: parts[0], goarch: parts[1]}
+		if !seen[target.String()] {
+			seen[target.String()] = true
+			targets = append(targets, target)
+		}
+	}
+	if len(targets) == 0 {
+		return nil, errors.New("at least one target is required")
+	}
+	return targets, nil
+}
+
+func targetList(targets []target) string {
+	values := make([]string, len(targets))
+	for i, target := range targets {
+		values[i] = target.String()
+	}
+	return strings.Join(values, ",")
+}
+
+func withEnv(base []string, replacements map[string]string) []string {
+	result := make([]string, 0, len(base)+len(replacements))
+	for _, value := range base {
+		key, _, found := strings.Cut(value, "=")
+		if !found {
+			continue
+		}
+		if _, replace := replacements[key]; !replace {
+			result = append(result, value)
+		}
+	}
+	keys := make([]string, 0, len(replacements))
+	for key := range replacements {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		result = append(result, key+"="+replacements[key])
+	}
+	return result
+}

--- a/cmd/queqiaopack/main_test.go
+++ b/cmd/queqiaopack/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestArchivesAreDeterministicAndKeepModes(t *testing.T) {
+	timestamp := time.Date(2026, time.August, 17, 3, 4, 6, 0, time.UTC)
+	files := []archiveFile{
+		{name: "README.md", mode: 0o644, data: []byte("release notes\n")},
+		{name: "queqiaod", mode: 0o755, data: []byte("binary\n")},
+	}
+	for _, format := range []string{"tar.gz", "zip"} {
+		t.Run(format, func(t *testing.T) {
+			dir := t.TempDir()
+			first := filepath.Join(dir, "first."+format)
+			second := filepath.Join(dir, "second."+format)
+			var err error
+			if format == "tar.gz" {
+				err = writeTarGzip(first, "queqiaod_v1_linux_amd64", files, timestamp)
+				if err == nil {
+					err = writeTarGzip(second, "queqiaod_v1_linux_amd64", files, timestamp)
+				}
+			} else {
+				err = writeZip(first, "queqiaod_v1_windows_amd64", files, timestamp)
+				if err == nil {
+					err = writeZip(second, "queqiaod_v1_windows_amd64", files, timestamp)
+				}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			firstData, _ := os.ReadFile(first)
+			secondData, _ := os.ReadFile(second)
+			if sha256.Sum256(firstData) != sha256.Sum256(secondData) {
+				t.Fatal("identical inputs produced different archives")
+			}
+			modes := archiveModes(t, first, format)
+			if modes["queqiaod"] != 0o755 || modes["README.md"] != 0o644 {
+				t.Fatalf("archive modes = %v", modes)
+			}
+		})
+	}
+}
+
+func TestTargetsAreParsedOnceInRequestedOrder(t *testing.T) {
+	got, err := parseTargets("linux/amd64, windows/arm64,linux/amd64")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []target{{goos: "linux", goarch: "amd64"}, {goos: "windows", goarch: "arm64"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("targets = %#v, want %#v", got, want)
+	}
+	if _, err := parseTargets("linux"); err == nil {
+		t.Fatal("target without architecture was accepted")
+	}
+}
+
+func TestChecksumsAreSorted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "SHA256SUMS")
+	checksums := map[string][sha256.Size]byte{
+		"z.zip": sha256.Sum256([]byte("z")),
+		"a.zip": sha256.Sum256([]byte("a")),
+	}
+	if err := writeChecksums(path, checksums); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if !strings.HasSuffix(lines[0], "  a.zip") || !strings.HasSuffix(lines[1], "  z.zip") {
+		t.Fatalf("checksums are not sorted: %q", data)
+	}
+}
+
+func archiveModes(t *testing.T, path, format string) map[string]os.FileMode {
+	t.Helper()
+	modes := make(map[string]os.FileMode)
+	if format == "zip" {
+		reader, err := zip.OpenReader(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer reader.Close()
+		for _, file := range reader.File {
+			modes[filepath.Base(file.Name)] = file.Mode().Perm()
+		}
+		return modes
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gz.Close()
+	reader := tar.NewReader(gz)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		modes[filepath.Base(header.Name)] = os.FileMode(header.Mode).Perm()
+	}
+	return modes
+}

--- a/deploy/me.01.queqiao.client.plist
+++ b/deploy/me.01.queqiao.client.plist
@@ -7,7 +7,7 @@
     # edit the paths and <EGRESS-IP> below
     launchctl load ~/Library/LaunchAgents/me.01.queqiao.client.plist
 
-  Restart after the client stalls (see docs/DEPLOYING.md):
+  Restart after upgrading the binary or changing configuration:
     launchctl kickstart -k gui/$(id -u)/me.01.queqiao.client
 
   See docs/DEPLOYING.md for the egress side and the Clash profile.
@@ -62,10 +62,9 @@
   <key>RunAtLoad</key>
   <true/>
 
-  <!-- Restarts on crash. It does NOT rescue the stall documented in
-       docs/DEPLOYING.md: a stalled client keeps running and keeps accepting
-       connections, so launchd sees a healthy process. That one needs an
-       explicit kickstart. -->
+  <!-- Restarts on an unsuccessful process exit. The cancelled-transfer stall
+       that previously left a live but unusable process is fixed and covered
+       by deterministic regressions; use kickstart after upgrades or edits. -->
   <key>KeepAlive</key>
   <dict>
     <key>SuccessfulExit</key>

--- a/deploy/queqiaod.service
+++ b/deploy/queqiaod.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=queqiao performance-enhancing proxy
+Documentation=https://github.com/bojieli/queqiao
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=queqiao
+Group=queqiao
+# Put whitespace-separated queqiaod flags in /etc/queqiao/queqiaod.env as:
+# QUEQIAOD_ARGS=--mode server --listen :12540 ...
+EnvironmentFile=/etc/queqiao/queqiaod.env
+ExecStart=/usr/local/bin/queqiaod $QUEQIAOD_ARGS
+Restart=on-failure
+RestartSec=2s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/queqiao /var/log/queqiao
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+LimitNOFILE=65536
+LimitNPROC=4096
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -123,6 +123,10 @@ go run ./cmd/queqiaobench --stacks vless-tcp,vless-ws \
 # The standard matrix, five trials per cell.
 ./scripts/bench_matrix.sh --trials 5 --output /tmp/matrix.tsv
 
+# An archival bundle: TSV, per-cell JSON, source/toolchain manifest, any dirty
+# source patch, and checksums. The directory must not already exist.
+./scripts/bench_matrix.sh --trials 5 --json-dir /tmp/queqiao-report
+
 # One cell, both stacks, with a machine-readable record and a CI gate.
 go run ./cmd/queqiaobench --rtt 200 --loss 3 --rate 100 --trials 5 \
     --json /tmp/result.json --gate --tolerance 0.10
@@ -169,6 +173,27 @@ sequential number, and the opposite conclusion.
 bounds every transport number taken through it: 1722 Mbit/s at 200 ms, 1784 at
 20 ms. Quote no result that is within a small factor of these without checking
 it first.
+
+## Archival reports and provenance
+
+`bench_matrix.sh --json-dir DIR` creates a self-checking report bundle instead
+of loose JSON files. `manifest.txt` records the commit, Go toolchain, target,
+matrix settings, and shell-escaped invocation. Every per-cell JSON report has
+schema version 1 and repeats the exact command arguments, seeded path settings,
+VCS revision/dirty bit, Go target, and complete module dependency graph. Cold
+and warm latency records and contention records are machine-readable too; they
+are no longer terminal-only output. `SHA256SUMS` covers the bundle.
+
+For a report intended to support a published claim, start from a clean tree so
+the recorded commit is sufficient to reproduce its source. A development run
+is still honest: `source-status.txt` records the dirty paths and `source.patch`
+captures tracked changes. Untracked files cannot be reconstructed from that
+patch, which is why an archival run must be clean.
+
+The emulator is deterministic for a given seed, but elapsed time is not:
+scheduler load, CPU frequency, kernel, and Go version still affect performance.
+Reproduce comparisons on a comparable host and judge paired stacks from the
+same cell, rather than expecting benchmark JSON to be byte-identical.
 
 ## Live campaigns
 

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -6,8 +6,14 @@ to point Clash Verge or any mihomo-based client at it.
 Read [the limits](#what-you-are-signing-up-for) before deploying this anywhere
 you care about. The project has not met the release gates in
 [`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md). The two tunnel-stall defects
-measured on 2026-08-16 are fixed and have deterministic regressions, but the
-broader live fallback, soak, packaging, and security gates remain open.
+measured on 2026-08-16 are fixed and have deterministic regressions. A live
+UDP blackhole recovered over TCP in 9.51 seconds, and release packaging is now
+reproducible; broader intermittent-loss, soak, resource, and security gates
+remain open.
+
+The deployment trust boundaries and resource ceilings are enumerated in
+[`SECURITY-REVIEW.md`](SECURITY-REVIEW.md). In particular, the local SOCKS and
+metrics listeners are unauthenticated and should remain on loopback.
 
 ## The shape of a deployment
 
@@ -31,7 +37,22 @@ back by deleting one node and one rule.
 
 ## Build and install
 
-Go 1.25 or later.
+Go 1.25.13 or later. Earlier Go 1.25 patch releases contain standard-library
+vulnerabilities reachable through the TLS, X.509, HTTP metrics, and network
+paths used by queqiao; the module directive enforces the patched toolchain.
+
+For a tagged build, prefer the release archive for the target host and verify
+its `SHA256SUMS`. [`RELEASING.md`](RELEASING.md) documents provenance, atomic
+installation, and rollback. To build the entire six-target release matrix from
+a checkout:
+
+```sh
+go run ./cmd/queqiaopack --version v0.1.0 \
+  --commit "$(git rev-parse HEAD)" \
+  --build-date "$(git show -s --format=%cI HEAD)" --output dist
+```
+
+For development builds:
 
 ```sh
 git clone https://github.com/bojieli/queqiao && cd queqiao
@@ -65,8 +86,8 @@ sudo chmod 600 key.pem secret
 verified TLS name, not a DNS lookup: the client dials the literal IP in
 `--remote` and presents this as SNI.
 
-Run it under systemd. [`deploy/queqiaod-dev.service`](../deploy/queqiaod-dev.service)
-is the hardened unit this project uses; the minimal form is:
+Run it under systemd. [`deploy/queqiaod.service`](../deploy/queqiaod.service)
+is the packaged hardened template; the minimal form is:
 
 ```ini
 [Service]
@@ -251,9 +272,11 @@ serving the alternatives:
 
 Also unfinished, and relevant to a daily driver: interactive latency still
 moves under queqiao's own bulk load, although the corrected live A/B is now in
-the range of the measured QUIC alternatives; TUN/VLESS ingress does not exist,
-so Clash's SOCKS hand-off is the only integration; and UDP-blocked, restart,
-and long-soak behaviour is unmeasured on a real path.
+the range of the measured QUIC alternatives. Clash's TUN-to-SOCKS hand-off is
+the supported transparent integration; direct TUN/VLESS ingress is not part of
+the current architecture. A real-path UDP blackhole recovered over TCP in
+9.51 seconds, but intermittent blocking, restart, and long-soak behaviour still
+need broader campaigns.
 
 ## Troubleshooting
 

--- a/docs/PRODUCTION-DESIGN.md
+++ b/docs/PRODUCTION-DESIGN.md
@@ -271,8 +271,9 @@ address as the PEP socket endpoint.
   authentication.
 - Destination allow/deny policy, including private-address rejection by
   default.
-- Per-user/session/flow limits for handshakes, lanes, frames, reassembly
-  bytes, reconnect rate, and application-idle/maximum-lifetime duration.
+- Connection/session/flow limits for handshakes, lanes, frames, reassembly
+  bytes, reconnect rate, and application-idle/maximum-lifetime duration. The
+  shared credential does not provide per-user identities or quotas.
 - Metrics and structured logs that never contain the shared secret or
   application plaintext.
 - A systemd unit isolated from Xray, sing-box, Cloudflare, Nginx, and the
@@ -289,6 +290,11 @@ under the lock, allocating as it went. Neither is a frame-size limit or a
 buffered-byte limit, and neither would have been found by one. Both are
 bounded now, and `deep.yml` smokes every fuzz target weekly so the next one of
 this shape is found by the repository rather than by the path.
+
+The Stage 5 review also found that the stream semaphore did not bound a QUIC
+connection that authenticated at TLS and then opened no stream. Accepted QUIC
+connections now have a separate `MaxSessions`-sized admission bound. The full
+trust-boundary review and residual risks are in `SECURITY-REVIEW.md`.
 
 ## Release gates
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,94 @@
+# Releases, installation, and rollback
+
+Release archives are built by `cmd/queqiaopack`, not by host-specific `tar`
+or `zip` commands. The packager fixes archive ordering, timestamps, ownership,
+permissions, build metadata, and Go path information. Given the same commit,
+Go toolchain, version, and commit timestamp, it produces the same bytes.
+
+## Build a release locally
+
+Start from a clean checkout at the commit being released. Use the commit time,
+not the wall clock, as the build date:
+
+```sh
+version=v0.1.0
+commit=$(git rev-parse HEAD)
+build_date=$(git show -s --format=%cI HEAD)
+go run ./cmd/queqiaopack \
+  --version "$version" --commit "$commit" --build-date "$build_date" \
+  --output dist
+```
+
+The default target set is Linux, macOS, and Windows on amd64 and arm64. The
+output directory must not already exist, preventing a new release from being
+mixed with stale artifacts. `SHA256SUMS` covers every archive.
+
+Verify a downloaded release before unpacking it:
+
+```sh
+sha256sum -c SHA256SUMS                 # Linux
+shasum -a 256 -c SHA256SUMS             # macOS
+```
+
+Then confirm that the embedded metadata matches the tag:
+
+```sh
+./queqiaod --version
+cat BUILDINFO
+```
+
+## Atomic Unix installation
+
+Do not overwrite the running binary without retaining the exact prior build.
+The running process is unaffected by a rename, so installation and rollback
+can be prepared before a controlled service restart:
+
+```sh
+sudo install -d -m 0755 /usr/local/lib/queqiao/rollback
+installed=/usr/local/bin/queqiaod
+backup=/usr/local/lib/queqiao/rollback/queqiaod-$(date -u +%Y%m%dT%H%M%SZ)
+test ! -e "$installed" || sudo cp -p "$installed" "$backup"
+sudo install -m 0755 ./queqiaod "${installed}.new"
+sudo mv "${installed}.new" "$installed"
+sudo systemctl restart queqiaod
+sudo systemctl is-active --quiet queqiaod
+"$installed" --version
+```
+
+Keep configuration, certificates, and the session secret outside the release
+directory. Upgrading the binary then cannot replace credentials or the known
+working configuration.
+
+For a macOS LaunchAgent, use the same `install`/`mv` sequence for
+`~/.queqiao/bin/queqiaod`, then run:
+
+```sh
+launchctl kickstart -k "gui/$(id -u)/me.01.queqiao.client"
+```
+
+## Roll back
+
+Choose the backup explicitly, verify its embedded version, install it through
+a temporary pathname, and restart:
+
+```sh
+backup=/usr/local/lib/queqiao/rollback/queqiaod-YYYYMMDDTHHMMSSZ
+"$backup" --version
+sudo install -m 0755 "$backup" /usr/local/bin/queqiaod.rollback
+sudo mv /usr/local/bin/queqiaod.rollback /usr/local/bin/queqiaod
+sudo systemctl restart queqiaod
+sudo systemctl is-active --quiet queqiaod
+```
+
+If a new build fails its smoke check, roll back the binary before changing the
+configuration. That preserves one variable per incident. The Clash side needs
+no binary rollback: select the previous profile or remove the `queqiao` SOCKS5
+node and rule.
+
+## Publishing
+
+Pushing a `v*` tag starts `.github/workflows/release.yml`.
+The workflow derives the build date from the tagged commit, runs tests, builds
+all six archives, verifies their checksums, and attaches them to a GitHub
+Release. Tags are immutable release inputs; replace a bad release with a new
+version rather than moving its tag.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,16 +75,43 @@ deletion record are in `DESIGN-MULTIPATH.md`.
 Gate: injected UDP loss/blocking causes new and existing sessions to recover
 within a measured bound, and a resumable association must preserve the
 remote relay's source address across the transition without exposing duplicate
-bytes. The mechanism exists and is tested; the measured bound on the live path
-is what remains.
+bytes.
 
-## Stage 5 — TUN and release hardening
+Status: met for the bounded fallback mechanism. A live UDP blackhole recovered
+the same SOCKS5 UDP association over a fresh authenticated TCP lane in 9.51 s,
+preserving its local endpoint and remote relay source address. Deterministic
+tests cover TCP stream replay without duplicate bytes, relay-source
+preservation, single-use resume tokens, and repeated rescue under the race
+detector. Intermittent blocking and long-soak coverage remain Stage 5 release
+hardening rather than an unimplemented fallback mechanism.
 
-- TUN integration and Clash Verge setup guide.
+## Stage 5 — integration and release hardening
+
+- ~~TUN integration through Clash Verge and setup guide.~~ Done: Clash/mihomo
+  owns transparent TUN capture and hands selected traffic to queqiao's local
+  SOCKS5 TCP/UDP ingress. Direct in-process TUN/VLESS ingress is deliberately
+  outside the current two-process architecture.
 - ~~Native QUIC DATAGRAM mode for UDP, retaining stream/TCP fallback.~~ Done:
   chosen by QUIC's own capability exchange rather than configured, with the
   control stream retained for lanes that have no datagrams. Measured emulated,
   not live.
-- Cross-platform packaging.
-- Fuzzing, race tests, resource limits, and security review.
-- Reproducible benchmark reports and rollback instructions.
+- ~~Cross-platform packaging.~~ Done: deterministic Linux, macOS, and Windows
+  archives for amd64 and arm64, embedded provenance, SHA-256 checksums, and a
+  tag-driven release workflow.
+- ~~Fuzzing and race automation.~~ Done: the weekly deep workflow discovers
+  every fuzz target and runs the complete suite under the race detector.
+- ~~Resource-limit and security review.~~ Done for the paired SOCKS deployment:
+  documented trust boundaries and residual risk, bounded unauthenticated QUIC
+  connections, sessions, frames, flow buffers, replay state, relay sockets,
+  lanes, and lifetimes, plus pinned vulnerability scanning and an enforced
+  patched Go toolchain. Independent audit and live soak remain release gates.
+- ~~Reproducible benchmark reports.~~ Done: versioned JSON records include the
+  exact invocation, seeded path, VCS state, toolchain, module graph, latency,
+  and contention results; matrix bundles add the source patch and checksums.
+- ~~Deterministic intermittent-block and fallback soak.~~ Done: UDP is removed,
+  associations fall back to TCP without changing their relay source, UDP is
+  restored on the same endpoint, and post-cooldown probes return to QUIC. The
+  normal/race soak runs weekly with checksummed provenance.
+- Real-path intermittent firewall/NAT and long-duration soak campaigns.
+- ~~Documented rollback instructions.~~ Done: checksum verification, atomic
+  binary installation, retained prior builds, and explicit service rollback.

--- a/docs/SECURITY-REVIEW.md
+++ b/docs/SECURITY-REVIEW.md
@@ -1,0 +1,87 @@
+# Security and resource review
+
+This review covers the current paired deployment: a local SOCKS5 agent under
+the operator's control and one Internet-facing egress agent. It is not a claim
+of third-party audit or a production-readiness certificate.
+
+## Trust boundaries
+
+- The egress accepts traffic only after TLS 1.3 and the queqiao HELLO HMAC.
+  The certificate authenticates the egress to the client; the pre-shared
+  secret authenticates the client to the egress.
+- The local SOCKS5 listener has no user authentication. It must bind to
+  loopback or another access-controlled interface. Anyone who can reach it can
+  use the fixed egress and consume its session budget.
+- A holder of the shared secret is trusted to use the proxy, but is not trusted
+  to supply well-formed frames or bounded identifiers. Parser, admission, and
+  memory limits still apply after authentication.
+- Destination hosts and the network path are untrusted. TLS protects the outer
+  payload and handshake; endpoints still observe normal connection metadata.
+
+## Controls reviewed
+
+| Area | Current control | Verification |
+| --- | --- | --- |
+| Transport identity | TLS 1.3, verified certificate name/root, fixed ALPN | configuration and integration tests |
+| Client authentication | HMAC-SHA-256 over timestamp, random nonce, session/lane identity, and kind | session unit tests; constant-time MAC comparison |
+| Replay | five-minute timestamp window plus a ten-minute bounded nonce cache | replay-guard tests |
+| Wire allocation | payload length rejected before allocation; hard 1 MiB protocol ceiling and 256 KiB service default | protocol unit tests and fuzz targets |
+| Sessions | local and remote admission semaphores; configured ceiling capped at 65,536 | configuration/admission tests |
+| QUIC connections | accepted connections capped at `MaxSessions`, including connections that never authenticate or open a stream | `TestQUICConnectionsHaveAnAdmissionBound` |
+| Lanes and replay memory | fixed per-flow lane budget, 16,384 retained chunks, 64 MiB sender ceiling, 128 MiB reassembly ceiling | scheduler/reassembly tests |
+| UDP rescue | cryptographic 128-bit, single-use token; 30-second expiry; at most 256 retained relay sockets | UDP relay and repeated rescue tests |
+| Lifetime | bounded handshake, path idle, application idle, maximum flow lifetime, lane recovery attempts, and completion tombstone | lifecycle and failure-injection tests |
+| Egress SSRF | DNS resolved at the egress to a concrete address; private, loopback, link-local, multicast, documentation, benchmark, and shared ranges rejected by default | destination policy tests |
+| Service account | packaged systemd unit uses a dedicated user, no new privileges, strict filesystem protection, syscall architecture restriction, and explicit writable paths | deployment template review |
+| Parser robustness | all discovered fuzz targets run weekly; malformed frames, ACK ranges, and coded symbols have dedicated fuzzers | `.github/workflows/deep.yml` |
+| Concurrency | complete race suite runs weekly | `.github/workflows/deep.yml` |
+| Known vulnerabilities | pinned `govulncheck` performs reachability-aware scans against Go's official vulnerability database weekly and before publishing | deep and release workflows |
+| Fallback soak | repeated UDP removal, TCP rescue, relay-source preservation, UDP restoration, and race-detector runs | `scripts/fallback_soak.sh` and the deep workflow |
+
+The review found one remotely reachable resource gap: QUIC connection objects
+were admitted before the per-stream session semaphore, so a peer that never
+opened a stream could create an unbounded number of server goroutines and live
+connections. Accepted QUIC connections now have their own `MaxSessions`-sized
+admission semaphore and excess connections are closed immediately.
+
+The first pinned vulnerability scan also found 11 reachable standard-library
+advisories in the workstation's Go 1.25.7 toolchain. All are fixed in Go
+1.25.13, so `go.mod` now requires that patch release or newer. This is a build
+input, not only a CI preference: Go's toolchain selection upgrades an older
+local command before compiling release binaries.
+
+## Residual risks and operating requirements
+
+- One pre-shared secret represents the whole client side. There are no
+  per-user identities, quotas, revocation list, or online secret rotation.
+- Per-flow buffering is bounded, but the aggregate ceiling is the product of
+  `MaxSessions` and the per-flow limits. Operators must set `MaxSessions` to a
+  value the host can fund; the command default is 1,024, not a sizing promise.
+- The metrics endpoint has no authentication. Bind it to loopback or leave it
+  disabled. Logs and metrics omit application plaintext and the shared secret,
+  but destinations remain observable to the two endpoints and their kernels.
+- Secret bytes are not locked in memory. Configuration files must be readable
+  only by the service account, and core dumps should remain disabled by the
+  service manager.
+- The egress policy prevents connections to non-public resolved addresses by
+  default, but enabling `--allow-private-destinations` intentionally removes
+  that boundary and must be confined to a benchmark environment.
+- This is a manual code/configuration review, not an independent cryptographic
+  assessment. Broader interoperability, long-soak, intermittent-blocking, and
+  live fault campaigns remain release gates.
+
+## Release verification
+
+Before a tagged release, run the normal and deep workflows, verify
+`SHA256SUMS`, and retain the previous binary as described in `RELEASING.md`.
+A release report should record:
+
+```sh
+go test -timeout 50m ./...
+go test -race -timeout 110m ./...
+go vet ./...
+go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
+```
+
+The scheduled deep workflow additionally discovers and smokes every fuzz
+target, so adding a fuzzer does not require editing a static target list.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bojieli/queqiao
 
-go 1.25.0
+go 1.25.13
 
 require github.com/apernet/quic-go v0.61.1-0.20260806010916-184d081eef3e
 

--- a/internal/pep/config_test.go
+++ b/internal/pep/config_test.go
@@ -71,3 +71,24 @@ func TestServerRejectsUnserviceableConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestQUICConnectionsHaveAnAdmissionBound(t *testing.T) {
+	certificate, _ := testCertificate(t)
+	server, err := NewServer(ServerConfig{
+		ListenAddr: "127.0.0.1:0", Certificate: certificate,
+		Secret: []byte("0123456789abcdef"), MaxSessions: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !server.admitConnection() || !server.admitConnection() {
+		t.Fatal("the configured connection capacity was not admitted")
+	}
+	if server.admitConnection() {
+		t.Fatal("an unauthenticated QUIC connection exceeded the admission bound")
+	}
+	server.releaseConnection()
+	if !server.admitConnection() {
+		t.Fatal("released QUIC connection capacity was not reusable")
+	}
+}

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -66,6 +66,7 @@ type Server struct {
 	cfg              ServerConfig
 	replay           *session.ReplayGuard
 	semaphore        chan struct{}
+	connections      chan struct{}
 	sessionsMu       sync.RWMutex
 	sessions         map[[16]byte]*serverFlow
 	maxObservedLanes atomic.Int64
@@ -210,6 +211,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		cfg:              cfg,
 		replay:           session.NewReplayGuard(10*time.Minute, cfg.MaxSessions*4),
 		semaphore:        make(chan struct{}, cfg.MaxSessions),
+		connections:      make(chan struct{}, cfg.MaxSessions),
 		sessions:         make(map[[16]byte]*serverFlow),
 		budget:           limiter.New(limiter.Config{TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec}),
 		metrics:          cfg.Metrics,
@@ -342,17 +344,35 @@ func (s *Server) ServePacketConn(ctx context.Context, packetConn net.PacketConn)
 			}
 			return fmt.Errorf("accept QUIC lane: %w", acceptErr)
 		}
+		if !s.admitConnection() {
+			_ = conn.CloseWithError(0x100, "server connection limit reached")
+			s.cfg.Logger.Warn("remote QUIC connection limit reached")
+			continue
+		}
 		// Session admission is performed per QUIC stream in handleQUIC. Holding
-		// one global semaphore slot for the lifetime of a multiplexed
+		// one slot from that session semaphore for the lifetime of a multiplexed
 		// connection would incorrectly reduce MaxSessions and prevent the
 		// connection from carrying the configured number of independent flows.
+		// The separate connection semaphore above bounds idle/untrusted peers.
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer s.releaseConnection()
 			s.handleQUIC(ctx, conn)
 		}()
 	}
 }
+
+func (s *Server) admitConnection() bool {
+	select {
+	case s.connections <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) releaseConnection() { <-s.connections }
 
 func (s *Server) handleQUIC(ctx context.Context, conn *quic.Conn) {
 	var wg sync.WaitGroup

--- a/internal/pep/udp_rescue_test.go
+++ b/internal/pep/udp_rescue_test.go
@@ -140,6 +140,92 @@ func TestUDPAssociationRescuesToTCP(t *testing.T) {
 	}
 }
 
+// Blocking UDP is not a one-way mode switch. AUTO has to use TCP while the
+// endpoint is in cooldown, then probe QUIC again after the cooldown and clear
+// the penalty when that probe succeeds. This covers the blocked/recovered
+// sequence without relying on a host firewall or wall-clock minutes.
+func TestIntermittentUDPBlockingReturnsToQUIC(t *testing.T) {
+	tcpListener, quicPacketConn := listenTCPAndUDPOnOnePort(t)
+	defer tcpListener.Close()
+	tlsCert, roots := testCertificate(t)
+	secret := []byte("intermittent-udp-test-secret-32b")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server, err := NewServer(ServerConfig{
+		ListenAddr: tcpListener.Addr().String(), Certificate: tlsCert, Secret: secret,
+		DestinationPolicy: DestinationPolicy{AllowPrivate: true}, EnableTCP: true, EnableQUIC: true,
+		Logger: logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewClient(ClientConfig{
+		ListenAddr: "127.0.0.1:0", RemoteAddr: tcpListener.Addr().String(), ServerName: "queqiao.test",
+		Secret: secret, RootCAs: roots, Transport: TransportAuto,
+		FallbackDelay: 250 * time.Millisecond, UDPFailureThreshold: 1, UDPCooldown: 150 * time.Millisecond,
+		DialTimeout: 2 * time.Second, HandshakeTimeout: 2 * time.Second, Logger: logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serviceCtx, serviceCancel := context.WithCancel(context.Background())
+	defer serviceCancel()
+	firstQUICCtx, stopFirstQUIC := context.WithCancel(serviceCtx)
+	tcpErr := make(chan error, 1)
+	firstQUICErr := make(chan error, 1)
+	go func() { tcpErr <- server.ServeListener(serviceCtx, tcpListener) }()
+	go func() { firstQUICErr <- server.ServePacketConn(firstQUICCtx, quicPacketConn) }()
+
+	open := func(want TransportKind) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(serviceCtx, 5*time.Second)
+		defer cancel()
+		association, err := client.openUDPAssociation(ctx, nil)
+		if err != nil {
+			t.Fatalf("open UDP association expecting %s: %v", want, err)
+		}
+		if association.lane.kind != want {
+			_ = association.lane.fc.Close()
+			t.Fatalf("association transport = %s, want %s", association.lane.kind, want)
+		}
+		_ = association.lane.fc.Close()
+	}
+
+	open(TransportQUIC)
+	stopFirstQUIC()
+	select {
+	case <-firstQUICErr:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first QUIC listener did not stop")
+	}
+	open(TransportTCP)
+
+	// Restore UDP on the same endpoint. The next post-cooldown association is
+	// the health probe; a successful QUIC authentication makes UDP healthy.
+	restartedPacketConn, err := net.ListenPacket("udp", tcpListener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	restartedCtx, stopRestarted := context.WithCancel(serviceCtx)
+	defer stopRestarted()
+	restartedErr := make(chan error, 1)
+	go func() { restartedErr <- server.ServePacketConn(restartedCtx, restartedPacketConn) }()
+	time.Sleep(250 * time.Millisecond)
+	open(TransportQUIC)
+	if got := client.Metrics().Snapshot().Fallbacks; got == 0 {
+		t.Fatal("blocked interval did not record a TCP fallback")
+	}
+
+	serviceCancel()
+	for name, errors := range map[string]<-chan error{"TCP": tcpErr, "restarted QUIC": restartedErr} {
+		select {
+		case <-errors:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("%s service did not stop", name)
+		}
+	}
+}
+
 func openTestUDPAssociation(t *testing.T, control net.Conn) *net.UDPAddr {
 	t.Helper()
 	_ = control.SetDeadline(time.Now().Add(5 * time.Second))

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,3 +120,20 @@ The sink requires an explicit bounded `Content-Length`, accepts one request by
 default, and exits after that request. It must not be left as a public
 service; use a temporary systemd unit or process supervisor and verify that
 the listener is gone after the measurement.
+
+## Fallback soak
+
+`fallback_soak.sh` repeatedly withdraws UDP under live associations, verifies
+TCP rescue and remote relay-source preservation, restores UDP on the same
+endpoint, and verifies that post-cooldown health probes return new associations
+to QUIC. It runs both normal and race-detector repetitions and emits a
+checksummed provenance bundle:
+
+```sh
+./scripts/fallback_soak.sh --runs 50 --race-runs 20 \
+  --output-dir /tmp/queqiao-fallback-soak
+```
+
+This is the deterministic release soak and runs weekly at a smaller count. It
+does not replace intermittent firewall and NAT tests on the real China-US
+path.

--- a/scripts/bench_matrix.sh
+++ b/scripts/bench_matrix.sh
@@ -8,6 +8,8 @@
 # see docs/MEASUREMENTS-*.md for those.
 set -Euo pipefail
 
+invocation=("$0" "$@")
+
 output=${QUEQIAO_OUTPUT:-}
 trials=${QUEQIAO_TRIALS:-5}
 congestion=${QUEQIAO_CONGESTION:-bbr-tuic}
@@ -51,6 +53,35 @@ while (($#)); do
 done
 
 [[ "$trials" =~ ^[1-9][0-9]*$ ]] || { echo "trials must be positive" >&2; exit 2; }
+if [[ -n "$json_dir" ]]; then
+    [[ ! -e "$json_dir" ]] || { echo "JSON report directory already exists: $json_dir" >&2; exit 1; }
+    source_status=$(git status --porcelain=v1 --untracked-files=normal)
+    tree_state=clean
+    if [[ -n "$source_status" ]]; then tree_state=modified; fi
+    mkdir -p "$json_dir"
+    if [[ -z "$output" ]]; then output=$json_dir/results.tsv; fi
+    {
+        echo 'format=queqiao-benchmark-bundle-v1'
+        echo "started_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "commit=$(git rev-parse HEAD)"
+        echo "tree_state=$tree_state"
+        echo "go_version=$(go version)"
+        echo "goos=$(go env GOOS)"
+        echo "goarch=$(go env GOARCH)"
+        echo "trials=$trials"
+        echo "congestion=$congestion"
+        echo "timeout=$timeout_seconds"
+        echo "gate=$gate"
+        echo "tolerance=$tolerance"
+        printf 'command='
+        printf '%q ' "${invocation[@]}"
+        printf '\n'
+    } >"$json_dir/manifest.txt"
+    if [[ -n "$source_status" ]]; then printf '%s\n' "$source_status" >"$json_dir/source-status.txt"
+    else : >"$json_dir/source-status.txt"
+    fi
+    git diff --binary HEAD >"$json_dir/source.patch"
+fi
 if [[ -n "$output" ]]; then
     [[ ! -e "$output" ]] || { echo "output already exists: $output" >&2; exit 1; }
     exec >"$output"
@@ -105,6 +136,15 @@ bench --rtt 200 --rate 100 --loss 1 --bytes 1024 --flows 1 --latency
 echo
 echo "## block G: interactive latency during a bulk transfer"
 bench --rtt 200 --rate 100 --loss 1 --bytes $((50 * 1024 * 1024)) --flows 1 --interactive
+
+if [[ -n "$json_dir" ]]; then
+    (
+        cd "$json_dir"
+        report_files=(manifest.txt source-status.txt source.patch block-*.json)
+        if [[ -f results.tsv ]]; then report_files+=(results.tsv); fi
+        shasum -a 256 "${report_files[@]}" >SHA256SUMS
+    )
+fi
 
 if ((failures)); then
     echo >&2 "bench_matrix: $failures block(s) failed the gate"

--- a/scripts/fallback_soak.sh
+++ b/scripts/fallback_soak.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Repeatedly exercise UDP block, TCP rescue, source-preserving resume, and UDP
+# recovery. Results carry source/toolchain provenance so a passing soak can be
+# attached to a release rather than copied out of a terminal.
+set -Euo pipefail
+
+runs=${QUEQIAO_SOAK_RUNS:-20}
+race_runs=${QUEQIAO_SOAK_RACE_RUNS:-5}
+output_dir=${QUEQIAO_SOAK_OUTPUT:-}
+invocation=("$0" "$@")
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: fallback_soak.sh --output-dir DIR [--runs N] [--race-runs N]
+
+The output directory must not exist. Normal and race logs, source status, any
+tracked source patch, a manifest, and SHA-256 checksums are retained there.
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+        --output-dir) output_dir=$2; shift 2 ;;
+        --runs) runs=$2; shift 2 ;;
+        --race-runs) race_runs=$2; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+[[ -n "$output_dir" ]] || { echo "--output-dir is required" >&2; usage; exit 2; }
+[[ "$runs" =~ ^[1-9][0-9]*$ ]] || { echo "runs must be positive" >&2; exit 2; }
+[[ "$race_runs" =~ ^[1-9][0-9]*$ ]] || { echo "race runs must be positive" >&2; exit 2; }
+[[ ! -e "$output_dir" ]] || { echo "output directory already exists: $output_dir" >&2; exit 1; }
+
+source_status=$(git status --porcelain=v1 --untracked-files=normal)
+tree_state=clean
+if [[ -n "$source_status" ]]; then tree_state=modified; fi
+mkdir -p "$output_dir"
+{
+    echo 'format=queqiao-fallback-soak-v1'
+    echo "started_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "commit=$(git rev-parse HEAD)"
+    echo "tree_state=$tree_state"
+    echo "go_version=$(go version)"
+    echo "goos=$(go env GOOS)"
+    echo "goarch=$(go env GOARCH)"
+    echo "runs=$runs"
+    echo "race_runs=$race_runs"
+    printf 'command='
+    printf '%q ' "${invocation[@]}"
+    printf '\n'
+} >"$output_dir/manifest.txt"
+if [[ -n "$source_status" ]]; then printf '%s\n' "$source_status" >"$output_dir/source-status.txt"
+else : >"$output_dir/source-status.txt"
+fi
+git diff --binary HEAD >"$output_dir/source.patch"
+
+tests='TestUDPAssociationRescuesToTCP|TestARescuedUDPAssociationKeepsItsRemoteSourceAddress|TestIntermittentUDPBlockingReturnsToQUIC'
+status=0
+go test ./internal/pep -run "^(${tests})$" -count "$runs" -timeout 45m \
+    2>&1 | tee "$output_dir/normal.log" || status=$?
+go test -race ./internal/pep -run "^(${tests})$" -count "$race_runs" -timeout 45m \
+    2>&1 | tee "$output_dir/race.log" || status=$?
+
+(
+    cd "$output_dir"
+    shasum -a 256 manifest.txt source-status.txt source.patch normal.log race.log >SHA256SUMS
+)
+exit "$status"


### PR DESCRIPTION
# Summary

- add deterministic six-target release archives, embedded provenance, checksums, tagged release publishing, and rollback guidance
- make benchmark JSON and matrix bundles record exact source, toolchain, invocation, latency, contention, dirty patches, and checksums
- bound unauthenticated QUIC connections, document the security/resource review, enforce Go 1.25.13, and add pinned vulnerability scanning
- verify UDP block -> TCP fallback -> UDP recovery end to end and add a checksummed normal/race fallback soak

# Verification

- go test -timeout 50m ./...
- go test -race -timeout 110m ./...
- go vet ./...
- actionlint .github/workflows/*.yml
- six direct cross-builds and six queqiaopack archives; all SHA256SUMS verified
- govulncheck v1.7.0 ./... (clean with Go 1.25.13)
- fallback soak: 20 normal + 5 race repetitions, clean-tree checksummed report
