### PR TITLE
Fix deep workflow regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           - {os: windows, arch: amd64}
           - {os: windows, arch: arm64}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go build ./...
@@ -46,8 +46,8 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go vet ./...
@@ -65,8 +65,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go test -short -timeout 20m ./...
@@ -79,8 +79,8 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: package smoke test

--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go test -timeout 50m ./...
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go test -race -timeout 110m ./...
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
@@ -54,12 +54,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: ./scripts/fallback_soak.sh --runs 20 --race-runs 5 --output-dir fallback-soak
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: fallback-soak-${{ github.run_id }}
@@ -74,8 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: smoke every fuzz target
@@ -107,8 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
       - name: Resolve immutable release inputs
@@ -60,7 +60,7 @@ jobs:
             --output dist
           cd dist
           sha256sum -c SHA256SUMS
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: queqiaod-${{ steps.release.outputs.version }}
           path: dist/

--- a/internal/pathsim/capacity_test.go
+++ b/internal/pathsim/capacity_test.go
@@ -70,8 +70,17 @@ func TestForwardingCapacity(t *testing.T) {
 // limiter's queue is sized from the product and is exactly where a fault would
 // hide.
 func TestRateLimiterDeliversItsConfiguredRate(t *testing.T) {
+	rates := []float64{50, 200, 400}
+	if raceDetectorEnabled {
+		// Race instrumentation capped the two-core hosted runner near 180
+		// Mbit/s, so asking it to generate 200 or 400 Mbit/s measures CPU
+		// instrumentation rather than the rate limiter. Keep one attainable
+		// cell at every RTT for race coverage; the normal deep job retains the
+		// complete calibration matrix.
+		rates = []float64{50}
+	}
 	for _, rtt := range []time.Duration{50, 200, 400} {
-		for _, mbits := range []float64{50, 200, 400} {
+		for _, mbits := range rates {
 			rtt, mbits := rtt*time.Millisecond, mbits
 			name := fmt.Sprintf("rtt%v_rate%.0f", rtt, mbits)
 			t.Run(name, func(t *testing.T) {

--- a/internal/pathsim/race_disabled_test.go
+++ b/internal/pathsim/race_disabled_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package pathsim
+
+const raceDetectorEnabled = false

--- a/internal/pathsim/race_enabled_test.go
+++ b/internal/pathsim/race_enabled_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package pathsim
+
+const raceDetectorEnabled = true

--- a/internal/pep/udp.go
+++ b/internal/pep/udp.go
@@ -888,6 +888,14 @@ func (s *Server) handleUDPAssociation(ctx context.Context, conn streamConn, fc *
 			counters.down.Add(uint64(len(packet.payload)))
 			resetIdle()
 		case err := <-frameErr:
+			if assocCtx.Err() != nil {
+				// Service shutdown closes the transport and cancels this context
+				// concurrently. The reader's EOF can win the select even though
+				// the association did not fail; keep shutdown from incrementing
+				// the failure counter nondeterministically.
+				retain = true
+				goto done
+			}
 			endErr = err
 			failed = true
 			// Same: the lane's stream ended under an association that had
@@ -900,6 +908,13 @@ func (s *Server) handleUDPAssociation(ctx context.Context, conn streamConn, fc *
 			s.cfg.Logger.Debug("UDP relay frame reader ended", "error", err)
 			goto done
 		case err := <-packetErr:
+			if assocCtx.Err() != nil {
+				// The relay read deadline observes the same cancellation. As with
+				// the frame reader, selecting its error first is still a clean
+				// service shutdown.
+				retain = true
+				goto done
+			}
 			endErr = err
 			failed = true
 			s.cfg.Logger.Debug("UDP relay packet reader ended", "error", err)


### PR DESCRIPTION
## Summary
- keep the full 50/200/400 Mbit/s rate-limiter calibration in normal runs while limiting race-instrumented calibration to the attainable 50 Mbit/s cells
- make UDP service cancellation win over concurrent lane/relay EOF classification, so clean shutdown cannot increment the failed-flow counter
- update checkout, setup-go, and upload-artifact to their current Node 24 / ESM major releases

## Failure evidence
- scheduled deep run 31998160396 measured race/runner overhead rather than the limiter at 200/400 Mbit/s
- first manual run 32004224111 exposed a select race where clean service cancellation and UDP lane EOF were both ready and EOF was counted as failure

## Local verification
- normal capacity matrix: pass (55.0s)
- race capacity matrix: pass (28.2s)
- UDP TCP/QUIC shutdown: 100 normal and 30 race repetitions
- go test -short -timeout 20m ./...
- go vet ./...
- Python helper unit tests, actionlint, and diff check

A fresh complete deep run is required before merge.