### PR TITLE
Record live release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -short -timeout 20m ./...
+      - name: live probe helper tests
+        run: python3 -m unittest scripts/test_udp_association_check.py
 
   # Exercise the actual release path, including embedded version metadata and
   # deterministic archive creation. One target is enough here; release.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /dist/
 /coverage.out
 /coverage.html
+__pycache__/
+*.py[cod]
 
 # Local configuration and secrets
 *.local.yaml

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ same guide is fixed; its diagnosis and regression proof remain in
 
 ## Current status
 
-The repository now contains an authenticated SOCKS-to-PEP prototype with
+The repository now contains an authenticated fixed-egress SOCKS-to-PEP with
 TLS/TCP, QUIC, lane joins, cross-lane reassembly, PIAS-inspired
 classification, SOCKS5 TCP CONNECT and bounded UDP ASSOCIATE, new-flow
 UDP/TCP racing, bounded lane recovery, completion tombstones, aggregate
@@ -64,10 +64,13 @@ pacing, and opt-in QUIC controllers. The stock apNet
 QUIC controller is retained as the control; an independently implemented
 BBRv1-shaped controller, an adaptive controller, and a Hysteria-style
 fixed-rate (Brutal) controller can be selected for measurement.
-An isolated development service is deployed without replacing the existing
-tunnels. The latest five-block real-link evidence is recorded in
+The hardened pair is deployed with retained rollback binaries. The early
+five-block real-link evidence is recorded in
 [`docs/MEASUREMENTS-20260810.md`](docs/MEASUREMENTS-20260810.md); the earlier
 pilot remains in [`docs/MEASUREMENTS-20260809.md`](docs/MEASUREMENTS-20260809.md).
+The release build, security, live fallback, upgrade, and mixed-soak evidence is
+in
+[`docs/RELEASE-HARDENING-20260817.md`](docs/RELEASE-HARDENING-20260817.md).
 
 ### Measuring against a reference
 
@@ -194,11 +197,11 @@ shared control connection exists at all.
 
 ### Recommended configuration
 
-The measured configuration is `--quic-pool --optimistic-open`. There is nothing
-to size: a flow's data goes over one connection, and what it may commit ahead
-of its transport is a fraction of that transport's own congestion window, so it
-follows the path rather than a constant. Both flags remain opt-in because this
-project's release gates are not met, not because they measured badly.
+The measured behavior is now the default: `--quic-pool=true` shares the control
+connection and `--wait-for-open-ack=false` pipelines the destination open.
+There is nothing to size: a flow's data goes over one connection, and what it
+may commit ahead of its transport is a fraction of that transport's own
+congestion window, so it follows the path rather than a constant.
 
 Outside the standard matrix, queqiao is ahead at 20 ms / 1 Gbit/s (708 against
 685 Mbit/s), at parity at 30 ms / 200 Mbit/s, ahead under 25% upstream loss
@@ -206,25 +209,30 @@ Outside the standard matrix, queqiao is ahead at 20 ms / 1 Gbit/s (708 against
 jitter it measures 8.4 Mbit/s against 2.9, because reassembling by byte offset
 does not stall a stream on an out-of-order packet the way relaying one does.
 
-The prototype is still not safe to use as a general-purpose production tunnel.
-Broader loss/soak campaigns remain outstanding, and under extreme correlated
-loss (35% in 10-packet bursts) queqiao's behavior still differs from the
-reference's: it completes more transfers but is slower on the ones both
+This is a fixed-egress experimental transport, not a general-purpose production
+VPN. Under extreme correlated loss (35% in 10-packet bursts), queqiao's
+behavior still differs from the reference's: it completes more transfers but
+is slower on the ones both
 finish. That case is now diagnosed -- lanes die of QUIC's idle timeout mid-burst
 and the rejoin is refused because the server's session went with its own
-connection. The former TCP-rescue acknowledgement-loop failure is fixed, and
-the UDP association rescue test now passes 50 consecutive focused runs and 20
-under `-race`. TUN/VLESS ingress is not yet implemented. A mid-session UDP
-rescue now reclaims the same remote relay socket by token, so the destination
-keeps seeing one source address, but
-datagrams in flight when the lane died are still lost rather than replayed. The project has not passed all controlled-loss/resource release
-gates in [`docs/PRODUCTION-DESIGN.md`](docs/PRODUCTION-DESIGN.md).
+connection. TCP and UDP rescue now have deterministic/race coverage; a live
+intermittent UDP block recovered the unchanged association over TCP and fresh
+traffic returned to QUIC after restoration. A mid-session UDP rescue reclaims
+the same remote relay socket by token, so the destination keeps seeing one
+source address; datagrams in flight when a lane dies remain lost, as allowed by
+UDP semantics. Clash/mihomo supplies transparent TUN capture and hands traffic
+to the SOCKS endpoint; direct TUN/VLESS ingress is outside this architecture.
+Repository-controlled loss, resource, packaging, vulnerability, rollback, and
+bounded-soak gates are complete. Independent review and broader NAT/middlebox
+operation remain external qualifications; see
+[`docs/PRODUCTION-DESIGN.md`](docs/PRODUCTION-DESIGN.md).
 
 ## Design goals
 
-- One local SOCKS5/TUN-facing agent and one fixed-egress US agent.
-- One application TCP flow can be framed, reordered, and striped over
-  one QUIC connection, framed so that arrival order does not gate delivery.
+- One local SOCKS5-facing agent, fed by Clash/mihomo's TUN integration, and one
+  fixed-egress US agent.
+- One application TCP flow is framed and reordered over exactly one data
+  connection at a time, so transport arrival order does not gate delivery.
   Striping a flow across several connections was tried, measured, and deleted:
   the path has one bottleneck per endpoint pair, and an open-loop probe
   delivers the same total however many connections carry it.
@@ -270,14 +278,13 @@ recorded in [`docs/DESIGN-MULTIPATH.md`](docs/DESIGN-MULTIPATH.md); it does not
 describe the path this targets. See [`docs/DESIGN.md`](docs/DESIGN.md) for why
 that regime is not this one.
 
-`--quic-pool` is an explicit opt-in that keeps one bounded QUIC connection for
+`--quic-pool` is enabled by default and keeps one bounded QUIC connection for
 initial/control streams and lets multiple short flows share its congestion
 controller. On a capable peer, bulk promotion also lazily creates one
 separately authenticated secondary QUIC pool and attaches the lane with a
 capability-gated `OPEN_JOIN_FAST`; peers without that capability use the
-legacy independent join. These modes must
-be validated with the supplied single-flow and concurrent-flow harnesses
-before being enabled in a live Clash profile. The first pooled stream performs
+legacy independent join. These modes are covered by the supplied single-flow,
+concurrent-flow, and live-path harnesses. The first pooled stream performs
 the authenticated `HELLO`; subsequent streams on a capable peer use a
 connection-scoped fast open while retaining independent flow identities and
 US-side destination-policy checks. Capability-free peers automatically keep
@@ -290,7 +297,8 @@ correctness or TCP fallback.
 - Circumventing a hard aggregate capacity limit on the China-US path.
 - Automatically decrypting or classifying HTTPS URLs or payloads.
 - Claiming that multiple lanes are always fair or faster.
-- Replacing the existing tunnel before a measured rollback path exists.
+- Automatically replacing or reconfiguring unrelated Xray, sing-box, or Clash
+  services.
 
 ## Development
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,91 +2,103 @@
 
 ## Problem statement
 
-The measured China-to-US path has a large difference between one and several
-independent flows. Direct outer TCP transports show severe retransmission and
-tail behavior. QUIC-based TUIC and Hysteria 2 are substantially more robust,
-but ordinary Clash proxying still maps one application connection to one
-logical proxy flow.
-
-`queqiao` is a paired performance-enhancing proxy (PEP): the local agent
-terminates the application-side socket, and the US agent creates the
-destination-side socket. Bytes in between are carried as numbered frames over
-one or more authenticated lanes.
+The measured China-to-US path has high RTT, rapidly changing erasure, and
+severe tails for direct outer TCP transports. `queqiao` is a paired
+performance-enhancing proxy (PEP): the local agent terminates the
+application-side socket, and the fixed-egress agent creates the
+destination-side socket. Bytes in between are numbered and framed so transport
+recovery does not expose duplicate application bytes.
 
 ## Components
 
 ```text
-         local machine                         icourses-dev
-  +--------------------------+          +--------------------------+
-  | SOCKS5/TUN ingress       |          | authenticated listener   |
-  | flow classifier           |          | session manager          |
-  | PIAS scheduler            |  lanes   | reassembly / ordering    |
-  | lane manager              | <------> | destination dialer       |
-  | UDP/TCP transport probes |          | metrics / limits         |
-  +--------------------------+          +--------------------------+
+application -> Clash/mihomo TUN or system proxy
+                    |
+                    v
+              SOCKS5 TCP/UDP ingress
+              classifier / scheduler
+              pooled control connection ---- QUIC/UDP or TLS/TCP ----+-- egress agent
+              isolated bulk connection  ---- QUIC/UDP ---------------+       |
+                                                                              v
+                                                                         destination
 ```
 
-The first usable integration surface is a local SOCKS5 listener. TUN support
-comes after the flow/session semantics are stable. Clash Verge can route its
-final `MATCH` rule to the local SOCKS5 endpoint without knowing the custom
-wire protocol.
+Clash/mihomo owns transparent TUN capture and routes selected traffic to the
+local SOCKS5 endpoint. Queqiao installs no TUN device or host routes. Direct
+in-process TUN or VLESS ingress is outside the two-process architecture.
 
-## Data path
+## TCP data path
 
-1. Ingress accepts a TCP connection and assigns a random `flow_id` within an
-   authenticated `session_id`.
-2. The destination address is sent in a bounded `OPEN` frame.
-3. The US agent dials the destination and returns `OPEN_OK` or a typed error.
-4. Each direction is split into bounded frames with monotonically increasing
-   byte sequence numbers.
-5. The scheduler selects lanes according to class, lane health, and global
-   pacing. The receiver reorders frames before writing to the socket.
-6. `CLOSE`, `RESET`, and `WINDOW` frames provide lifecycle and backpressure.
+1. Ingress accepts a SOCKS5 TCP connection and assigns random session and flow
+   identifiers.
+2. The bounded destination address is authenticated and sent in `OPEN` or
+   negotiated `OPEN_FAST` framing.
+3. The egress agent applies destination policy, dials it, and reports success
+   or a typed error. By default the client pipelines this open; operators can
+   choose `--wait-for-open-ack` for precise early failure at the cost of a
+   round trip.
+4. Each direction is split into bounded DATA frames with monotonically
+   increasing byte sequence numbers.
+5. Bounded reassembly, cumulative ACKs, negotiated selective ACK ranges, and
+   duplicate suppression preserve application byte order across replacement.
+6. `CLOSE`, `RESET`, and completion tombstones provide bounded lifecycle and
+   final-state replay. Protocol version 2 removed the unused WINDOW/PING/PONG
+   frame types.
 
-The application TLS session remains end-to-end between the application and
-its destination. The optimizer sees byte counts, destination metadata, and
-timing, but does not need HTTPS MITM.
+The application TLS session remains end-to-end between the application and its
+destination. The PEP sees the SOCKS destination, byte counts, packet sizes, and
+timing, but does not decrypt application traffic.
 
-## Workload classes
+## Workload isolation
 
-`NEW` receives a small byte/time budget and one lane. `INTERACTIVE` is selected
-by bidirectionality, packet-size distribution, idle gaps, and a bounded
-sustained rate. `BULK` requires a larger byte count plus sustained one-way
-delivery. Transitions use hysteresis and a minimum dwell time.
+`NEW`, `INTERACTIVE`, and `BULK` classification is behavioral and uses byte
+count, direction, recent payload distribution, idle gaps, age, and hysteresis.
+It is a scheduling hint, not a security boundary.
 
-Byte count alone is deliberately insufficient: SSH and remote desktop flows
-can be long-lived, while Git can transition from interactive negotiation to a
-large packfile transfer.
+The QUIC pool is enabled by default. Short and interactive flows share one
+bounded control connection, amortizing authentication and keeping its
+congestion window free from avoidable bulk queueing. If classified bulk work
+and competing work would share that connection, the bulk flow is moved to one
+lazily created secondary connection. One flow has exactly one data connection
+at a time: secondary connections isolate workloads and replace failed paths;
+they never aggregate one flow's capacity. The deleted multipath experiment and
+its measurements are retained in
+[`DESIGN-MULTIPATH.md`](DESIGN-MULTIPATH.md).
 
-## Lane policy
+An optional aggregate token bucket and interactive reserve apply above all
+connections. Each QUIC connection retains its own selected congestion
+controller.
 
-New and interactive flows normally use one QUIC lane. Bulk flows start with
-two lanes and may grow to a configured maximum if marginal goodput improves
-without exceeding an interactive RTT budget. The scheduler uses a global
-aggregate token bucket in addition to per-lane QUIC congestion control; this
-prevents N independent congestion controllers from blindly taking the whole
-path.
+## UDP and transport fallback
 
-## Fallback
+SOCKS5 UDP ASSOCIATE preserves datagram boundaries. Where QUIC negotiates
+DATAGRAM support, packets use it; TLS/TCP and capability-free peers use the
+lane control stream. The receiver applies a bounded anti-replay window.
 
-Each endpoint has an authenticated UDP probe. A new session may race a UDP
-handshake and a TCP/TLS handshake. The first authenticated path wins. Health
-states are `healthy`, `degraded`, and `blocked`; lane creation and replacement
-respect the state. Seamless replacement of a failed lane requires session
-resume tokens and sequence-aware replay, which is a later milestone.
+Each remote endpoint has `healthy`, `degraded`, and `blocked` UDP health. New
+work in `auto` mode races QUIC against delayed TLS/TCP; repeated UDP failures
+enter a cooldown, and later probes allow QUIC to become preferred again.
 
-TCP fallback normally uses one lane. Multiple reliable outer TCP lanes are
-not the default because nested TCP head-of-line blocking can amplify loss.
+Failed TCP flows use bounded sequence-aware replay over an authenticated
+replacement without duplicating bytes. Failed UDP associations retain the
+local SOCKS endpoint and reclaim the same remote relay socket using a scoped,
+single-use, expiring resume token. Datagrams in flight at failure can be lost;
+UDP recovery is not presented as lossless.
 
-## Threat model and limits
+## Trust and resource boundaries
 
-The server is trusted with destination metadata and with forwarding encrypted
-application bytes. It must not be trusted with application plaintext. The
-protocol must authenticate every session and reject unauthenticated lane
-joins, oversized frames, flow-id reuse, replayed opens, and unbounded buffer
-growth.
+TLS 1.3 protects both outer transports. Timestamped HMAC handshakes and nonce
+tracking authenticate sessions and joins; connection-scoped capabilities gate
+fast opens, selective ACKs, control reservation, and UDP resume. The egress
+rejects private destinations unless explicitly configured otherwise.
 
-No scheduler can exceed a hard aggregate bottleneck. Multiple lanes are useful
-only when the path's policy or congestion behavior is materially per-flow, or
-when independent retransmission windows reduce loss interaction.
+Connections, sessions, flows, frame payloads, reassembly, replay, UDP relays,
+anti-replay windows, handshakes, idle periods, and total lifetimes are bounded.
+The loopback-only metrics endpoint reports flow, lane, controller, fallback,
+replacement, timeout, and replay state. The detailed review and residual risks
+are in [`SECURITY-REVIEW.md`](SECURITY-REVIEW.md).
 
+No scheduler can exceed a hard aggregate bottleneck. The transport is designed
+for one measured fixed-egress path and is not evidence of universal advantage;
+see [`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md) for release evidence and
+external qualifications.

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -4,12 +4,13 @@ This is the practical guide: how to build it, how to run the two ends, and how
 to point Clash Verge or any mihomo-based client at it.
 
 Read [the limits](#what-you-are-signing-up-for) before deploying this anywhere
-you care about. The project has not met the release gates in
-[`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md). The two tunnel-stall defects
-measured on 2026-08-16 are fixed and have deterministic regressions. A live
-UDP blackhole recovered over TCP in 9.51 seconds, and release packaging is now
-reproducible; broader intermittent-loss, soak, resource, and security gates
-remain open.
+you care about. The repository-actionable release gates in
+[`PRODUCTION-DESIGN.md`](PRODUCTION-DESIGN.md) now have implementation and
+evidence. The tunnel-stall defects have deterministic regressions; real UDP
+blackholes recovered over TCP; restored UDP was re-preferred; packaging,
+resource bounds, vulnerability scanning, and rollback are reproducible; and a
+mixed production soak passed. Broader path/middlebox diversity and independent
+review remain external qualifications.
 
 The deployment trust boundaries and resource ceilings are enumerated in
 [`SECURITY-REVIEW.md`](SECURITY-REVIEW.md). In particular, the local SOCKS and
@@ -270,13 +271,13 @@ serving the alternatives:
   regression coverage are in
   [`STALL-20260817.md`](STALL-20260817.md).
 
-Also unfinished, and relevant to a daily driver: interactive latency still
-moves under queqiao's own bulk load, although the corrected live A/B is now in
-the range of the measured QUIC alternatives. Clash's TUN-to-SOCKS hand-off is
-the supported transparent integration; direct TUN/VLESS ingress is not part of
-the current architecture. A real-path UDP blackhole recovered over TCP in
-9.51 seconds, but intermittent blocking, restart, and long-soak behaviour still
-need broader campaigns.
+Interactive latency still moves under queqiao's own bulk load, although the
+corrected live A/B is in the range of the measured QUIC alternatives. Clash's
+TUN-to-SOCKS hand-off is the supported transparent integration; direct
+TUN/VLESS ingress is not part of the current architecture. Intermittent UDP
+blocking, recovery, restart, and a bounded mixed production soak are recorded
+in [`RELEASE-HARDENING-20260817.md`](RELEASE-HARDENING-20260817.md). Longer
+operation across other NATs and middleboxes still needs field evidence.
 
 ## Troubleshooting
 

--- a/docs/PRODUCTION-DESIGN.md
+++ b/docs/PRODUCTION-DESIGN.md
@@ -8,13 +8,13 @@ Clash profile.
 
 ## What the measurements imply
 
-The prototype is functionally useful, but it is not yet a production
-transport. The latest five-block campaign is summarized in
+The fixed-egress transport is deployed experimentally, but it is not presented
+as a general-purpose VPN. An early five-block campaign is summarized in
 [`MEASUREMENTS-20260810.md`](MEASUREMENTS-20260810.md): adaptive reached a
 101.8 Mbps median for eight concurrent 10 MiB HTTP flows with 40/40 complete,
 while the stock control had 33/40 complete and Brutal had 39/40. The same
-campaign still found OpenAI timeouts and long tails, so goodput alone is not a
-release criterion.
+campaign found OpenAI timeouts and long tails that later regression work had
+to resolve, demonstrating why goodput alone is not a release criterion.
 
 The packet trace also found an effective path MTU problem. Starting QUIC at
 1200-byte packets avoids the 1441-byte probe packets that stalled the first
@@ -28,7 +28,7 @@ opening more CUBIC lanes is sufficient.
 ```text
 Clash Verge
     |
-local SOCKS5/TUN ingress -- classifier -- scheduler -- session controller
+local SOCKS5 ingress ------- classifier -- scheduler -- session controller
     |                         |                  |
     +-------------------------+------------------+-- encrypted lanes
                                                      |
@@ -43,21 +43,21 @@ HTTPS URLs or plaintext and does not perform MITM.
 
 ### Session and lane model
 
-One logical flow has a random `session_id` and `flow_id`. The first lane is a
-control/interactive lane. Additional lanes are independent authenticated
-QUIC connections, each carrying a reliable stream of bounded frames. Every
-DATA frame carries a byte sequence number. The receiver uses a bounded
-reassembly window and emits cumulative acknowledgements. Selective ACK ranges
-remain future protocol work for TCP flows; the current replay mechanism relies
-on duplicate-safe sequence reassembly. UDP associations do have a resume
+One logical flow has a random `session_id` and `flow_id`. Its data plane uses
+exactly one authenticated connection at a time; connections are replacement
+and workload-isolation boundaries, not stripes for aggregating one flow's
+capacity. Every DATA frame carries a byte sequence number. The receiver uses a
+bounded reassembly window and emits cumulative acknowledgements plus negotiated,
+bounded selective ACK ranges. Duplicate-safe sequence reassembly and replay
+make TCP-flow replacement safe. UDP associations use a separate relay-resume
 token, described under UDP preference and TCP fallback below.
 
-The implementation also has an explicit, opt-in QUIC stream pool. When
-`--quic-pool` is enabled, initial/control streams for concurrent flows share
-one bounded QUIC connection and one congestion controller, while bulk lane
-joins remain independent connections. This improves the short-flow handshake
-amortization characteristic of TUIC, but it is not the default: the measured
-path still needs a controller and queue policy that preserve bulk goodput.
+The QUIC stream pool is enabled by default. Initial/control streams for
+concurrent flows share one bounded QUIC connection and one congestion
+controller. When a classified bulk flow would otherwise share that connection
+with interactive work, it is moved to one lazily created, bounded secondary
+connection; the flow is never striped across both. This improves short-flow
+handshake amortization while isolating bulk queueing.
 The first pooled stream performs the PSK `HELLO`; later streams on a capable
 peer use one `OPEN_FAST` frame, saving one China-US request/response exchange.
 Authentication is scoped to the TLS/QUIC connection, and each fast stream
@@ -67,16 +67,10 @@ admission checks. Capability negotiation keeps the original 24-byte
 all learned authentication/capability state, and capability-free peers retain
 the per-stream legacy handshake.
 
-The scheduler must never wait for eight handshakes before acknowledging a
-short request. The unattended-safe default starts one lane and grows only
-after the classifier and a measured lane probe justify it; operators can
-explicitly pre-warm spare lanes after a path-specific campaign.
-Lane joins must be bounded-time and failure-tolerant; a failed join leaves
-the original flow usable. The adaptive manager opens at most one speculative
-join per scheduler tick and stops joining as soon as both FIN directions are
-observable. This is an important resource invariant: a session that is
-already completing must not turn a rejected join into an unbounded stream of
-zero-byte lanes.
+Lane joins are bounded-time and failure-tolerant; a failed isolation or
+replacement join leaves the original flow usable. An already completing
+session must not turn a rejected join into an unbounded stream of zero-byte
+lanes.
 
 The server’s stream-pool accept loop has a separate lifecycle invariant: the
 per-stream handshake deadline must never be applied while waiting for another
@@ -104,7 +98,7 @@ downloads remained 10/10 successful (median 1.18 s, p95 2.19 s). These are
 path-specific development measurements, not a universal claim about Brutal or
 QUIC.
 
-Before release, compare:
+The retained controller comparison set is:
 
 1. the opt-in independently implemented BBRv1-shaped controller with
    explicit loss and queue-delay limits;
@@ -129,21 +123,19 @@ available. It does not import Hysteria's `internal/` packages or fork
 cryptography. Both BBR modes are opt-in: the original queqiao mode is an
 independent implementation of the public BBR model, while `bbr-tuic` is a
 separate Go implementation aligned with TUIC's public behavior. Neither is a
-claim that apNet quic-go itself provides BBR. A per-lane controller alone is unsafe: eight controllers can
-overrun the path and starve SSH. The aggregate token bucket is now implemented
+claim that apNet quic-go itself provides BBR. A per-connection controller alone
+is unsafe: concurrent controllers can overrun the path and starve SSH. The
+aggregate token bucket is implemented
 above all lanes, with a reserved interactive share; an 8 MiB/s budget plus a
 512 KiB/s reserve preserved 10/10 Google requests during eight bulk downloads.
-It remains opt-in until queue-delay and retransmission guardrails are exposed
-as telemetry.
+It remains operator-configured because a safe rate budget is path-specific;
+queue-delay and retransmission state are exposed as telemetry.
 
-The endpoint exposes aggregate active-QUIC lane count, latest/worst smoothed
+The endpoint exposes aggregate active-QUIC connection count, latest/worst smoothed
 RTT, bytes sent/received, QUIC loss counters, and (for the optional controllers)
 bytes in flight, pacing rate, congestion window, minimum RTT, recovery state,
 and delivery-rate estimates through the loopback-only metrics listener. These
-signals are now available for validation, but they remain a release gate for
-automatic lane-growth decisions: telemetry must be retained across lane
-replacement and tied to statistically valid marginal-gain samples before a
-non-default policy is enabled.
+signals are available for validation and are retained across replacement.
 
 ## PIAS-inspired workload policy
 
@@ -155,7 +147,8 @@ Classification is intentionally behavioral, not semantic:
   long-lived traffic such as SSH and remote desktop; one lane plus reserved
   queueing capacity.
 - `BULK`: sustained one-way transfer after a byte/age budget, with hysteresis;
-  eligible for additional lanes and larger aggregate pacing budget.
+  eligible for isolation on its own connection and a larger aggregate pacing
+  budget.
 
 The byte threshold must not be tied to an absolute Mbps floor. Otherwise a
 large transfer on a throttled path never reaches `BULK`, exactly the failure
@@ -164,15 +157,10 @@ large one-way SSH output. Use recent payload-size distribution, direction,
 idle gaps, and an operator-tunable hysteresis window. Classification is a
 policy hint, not a security boundary, and it must be visible in metrics.
 
-The scheduler should grow one lane at a time. A candidate lane is retained
-only if its marginal goodput is positive and the interactive RTT budget is
-not exceeded. It should retire the worst lane after a sustained negative
-contribution, with a minimum dwell time to prevent oscillation. The current
-implementation now feeds the measured worst smoothed RTT into this guard and
-retires the least productive non-control lane when the budget is exceeded or a
-negative marginal-gain probe is observed;
-controller-specific bytes-in-flight and delivery-rate signals are still needed
-to make that decision fully loss-aware.
+The scheduler keeps one data connection per flow. Demand-driven isolation is
+attempted only when classified bulk work and competing work share the pooled
+control connection. The secondary pool is bounded to one connection and
+expires when idle; it is an isolation mechanism, not adaptive multipath.
 
 ## UDP preference and TCP fallback
 
@@ -221,9 +209,9 @@ since packets ride QUIC datagrams. The duplicate policy the earlier note asked
 for is the receiver's anti-replay window.
 
 The controlled UDP-blackhole test transferred a complete 100 MiB response over
-a TCP rescue lane. This is development evidence, not a guarantee under all
-loss patterns: selective ACK ranges, path-independent resume tokens,
-intermittent blocking, and a broader fault matrix remain release gates.
+a TCP rescue lane. Selective ACK ranges, scoped resume tokens, and deterministic
+intermittent-block coverage are implemented. This is still not a guarantee
+under every loss pattern or middlebox.
 
 A second real-path blackhole test covered SOCKS5 UDP ASSOCIATE itself. After a
 valid DNS reply on QUIC, the server dropped only inbound UDP/12443. The same
@@ -234,6 +222,13 @@ firewall rule was removed and verified absent afterward. This establishes the
 bounded fallback behavior but not lossless UDP resume; in-flight datagrams may
 still be lost during the transition.
 
+A later intermittent real-path run kept the same UDP association open while
+UDP was blocked. Queries 27--37 timed out and queries 38--50 received valid DNS
+replies through TCP while the rule was still present, for a measured
+27.7-second first-loss-to-recovered-reply bound. After rule removal, a fresh
+association returned to QUIC. The exact procedure and metrics are recorded in
+[`RELEASE-HARDENING-20260817.md`](RELEASE-HARDENING-20260817.md).
+
 ## Clash Verge integration
 
 The safe first integration is a local SOCKS5 node, for example
@@ -241,17 +236,18 @@ The safe first integration is a local SOCKS5 node, for example
 to that node. The live profile remains untouched and can be restored by
 removing that one node/rule.
 
-The current client accepts TCP CONNECT and bounded UDP ASSOCIATE. A production
-Clash integration still needs a TUN/VLESS ingress for transparent capture and
-full HTTP/3 behavior; a SOCKS profile can use UDP ASSOCIATE for applications
-that support SOCKS5 UDP. Packets now ride the connection's QUIC datagrams
+The current client accepts TCP CONNECT and bounded UDP ASSOCIATE. Clash/mihomo
+owns transparent TUN capture and hands selected TCP and UDP traffic to this
+SOCKS endpoint. Direct in-process TUN or VLESS ingress is deliberately outside
+the two-process architecture. Packets ride the connection's QUIC datagrams
 where QUIC negotiated them, with the control stream as the fallback for a
 TLS/TCP lane or a peer without datagram support, so the release gate for
 loss-sensitive UDP is met in shape: a lost packet is no longer retransmitted
 and no longer holds up the one behind it. Emulated at 15% loss and a 200 ms
 round trip the worst delivered packet takes 202 ms against the stream's 448 to
-658. What remains for that gate is the live path and a fault matrix, not the
-mechanism. No HTTPS MITM is needed for either mode.
+658. Real blocked/restored-path behavior is recorded in
+[`RELEASE-HARDENING-20260817.md`](RELEASE-HARDENING-20260817.md). No HTTPS MITM
+is needed.
 
 On a host where Clash TUN installs a default route through `198.18.0.1`, the
 outer dev endpoint must be explicitly excluded from that route or the client
@@ -298,15 +294,23 @@ trust-boundary review and residual risks are in `SECURITY-REVIEW.md`.
 
 ## Release gates
 
-Do not call the project production-ready until all of the following are
-measured on the real China-US path:
+The repository-actionable gates and their evidence are:
 
-1. complete single-flow downloads and uploads at 1/2/4/8 lanes, with at least
-   five randomized repetitions and confidence intervals;
-2. API/web fresh and reused latency, including p95/p99 and timeout rates;
-3. interactive RTT under a simultaneous bulk transfer;
-4. controlled loss, delay, reordering, and MTU tests;
-5. UDP blocked, intermittently blocked, and recovered cases;
-6. mid-session lane replacement without duplicate or missing bytes;
-7. resource-limit, fuzz, race, and interoperability tests; and
-8. a documented rollback that leaves the existing tunnel unchanged.
+1. real-path downloads, uploads, and alternating deployed-proxy comparisons in
+   [`MEASUREMENTS-20260816.md`](MEASUREMENTS-20260816.md);
+2. fresh/reused API latency and interactive behavior under bulk load in
+   [`STALL-20260817.md`](STALL-20260817.md);
+3. seeded loss, delay, reordering, queueing, and MTU campaigns described in
+   [`BENCHMARKING.md`](BENCHMARKING.md), with versioned report provenance;
+4. blocked, intermittently blocked, TCP-rescued, and restored-QUIC cases in
+   [`RELEASE-HARDENING-20260817.md`](RELEASE-HARDENING-20260817.md);
+5. replacement without duplicate TCP bytes or a changed UDP relay source,
+   covered by deterministic/race tests and the same live fault campaign;
+6. connection/session/frame/buffer limits, fuzz/race coverage, and a clean
+   pinned vulnerability scan in [`SECURITY-REVIEW.md`](SECURITY-REVIEW.md); and
+7. deterministic multi-platform archives, checksums, atomic installation, and
+   rollback in [`RELEASING.md`](RELEASING.md).
+
+Independent third-party review and operation across a wider variety of NATs,
+paths, and middleboxes remain external deployment qualifications. They are not
+claims that repository code or one China-US route can close by itself.

--- a/docs/RELEASE-HARDENING-20260817.md
+++ b/docs/RELEASE-HARDENING-20260817.md
@@ -1,0 +1,110 @@
+# Release-hardening and live fallback report — 2026-08-17
+
+This report closes the repository-actionable Stage 4/5 work after merge commit
+`1a0ba07`. Tests used an isolated server on `155.103.252.95:12541` and local
+SOCKS/metrics listeners on `127.0.0.1:12180/12190`; production remained on
+`12540` and `12080` until the isolated matrix passed.
+
+## Build and repository gates
+
+The release build embedded:
+
+```text
+queqiaod roadmap-1a0ba07 commit=1a0ba07 built=2026-08-17T14:17:05+08:00 go=go1.25.13
+```
+
+The following passed before deployment:
+
+- complete tests (`go test -timeout 50m ./...`);
+- complete race tests (`go test -race -timeout 110m ./...`), including the
+  548-second FEC package;
+- vet, formatting, workflow lint, and all six direct cross-builds;
+- deterministic release archives for Linux, macOS, and Windows on amd64 and
+  arm64, with every SHA-256 checksum verified;
+- `govulncheck v1.7.0 ./...` with no reachable vulnerability on Go 1.25.13;
+- a clean-tree fallback soak at commit `cd8f56a`: 20 normal and five race
+  repetitions, with all report checksums verified; and
+- every PR #6 CI job, including the six-target build matrix and package smoke.
+
+The first vulnerability scan on the former Go 1.25.7 toolchain found 11
+reachable standard-library advisories. Requiring Go 1.25.13 made the same scan
+clean and prevents release builds from silently using the vulnerable patch
+level.
+
+## Real intermittent UDP block and recovery
+
+An HTTPS request through the isolated pair first returned the fixed egress IP
+with one active QUIC lane and zero fallbacks. One persistent SOCKS5 UDP
+association then issued DNS A queries to `1.1.1.1`.
+
+After valid replies, the server installed exactly one temporary rule:
+
+```text
+INPUT -p udp --dport 12541 -m comment \
+  --comment queqiao-roadmap-1a0ba07 -j DROP
+```
+
+Queries 27 through 37 received no reply. Query 38 and every query through 50
+then received a valid DNS response while that rule was still present, proving
+that the unchanged association had moved to TLS/TCP. The observed gap from the
+first missing response to the first recovered response was approximately
+27.7 seconds, including eleven two-second application receive deadlines and
+the 0.5-second probe intervals. The complete run delivered 39/50 replies.
+
+Client metrics after recovery were:
+
+```text
+queqiao_lane_failures_total 1
+queqiao_lane_replacements_total 1
+queqiao_fallbacks_total 1
+queqiao_udp_association_reconnects_total 1
+queqiao_udp_association_rescue_failures_total 0
+```
+
+The rule was removed by its full specification and independently verified
+absent. A server-side packet capture then observed a fresh QUIC handshake on
+UDP/12541 from the physical China uplink. A new post-cooldown association
+completed 8/8 DNS queries at 194–197 ms without increasing the fallback
+counter. This covers blocked, rescued, restored, and re-preferred behavior on
+the real path. It does not make datagrams in flight lossless; the eleven missed
+queries are the expected UDP semantics during failure detection.
+
+## Atomic production upgrade and rollback
+
+Only after the isolated matrix passed were the two production binaries
+replaced atomically and their services restarted. The new server PID was
+`135146`; the new local PID was `31378`. A post-restart HTTPS request through
+the production SOCKS listener returned `155.103.252.95`.
+
+The exact pre-upgrade binaries remain at:
+
+```text
+/home/ubuntu/queqiao-node/bin/queqiaod-rollback-pre-1a0ba07
+/Users/boj/.queqiao/bin/queqiaod-rollback-pre-1a0ba07
+```
+
+Production remains on `155.103.252.95:12540` and `127.0.0.1:12080`. The
+isolated 12541/12180/12190 listeners were stopped, and both their absence and
+the absence of the temporary firewall rule were verified.
+
+## Mixed production soak
+
+The upgraded production pair ran ten minutes of simultaneous traffic:
+
+- one unchanged SOCKS5 UDP association sent 115 DNS queries five seconds
+  apart, with 114 valid replies and a successful final five-query tail; and
+- 40 independent HTTPS flows completed 40/40 and all reported the fixed
+  egress IP.
+
+Final local counters were 44 started, 44 completed, zero failed, zero active,
+zero lane failures/replacements/fallbacks/reconnects/rescue failures, zero
+completion/flow timeouts, and zero replay bytes. Local RSS moved from 19,888
+KiB to 24,352 KiB while its descriptor count returned to the baseline 17.
+Server RSS moved from 13,668 KiB to 17,892 KiB and its descriptor count returned
+from nine during the active association to the baseline eight. The production
+service had no warning-or-higher journal entries during the soak.
+
+This is a bounded release soak, not a substitute for ongoing operational
+monitoring or an independent security assessment. The remaining external
+qualifications are broader path/middlebox diversity and third-party review,
+not missing Stage 4/5 repository mechanisms.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,9 @@
 # Implementation roadmap
 
+Stages 0--2 and 4 are implemented, Stage 3 was retired after measurement, and
+the repository-actionable Stage 5 gates are complete. Wider NAT/middlebox
+operation and independent third-party review remain external qualifications.
+
 ## Stage 0 — repository and measurement foundation
 
 - Dedicated repository and reproducible Go toolchain.
@@ -82,8 +86,9 @@ the same SOCKS5 UDP association over a fresh authenticated TCP lane in 9.51 s,
 preserving its local endpoint and remote relay source address. Deterministic
 tests cover TCP stream replay without duplicate bytes, relay-source
 preservation, single-use resume tokens, and repeated rescue under the race
-detector. Intermittent blocking and long-soak coverage remain Stage 5 release
-hardening rather than an unimplemented fallback mechanism.
+detector. A later real-path intermittent run measured a 27.7-second
+first-loss-to-recovered-reply bound, then proved that fresh post-cooldown
+associations returned to QUIC.
 
 ## Stage 5 — integration and release hardening
 
@@ -93,8 +98,8 @@ hardening rather than an unimplemented fallback mechanism.
   outside the current two-process architecture.
 - ~~Native QUIC DATAGRAM mode for UDP, retaining stream/TCP fallback.~~ Done:
   chosen by QUIC's own capability exchange rather than configured, with the
-  control stream retained for lanes that have no datagrams. Measured emulated,
-  not live.
+  control stream retained for lanes that have no datagrams. Measured under
+  seeded impairment and exercised on the live blocked/restored QUIC path.
 - ~~Cross-platform packaging.~~ Done: deterministic Linux, macOS, and Windows
   archives for amd64 and arm64, embedded provenance, SHA-256 checksums, and a
   tag-driven release workflow.
@@ -104,7 +109,8 @@ hardening rather than an unimplemented fallback mechanism.
   documented trust boundaries and residual risk, bounded unauthenticated QUIC
   connections, sessions, frames, flow buffers, replay state, relay sockets,
   lanes, and lifetimes, plus pinned vulnerability scanning and an enforced
-  patched Go toolchain. Independent audit and live soak remain release gates.
+  patched Go toolchain. Independent third-party audit remains external release
+  qualification rather than repository implementation work.
 - ~~Reproducible benchmark reports.~~ Done: versioned JSON records include the
   exact invocation, seeded path, VCS state, toolchain, module graph, latency,
   and contention results; matrix bundles add the source patch and checksums.
@@ -112,6 +118,11 @@ hardening rather than an unimplemented fallback mechanism.
   associations fall back to TCP without changing their relay source, UDP is
   restored on the same endpoint, and post-cooldown probes return to QUIC. The
   normal/race soak runs weekly with checksummed provenance.
-- Real-path intermittent firewall/NAT and long-duration soak campaigns.
+- ~~Real-path intermittent firewall and bounded production soak.~~ Done: an
+  unchanged UDP association recovered valid replies over TCP while UDP stayed
+  blocked, a fresh association returned to QUIC after rule removal, and the
+  upgraded production pair completed 114/115 persistent UDP probes plus 40/40
+  HTTPS flows over ten minutes with stable descriptors and no failed flows.
+  NAT/middlebox diversity remains an external deployment qualification.
 - ~~Documented rollback instructions.~~ Done: checksum verification, atomic
   binary installation, retained prior builds, and explicit service rollback.

--- a/docs/SECURITY-REVIEW.md
+++ b/docs/SECURITY-REVIEW.md
@@ -67,8 +67,9 @@ local command before compiling release binaries.
   default, but enabling `--allow-private-destinations` intentionally removes
   that boundary and must be confined to a benchmark environment.
 - This is a manual code/configuration review, not an independent cryptographic
-  assessment. Broader interoperability, long-soak, intermittent-blocking, and
-  live fault campaigns remain release gates.
+  assessment. The real intermittent-block and bounded mixed soak are recorded
+  in `RELEASE-HARDENING-20260817.md`; broader path/middlebox diversity and
+  third-party review remain external qualifications.
 
 ## Release verification
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -82,25 +82,23 @@ QUEQIAO_TRIALS=5 QUEQIAO_FLOWS='1 2 4 8' \
 
 The script intentionally measures concurrent independent application flows.
 It does not claim that eight application connections are equivalent to one
-logical striped flow; the latter is covered by the PEP integration tests and
-the real-path campaign reports. Run the client with a physical source binding
-when Clash TUN/fake DNS would otherwise capture the outer endpoint, and keep
-the existing tunnel as the rollback path.
+logical striped flow; single-flow striping was measured and then deleted. Run
+the client with a physical source binding when Clash TUN/fake DNS would
+otherwise capture the outer endpoint, and keep the previous binary as the
+rollback path.
 
 `bench_single_flow.sh` measures exactly one HTTP application connection per
-trial. Run it once for each separately configured client lane topology, and
-keep the label in the output so the rows cannot be mistaken for independent
-application flows:
+trial. Run it once for each separately configured transport/controller, and
+keep the label in the output so configurations cannot be mixed:
 
 ```sh
-QUEQIAO_SOCKS5=127.0.0.1:12080 QUEQIAO_LABEL=lanes-1 \
+QUEQIAO_SOCKS5=127.0.0.1:12080 QUEQIAO_LABEL=erasure-default \
   QUEQIAO_TRIALS=5 ./scripts/bench_single_flow.sh --output /tmp/one.tsv
 ```
 
 There is no lane count to set: a flow's data goes over one connection. See
-`docs/DESIGN.md` for why striping was deleted. `--quic-pool` remains an
-explicit opt-in for a persistent multiplexed QUIC control connection and
-should be enabled only after path-specific latency/throughput validation.
+`docs/DESIGN.md` for why striping was deleted. `--quic-pool` is enabled by
+default and provides the bounded multiplexed QUIC control connection.
 
 ## Dedicated upload sink
 
@@ -135,5 +133,16 @@ checksummed provenance bundle:
 ```
 
 This is the deterministic release soak and runs weekly at a smaller count. It
-does not replace intermittent firewall and NAT tests on the real China-US
-path.
+does not replace broader live NAT and middlebox campaigns.
+
+`udp_association_check.py` is the live-path companion. It sends DNS queries
+through one unchanged SOCKS5 UDP association, records every loss and latency as
+TSV, and can require both an overall success count and a successful tail. The
+tail condition matters in a blackhole test: successful queries before the
+fault must not hide a failure to recover afterward.
+
+```sh
+./scripts/udp_association_check.py --socks 127.0.0.1:12080 \
+  --count 50 --interval 0.5 --timeout 2 --min-success 10 \
+  --require-final-successes 5 --output /tmp/udp-rescue.tsv
+```

--- a/scripts/test_udp_association_check.py
+++ b/scripts/test_udp_association_check.py
@@ -1,0 +1,52 @@
+import argparse
+import unittest
+
+from scripts import udp_association_check as check
+
+
+class EndpointTests(unittest.TestCase):
+    def test_parse_ipv4_and_ipv6_endpoints(self):
+        self.assertEqual(check.parse_endpoint("127.0.0.1:1080"), ("127.0.0.1", 1080))
+        self.assertEqual(check.parse_endpoint("[2001:db8::1]:53"), ("2001:db8::1", 53))
+
+    def test_parse_endpoint_rejects_bad_ports(self):
+        for endpoint in ("missing-port", "host:nope", "host:0", "host:65536"):
+            with self.subTest(endpoint=endpoint):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    check.parse_endpoint(endpoint)
+
+
+class SocksAddressTests(unittest.TestCase):
+    def test_round_trip_supported_address_types(self):
+        for host in ("192.0.2.5", "2001:db8::5", "example.com"):
+            with self.subTest(host=host):
+                encoded = check.encode_address(host, 5353)
+                decoded_host, decoded_port, consumed = check.decode_address(encoded)
+                self.assertEqual(decoded_host, host)
+                self.assertEqual(decoded_port, 5353)
+                self.assertEqual(consumed, len(encoded))
+
+    def test_decode_rejects_truncated_and_empty_addresses(self):
+        invalid = (b"", b"\x01\x7f", b"\x04" + b"\0" * 10, b"\x03", b"\x03\x00\x00\x35")
+        for encoded in invalid:
+            with self.subTest(encoded=encoded):
+                with self.assertRaises(ValueError):
+                    check.decode_address(encoded)
+
+
+class DNSNameTests(unittest.TestCase):
+    def test_encode_dns_name(self):
+        self.assertEqual(
+            check.encode_dns_name("www.example.com."),
+            b"\x03www\x07example\x03com\x00",
+        )
+
+    def test_encode_dns_name_rejects_empty_labels(self):
+        for name in ("", ".", "www..example.com"):
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    check.encode_dns_name(name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/udp_association_check.py
+++ b/scripts/udp_association_check.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Probe DNS repeatedly through one persistent SOCKS5 UDP association."""
+
+import argparse
+import datetime
+import ipaddress
+import os
+import secrets
+import socket
+import struct
+import sys
+import time
+
+
+def parse_endpoint(value):
+    if value.startswith("["):
+        host, separator, port = value[1:].partition("]:")
+    else:
+        host, separator, port = value.rpartition(":")
+    if not separator or not host:
+        raise argparse.ArgumentTypeError("endpoint must be HOST:PORT")
+    try:
+        number = int(port)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("endpoint port must be numeric") from error
+    if not 1 <= number <= 65535:
+        raise argparse.ArgumentTypeError("endpoint port must be between 1 and 65535")
+    return host, number
+
+
+def receive_exact(connection, length):
+    result = bytearray()
+    while len(result) < length:
+        part = connection.recv(length - len(result))
+        if not part:
+            raise EOFError("SOCKS control connection closed")
+        result.extend(part)
+    return bytes(result)
+
+
+def encode_address(host, port):
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        encoded = host.encode("idna")
+        if not encoded or len(encoded) > 255:
+            raise ValueError("destination hostname must contain 1 to 255 encoded bytes")
+        return b"\x03" + bytes([len(encoded)]) + encoded + struct.pack("!H", port)
+    if address.version == 4:
+        return b"\x01" + address.packed + struct.pack("!H", port)
+    return b"\x04" + address.packed + struct.pack("!H", port)
+
+
+def decode_address(data, offset=0):
+    if len(data) <= offset:
+        raise ValueError("truncated SOCKS address")
+    kind = data[offset]
+    offset += 1
+    if kind == 1:
+        end = offset + 4
+        if len(data) < end + 2:
+            raise ValueError("truncated SOCKS address")
+        host = socket.inet_ntop(socket.AF_INET, data[offset:end])
+    elif kind == 4:
+        end = offset + 16
+        if len(data) < end + 2:
+            raise ValueError("truncated SOCKS address")
+        host = socket.inet_ntop(socket.AF_INET6, data[offset:end])
+    elif kind == 3:
+        if len(data) <= offset:
+            raise ValueError("truncated SOCKS hostname length")
+        length = data[offset]
+        if length == 0:
+            raise ValueError("empty SOCKS hostname")
+        offset += 1
+        end = offset + length
+        if len(data) < end + 2:
+            raise ValueError("truncated SOCKS address")
+        try:
+            host = data[offset:end].decode("idna")
+        except UnicodeError as error:
+            raise ValueError("invalid SOCKS hostname") from error
+    else:
+        raise ValueError(f"unsupported SOCKS address type {kind}")
+    return host, struct.unpack("!H", data[end : end + 2])[0], end + 2
+
+
+def encode_dns_name(name):
+    labels = name.rstrip(".").split(".")
+    if not labels or any(not label for label in labels):
+        raise ValueError("DNS name has an empty label")
+    encoded = bytearray()
+    for label in labels:
+        value = label.encode("idna")
+        if len(value) > 63:
+            raise ValueError("DNS label exceeds 63 encoded bytes")
+        encoded.append(len(value))
+        encoded.extend(value)
+    encoded.append(0)
+    if len(encoded) > 255:
+        raise ValueError("encoded DNS name exceeds 255 bytes")
+    return bytes(encoded)
+
+
+def open_association(endpoint, timeout):
+    control = socket.create_connection(endpoint, timeout)
+    control.settimeout(timeout)
+    control.sendall(b"\x05\x01\x00")
+    if receive_exact(control, 2) != b"\x05\x00":
+        control.close()
+        raise RuntimeError("SOCKS server refused no-authentication mode")
+    control.sendall(b"\x05\x03\x00\x01\x00\x00\x00\x00\x00\x00")
+    header = receive_exact(control, 4)
+    if header[:2] != b"\x05\x00" or header[2] != 0:
+        control.close()
+        raise RuntimeError(f"SOCKS UDP ASSOCIATE failed with reply {header[1]}")
+    kind = header[3]
+    if kind == 1:
+        rest = receive_exact(control, 6)
+    elif kind == 4:
+        rest = receive_exact(control, 18)
+    elif kind == 3:
+        length = receive_exact(control, 1)
+        rest = length + receive_exact(control, length[0] + 2)
+    else:
+        control.close()
+        raise RuntimeError(f"SOCKS server returned address type {kind}")
+    host, port, _ = decode_address(bytes([kind]) + rest)
+    if host in ("0.0.0.0", "::"):
+        host = endpoint[0]
+    udp = None
+    try:
+        addresses = socket.getaddrinfo(host, port, type=socket.SOCK_DGRAM)
+        if not addresses:
+            raise RuntimeError("SOCKS server returned an unresolvable UDP relay")
+        family, socktype, protocol, _, address = addresses[0]
+        udp = socket.socket(family, socktype, protocol)
+        udp.connect(address)
+    except Exception:
+        if udp is not None:
+            udp.close()
+        control.close()
+        raise
+    return control, udp, (host, port)
+
+
+def utc_now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="milliseconds")
+
+
+def main(arguments=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socks", type=parse_endpoint, default=("127.0.0.1", 1080))
+    parser.add_argument("--destination", type=parse_endpoint, default=("1.1.1.1", 53))
+    parser.add_argument("--name", default="cloudflare.com", help="DNS A name to query")
+    parser.add_argument("--count", type=int, default=10)
+    parser.add_argument("--interval", type=float, default=1.0, help="seconds between completed attempts")
+    parser.add_argument("--timeout", type=float, default=3.0, help="seconds per DNS reply")
+    parser.add_argument("--min-success", type=int, help="minimum successful replies (default: all)")
+    parser.add_argument("--require-final-successes", type=int, default=1)
+    parser.add_argument("--output", default="-", help="new TSV file, or - for stdout")
+    options = parser.parse_args(arguments)
+    if options.count <= 0 or options.interval < 0 or options.timeout <= 0:
+        parser.error("count and timeout must be positive and interval must be non-negative")
+    minimum = options.count if options.min_success is None else options.min_success
+    if not 0 <= minimum <= options.count:
+        parser.error("min-success must be between zero and count")
+    if not 0 <= options.require_final_successes <= options.count:
+        parser.error("require-final-successes must be between zero and count")
+    if options.output != "-" and os.path.exists(options.output):
+        parser.error(f"output already exists: {options.output}")
+
+    destination = encode_address(*options.destination)
+    question = encode_dns_name(options.name) + struct.pack("!HH", 1, 1)
+    control, udp, relay = open_association(options.socks, options.timeout)
+    try:
+        output = sys.stdout if options.output == "-" else open(
+            options.output, "x", encoding="utf-8", buffering=1
+        )
+    except Exception:
+        udp.close()
+        control.close()
+        raise
+    successes = 0
+    outcomes = []
+    try:
+        print(f"# socks={options.socks[0]}:{options.socks[1]} relay={relay[0]}:{relay[1]} "
+              f"destination={options.destination[0]}:{options.destination[1]} name={options.name}", file=output)
+        print("query\tstarted_utc\tstatus\tseconds\tbytes\terror", file=output)
+        for query in range(1, options.count + 1):
+            transaction = secrets.randbelow(65536)
+            dns = struct.pack("!HHHHHH", transaction, 0x0100, 1, 0, 0, 0) + question
+            packet = b"\x00\x00\x00" + destination + dns
+            started_at = utc_now()
+            started = time.monotonic()
+            status, size, message = "lost", 0, ""
+            try:
+                udp.send(packet)
+                deadline = started + options.timeout
+                while True:
+                    udp.settimeout(max(0.001, deadline - time.monotonic()))
+                    reply = udp.recv(65535)
+                    if len(reply) < 4 or reply[:3] != b"\x00\x00\x00":
+                        raise ValueError("invalid SOCKS UDP header")
+                    _, _, offset = decode_address(reply, 3)
+                    dns_reply = reply[offset:]
+                    if len(dns_reply) < 12:
+                        raise ValueError("truncated DNS reply")
+                    reply_transaction = struct.unpack("!H", dns_reply[:2])[0]
+                    if reply_transaction != transaction:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError("timed out after stale DNS replies")
+                        continue
+                    if not dns_reply[2] & 0x80:
+                        raise ValueError("DNS reply flag is not set")
+                    status, size = "ok", len(dns_reply)
+                    successes += 1
+                    break
+            except (OSError, ValueError) as error:
+                message = str(error).replace("\t", " ").replace("\n", " ")
+            elapsed = time.monotonic() - started
+            outcomes.append(status)
+            print(f"{query}\t{started_at}\t{status}\t{elapsed:.3f}\t{size}\t{message}", file=output, flush=True)
+            if query != options.count:
+                time.sleep(options.interval)
+        final = options.require_final_successes
+        final_successes = final if final == 0 else sum(result == "ok" for result in outcomes[-final:])
+        final_ok = final_successes == final
+        print(f"# successes={successes}/{options.count} final_successes={final_successes}/{final}", file=output)
+        return 0 if successes >= minimum and final_ok else 1
+    finally:
+        udp.close()
+        control.close()
+        if output is not sys.stdout:
+            output.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable persistent SOCKS5 UDP recovery probe with CI unit coverage
- record the real intermittent-block, QUIC restoration, production upgrade, rollback, and mixed-soak evidence
- reconcile the roadmap, architecture, deployment, security, and production docs with the shipped one-data-connection design and completed repository gates

## Verification
- python3 -m unittest scripts/test_udp_association_check.py
- live production probe: 3/3 DNS replies through one UDP association
- go test -short -timeout 20m ./...
- go vet ./...
- actionlint .github/workflows/*.yml
- git diff --check

The full and race suites, six release cross-builds/packages, fallback soak, and govulncheck passed for merged release commit 1a0ba07 as recorded in docs/RELEASE-HARDENING-20260817.md.