### PR TITLE
fix: apply aggregate pacing to data frames

### DIFF
--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -1501,6 +1501,12 @@ func (f *multipathFlow) enqueueFrameWritten(ctx context.Context, lane *mpLane, f
 	if lane == nil || lane.closed.Load() {
 		return errors.New("lane is closed")
 	}
+	if f.budget != nil {
+		interactive := !bulk
+		if err := f.budget.Wait(ctx, len(frame.Payload), interactive); err != nil {
+			return fmt.Errorf("aggregate pacing: %w", err)
+		}
+	}
 	queue := lane.writeQ
 	if !bulk && lane.writeInteractiveQ != nil {
 		queue = lane.writeInteractiveQ
@@ -1545,12 +1551,6 @@ func (f *multipathFlow) enqueueFrameWritten(ctx context.Context, lane *mpLane, f
 }
 
 func (f *multipathFlow) enqueueOnHealthyLane(ctx context.Context, frame protocol.Frame, bulk bool) error {
-	if f.budget != nil {
-		interactive := !bulk
-		if err := f.budget.Wait(ctx, len(frame.Payload), interactive); err != nil {
-			return fmt.Errorf("aggregate pacing: %w", err)
-		}
-	}
 	for {
 		// One lane carries this plane: the isolated one for data, lane zero for
 		// control. This used to try each of several without blocking before

--- a/internal/pep/mpflow_writer_test.go
+++ b/internal/pep/mpflow_writer_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bojieli/queqiao/internal/limiter"
 	"github.com/bojieli/queqiao/internal/metrics"
 	"github.com/bojieli/queqiao/internal/protocol"
 )
@@ -575,6 +576,31 @@ func TestLaneWriterPrioritizesInteractiveFrames(t *testing.T) {
 	case <-lane.writeDone:
 	case <-time.After(time.Second):
 		t.Fatal("lane writer did not stop")
+	}
+}
+
+func TestSchedulerDataFramesUseAggregateBudget(t *testing.T) {
+	flow := &multipathFlow{
+		ctx:     context.Background(),
+		done:    make(chan struct{}),
+		laneErr: make(chan laneFailure, 1),
+		budget: limiter.New(limiter.Config{
+			TotalBytesPerSec: 1,
+			Burst:            time.Millisecond,
+		}),
+	}
+	lane := &mpLane{
+		writeQ:    make(chan laneFrame, 1),
+		writeDone: make(chan struct{}),
+	}
+	frame := protocol.Frame{
+		Header:  protocol.Header{Version: protocol.Version, Type: protocol.TypeData, Class: protocol.ClassBulk},
+		Payload: make([]byte, 64*1024+1),
+	}
+
+	err := flow.enqueueFrameWritten(context.Background(), lane, frame, true, nil)
+	if !errors.Is(err, limiter.ErrInvalidRequest) {
+		t.Fatalf("oversized data frame error = %v, want aggregate pacing rejection", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- apply the endpoint aggregate budget at the frame enqueue path used by scheduler DATA frames
- preserve bulk versus interactive budget admission
- add a regression test for scheduler data bypassing aggregate pacing

## Problem

The scheduler sends DATA frames through `sendChunk` and `enqueueFrameWritten`, while aggregate budget admission currently happens only in `enqueueOnHealthyLane`. As a result, the active scheduler data path can bypass both `AggregateBytesPerSec` and `InteractiveReserveBytesPerSec`.

## Solution

Move the existing budget admission into `enqueueFrameWritten`, the common enqueue path used by scheduler DATA frames. The lane-selection path continues to use that enqueue function when it needs to wait for capacity, while zero-payload control and replayed close frames remain unaffected.

This does not change the wire protocol.

## Testing

- `go test -short -timeout 20m ./...`
- `go vet ./...`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `test -z "$(gofmt -l .)"`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 -checks=all,-U1000 ./...`
- `go test -race -count=1 -timeout 30m ./internal/pep ./internal/limiter`
