### PR TITLE
feat: support multiple client providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ Clash/mihomo at that SOCKS5 endpoint. The [deployment guide](docs/DEPLOYING.md)
 covers service installation, firewall and socket tuning, multiple users,
 source-interface selection, verification, upgrades, and rollback.
 
+To connect one desktop client process to several independent providers, give
+each profile its own loopback SOCKS5 listener in a version 1 manifest:
+
+```json
+{
+  "version": 1,
+  "providers": [
+    {"name": "hong-kong", "profile": "hk.json", "listen": "127.0.0.1:1081"},
+    {"name": "us-west", "profile": "us.json", "listen": "127.0.0.1:1082"}
+  ]
+}
+```
+
+```sh
+./queqiaod client --providers ~/.config/queqiao/providers.json
+```
+
+Relative profile paths are resolved from the manifest directory. Provider
+names, profile files, and listeners must be unique. Clash/mihomo can route and
+fail over new flows between the separate SOCKS5 endpoints; existing flows stay
+with the provider through which they started.
+
 ## Who is it for?
 
 Queqiao is designed for a known difficult link between a client and a trusted

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ workload; see the full [comparison and methodology](docs/COMPARISON.md).
 - One-time invitations, provider-pinned identity, per-device mutual TLS,
   renewal, revocation, and per-user session limits.
 - A starter [Clash/mihomo profile](deploy/clash-queqiao.yaml).
+- One client process serving several providers, each on its own loopback SOCKS5
+  listener, for Clash/mihomo routing and failover.
 - Bounded JSON logs, metrics, a local visualizer, deterministic benchmarks,
   release packaging, SBOMs, and rollback procedures.
 

--- a/README.md
+++ b/README.md
@@ -171,27 +171,8 @@ Clash/mihomo at that SOCKS5 endpoint. The [deployment guide](docs/DEPLOYING.md)
 covers service installation, firewall and socket tuning, multiple users,
 source-interface selection, verification, upgrades, and rollback.
 
-To connect one desktop client process to several independent providers, give
-each profile its own loopback SOCKS5 listener in a version 1 manifest:
-
-```json
-{
-  "version": 1,
-  "providers": [
-    {"name": "hong-kong", "profile": "hk.json", "listen": "127.0.0.1:1081"},
-    {"name": "us-west", "profile": "us.json", "listen": "127.0.0.1:1082"}
-  ]
-}
-```
-
-```sh
-./queqiaod client --providers ~/.config/queqiao/providers.json
-```
-
-Relative profile paths are resolved from the manifest directory. Provider
-names, profile files, and listeners must be unique. Clash/mihomo can route and
-fail over new flows between the separate SOCKS5 endpoints; existing flows stay
-with the provider through which they started.
+To use several providers from one desktop client process, follow the
+[multi-provider deployment guide](docs/DEPLOYING.md#connect-to-multiple-providers).
 
 ## Who is it for?
 

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -557,6 +557,7 @@ func validateRuntime(opts runtimeOptions, client bool) error {
 func runClient(args []string) (returnErr error) {
 	fs := newFlagSet("client")
 	profilePath := fs.String("profile", "", "imported client profile")
+	providersPath := fs.String("providers", "", "multi-provider manifest")
 	noAutoRenew := fs.Bool("no-auto-renew", false, "disable certificate renewal before expiry")
 	var opts runtimeOptions
 	bindRuntimeFlags(fs, &opts, true)
@@ -569,6 +570,21 @@ func runClient(args []string) (returnErr error) {
 	if err := requireNoArguments(fs); err != nil {
 		return err
 	}
+	if *profilePath != "" && *providersPath != "" {
+		return errors.New("--profile and --providers are mutually exclusive")
+	}
+	if *profilePath == "" && *providersPath == "" {
+		return errors.New("--profile is required; import an invitation first with `queqiaod enroll INVITATION`")
+	}
+	listenSet := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "listen" {
+			listenSet = true
+		}
+	})
+	if *providersPath != "" && listenSet {
+		return errors.New("--listen cannot be used with --providers; set each listener in the manifest")
+	}
 	if err := validateRuntime(opts, true); err != nil {
 		return err
 	}
@@ -577,10 +593,10 @@ func runClient(args []string) (returnErr error) {
 		return err
 	}
 	defer finishRuntimeLog(logger, logSink, "client", &returnErr)
-	logRuntimeConfiguration(logger, opts, true)
-	if *profilePath == "" {
-		return errors.New("--profile is required; import an invitation first with `queqiaod enroll INVITATION`")
+	if *providersPath != "" {
+		return runProviderClients(*providersPath, *noAutoRenew, opts, logger)
 	}
+	logRuntimeConfiguration(logger, opts, true)
 	profile, err := identity.LoadClientProfile(*profilePath)
 	if err != nil {
 		return fmt.Errorf("load client profile %q: %w", *profilePath, err)
@@ -588,40 +604,12 @@ func runClient(args []string) (returnErr error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if !*noAutoRenew {
-		needs, err := profile.NeedsRenewal(time.Now(), 7*24*time.Hour)
+		profile, err = renewClientProfile(ctx, *profilePath, profile, opts, logger)
 		if err != nil {
 			return err
 		}
-		if needs {
-			renewed, renewErr := identity.RenewProfileWithOptions(ctx, profile, identity.DialOptions{Timeout: opts.handshakeTimeout, LocalAddress: opts.localAddress})
-			if renewErr != nil {
-				logger.Warn("automatic certificate renewal failed; continuing with current valid identity", "error", renewErr)
-			} else if err := renewed.Save(*profilePath); err != nil {
-				return fmt.Errorf("save renewed profile: %w", err)
-			} else {
-				profile = renewed
-				logger.Info("device identity renewed")
-			}
-		}
 	}
-	credentials, err := profile.Credentials()
-	if err != nil {
-		return err
-	}
-	client, err := pep.NewClient(pep.ClientConfig{
-		ListenAddr: opts.listen, RemoteAddr: profile.Endpoint, LocalAddress: opts.localAddress,
-		Credentials: credentials, ChunkSize: opts.chunkSize,
-		DialTimeout: opts.dialTimeout, HandshakeTimeout: opts.handshakeTimeout,
-		FlowIdleTimeout: opts.flowIdleTimeout, FlowMaxLifetime: opts.flowMaxLifetime,
-		MaxSessions: opts.maxSessions, MaxPendingOpens: opts.maxPendingOpens, Transport: pep.TransportKind(opts.transport),
-		TCPFallbackLanes: opts.tcpFallbackLanes, EnableQUICPool: opts.quicPool,
-		WaitForOpenAcknowledgement: opts.waitForOpenAck, UDPOnStream: opts.udpOnStream,
-		Congestion: pep.CongestionControlKind(opts.congestion), BrutalBytesPerSec: opts.brutalBytesPerSec,
-		AdaptiveMinBytesSec: opts.adaptiveMinBytesSec, AdaptiveMaxBytesSec: opts.adaptiveMaxBytesSec,
-		AggregateBytesPerSec: opts.aggregateBytesPerSec, InteractiveReserveBytesPerSec: opts.interactiveReserveBytesPerSec,
-		FallbackDelay: opts.fallbackDelay, FallbackGrace: opts.fallbackGrace,
-		UDPFailureThreshold: opts.udpFailureThreshold, UDPCooldown: opts.udpCooldown, Logger: logger,
-	})
+	client, err := newRuntimeClient(profile, opts.listen, opts, logger, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -574,7 +574,7 @@ func runClient(args []string) (returnErr error) {
 		return errors.New("--profile and --providers are mutually exclusive")
 	}
 	if *profilePath == "" && *providersPath == "" {
-		return errors.New("--profile is required; import an invitation first with `queqiaod enroll INVITATION`")
+		return errors.New("either --profile or --providers is required; import each provider invitation first with `queqiaod enroll INVITATION`")
 	}
 	listenSet := false
 	fs.Visit(func(f *flag.Flag) {

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -609,7 +609,7 @@ func runClient(args []string) (returnErr error) {
 			return err
 		}
 	}
-	client, err := newRuntimeClient(profile, opts.listen, opts, logger, nil, nil)
+	client, err := newRuntimeClient(profile, opts.listen, opts, logger, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/queqiaod/main_test.go
+++ b/cmd/queqiaod/main_test.go
@@ -127,6 +127,17 @@ func TestClientMissingProfileExplainsEnrollment(t *testing.T) {
 	}
 }
 
+func TestClientProfileAndProvidersAreMutuallyExclusive(t *testing.T) {
+	err := runClient([]string{"--profile", "profile.json", "--providers", "providers.json"})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("profile and providers were not rejected together: %v", err)
+	}
+	err = runClient([]string{"--providers", "providers.json", "--listen", "127.0.0.1:1081"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be used") {
+		t.Fatalf("global listener was accepted with providers: %v", err)
+	}
+}
+
 func TestClientAndServerCreateSeparateRuntimeLogs(t *testing.T) {
 	directory := t.TempDir()
 	t.Setenv("QUEQIAO_LOG_DIR", directory)

--- a/cmd/queqiaod/main_test.go
+++ b/cmd/queqiaod/main_test.go
@@ -128,6 +128,10 @@ func TestClientMissingConfigurationExplainsEnrollment(t *testing.T) {
 }
 
 func TestClientProfileAndProvidersAreMutuallyExclusive(t *testing.T) {
+	// These checks sit above openRuntimeLogger today, but that is not a
+	// property the test should depend on: without this the first refactor which
+	// logs a validation error writes into the real platform log directory.
+	t.Setenv("QUEQIAO_LOG_DIR", t.TempDir())
 	err := runClient([]string{"--profile", "profile.json", "--providers", "providers.json"})
 	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("profile and providers were not rejected together: %v", err)

--- a/cmd/queqiaod/main_test.go
+++ b/cmd/queqiaod/main_test.go
@@ -119,11 +119,11 @@ func TestEnrollmentURIAllowsFollowingFlags(t *testing.T) {
 	}
 }
 
-func TestClientMissingProfileExplainsEnrollment(t *testing.T) {
+func TestClientMissingConfigurationExplainsEnrollment(t *testing.T) {
 	t.Setenv("QUEQIAO_LOG_DIR", t.TempDir())
 	err := runClient(nil)
-	if err == nil || !strings.Contains(err.Error(), "queqiaod enroll") {
-		t.Fatalf("missing profile produced unhelpful error: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "--profile") || !strings.Contains(err.Error(), "--providers") || !strings.Contains(err.Error(), "queqiaod enroll") {
+		t.Fatalf("missing client configuration produced unhelpful error: %v", err)
 	}
 }
 

--- a/cmd/queqiaod/providers.go
+++ b/cmd/queqiaod/providers.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/pep"
+)
+
+type providerManifest struct {
+	Version   int                     `json:"version"`
+	Providers []providerManifestEntry `json:"providers"`
+}
+
+type providerManifestEntry struct {
+	Name    string `json:"name"`
+	Profile string `json:"profile"`
+	Listen  string `json:"listen"`
+}
+
+type providerClientConfig struct {
+	name, profilePath, listen string
+	profile                   identity.ClientProfile
+}
+
+type providerClientRuntime struct {
+	config   providerClientConfig
+	client   *pep.Client
+	listener net.Listener
+	logger   *slog.Logger
+}
+
+func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
+	manifestPath, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve provider manifest path: %w", err)
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("read provider manifest %q: %w", manifestPath, err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest providerManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("decode provider manifest: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, errors.New("provider manifest contains trailing data")
+	}
+	if manifest.Version != 1 {
+		return nil, fmt.Errorf("unsupported provider manifest version %d", manifest.Version)
+	}
+	if len(manifest.Providers) == 0 {
+		return nil, errors.New("provider manifest must contain at least one provider")
+	}
+
+	configs := make([]providerClientConfig, 0, len(manifest.Providers))
+	names := make(map[string]struct{}, len(manifest.Providers))
+	listeners := make(map[string]struct{}, len(manifest.Providers))
+	profilePaths := make(map[string]struct{}, len(manifest.Providers))
+	for i, entry := range manifest.Providers {
+		if entry.Name == "" || entry.Name != strings.TrimSpace(entry.Name) || len(entry.Name) > 128 {
+			return nil, fmt.Errorf("provider %d has an invalid name", i+1)
+		}
+		if _, exists := names[entry.Name]; exists {
+			return nil, fmt.Errorf("duplicate provider name %q", entry.Name)
+		}
+		names[entry.Name] = struct{}{}
+
+		listen, err := normalizeProviderListener(entry.Listen)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q listen address: %w", entry.Name, err)
+		}
+		if _, exists := listeners[listen]; exists {
+			return nil, fmt.Errorf("duplicate provider listener %q", listen)
+		}
+		listeners[listen] = struct{}{}
+
+		if entry.Profile == "" {
+			return nil, fmt.Errorf("provider %q profile path is required", entry.Name)
+		}
+		profilePath := entry.Profile
+		if !filepath.IsAbs(profilePath) {
+			profilePath = filepath.Join(filepath.Dir(manifestPath), profilePath)
+		}
+		profilePath, err = filepath.Abs(profilePath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve provider %q profile path: %w", entry.Name, err)
+		}
+		profilePath = filepath.Clean(profilePath)
+		if _, exists := profilePaths[profilePath]; exists {
+			return nil, fmt.Errorf("duplicate provider profile path %q", profilePath)
+		}
+		profilePaths[profilePath] = struct{}{}
+		configs = append(configs, providerClientConfig{
+			name: entry.Name, profilePath: profilePath, listen: listen,
+		})
+	}
+
+	profileInfos := make([]os.FileInfo, 0, len(configs))
+	for _, config := range configs {
+		info, err := os.Stat(config.profilePath)
+		if err != nil {
+			return nil, fmt.Errorf("inspect provider %q profile: %w", config.name, err)
+		}
+		for _, previous := range profileInfos {
+			if os.SameFile(previous, info) {
+				return nil, fmt.Errorf("provider %q profile duplicates another profile file", config.name)
+			}
+		}
+		profileInfos = append(profileInfos, info)
+	}
+	for i := range configs {
+		profile, err := identity.LoadClientProfile(configs[i].profilePath)
+		if err != nil {
+			return nil, fmt.Errorf("load provider %q profile %q: %w", configs[i].name, configs[i].profilePath, err)
+		}
+		configs[i].profile = profile
+	}
+	return configs, nil
+}
+
+func normalizeProviderListener(address string) (string, error) {
+	host, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", errors.New("must be a TCP host:port address")
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return "", errors.New("must use a literal loopback IP; SOCKS has no remote authentication")
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil || port < 0 || port > 65535 {
+		return "", errors.New("must use a numeric port between 0 and 65535")
+	}
+	return net.JoinHostPort(ip.String(), strconv.Itoa(port)), nil
+}
+
+func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtimeOptions, logger *slog.Logger, registry *metrics.Registry, sessionLimit *pep.SessionLimit) (*pep.Client, error) {
+	credentials, err := profile.Credentials()
+	if err != nil {
+		return nil, err
+	}
+	return pep.NewClient(pep.ClientConfig{
+		ListenAddr: listen, RemoteAddr: profile.Endpoint, LocalAddress: opts.localAddress,
+		Credentials: credentials, ChunkSize: opts.chunkSize,
+		DialTimeout: opts.dialTimeout, HandshakeTimeout: opts.handshakeTimeout,
+		FlowIdleTimeout: opts.flowIdleTimeout, FlowMaxLifetime: opts.flowMaxLifetime,
+		MaxSessions: opts.maxSessions, SessionLimit: sessionLimit, MaxPendingOpens: opts.maxPendingOpens, Transport: pep.TransportKind(opts.transport),
+		TCPFallbackLanes: opts.tcpFallbackLanes, EnableQUICPool: opts.quicPool,
+		WaitForOpenAcknowledgement: opts.waitForOpenAck, UDPOnStream: opts.udpOnStream,
+		Congestion: pep.CongestionControlKind(opts.congestion), BrutalBytesPerSec: opts.brutalBytesPerSec,
+		AdaptiveMinBytesSec: opts.adaptiveMinBytesSec, AdaptiveMaxBytesSec: opts.adaptiveMaxBytesSec,
+		AggregateBytesPerSec: opts.aggregateBytesPerSec, InteractiveReserveBytesPerSec: opts.interactiveReserveBytesPerSec,
+		FallbackDelay: opts.fallbackDelay, FallbackGrace: opts.fallbackGrace,
+		UDPFailureThreshold: opts.udpFailureThreshold, UDPCooldown: opts.udpCooldown,
+		Metrics: registry, Logger: logger,
+	})
+}
+
+func renewClientProfile(ctx context.Context, profilePath string, profile identity.ClientProfile, opts runtimeOptions, logger *slog.Logger) (identity.ClientProfile, error) {
+	needs, err := profile.NeedsRenewal(time.Now(), 7*24*time.Hour)
+	if err != nil {
+		return profile, err
+	}
+	if !needs {
+		return profile, nil
+	}
+	renewed, err := identity.RenewProfileWithOptions(ctx, profile, identity.DialOptions{Timeout: opts.handshakeTimeout, LocalAddress: opts.localAddress})
+	if err != nil {
+		logger.Warn("automatic certificate renewal failed; continuing with current valid identity", "error", err)
+		return profile, nil
+	}
+	if err := renewed.Save(profilePath); err != nil {
+		return profile, fmt.Errorf("save renewed profile: %w", err)
+	}
+	logger.Info("device identity renewed")
+	return renewed, nil
+}
+
+func runProviderClients(manifestPath string, noAutoRenew bool, opts runtimeOptions, logger *slog.Logger) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return runProviderClientsContext(ctx, manifestPath, noAutoRenew, opts, logger)
+}
+
+func runProviderClientsContext(ctx context.Context, manifestPath string, noAutoRenew bool, opts runtimeOptions, logger *slog.Logger) error {
+	configs, err := loadProviderClients(manifestPath)
+	if err != nil {
+		return err
+	}
+	registry := metrics.New()
+	sessionLimit, err := pep.NewSessionLimit(opts.maxSessions)
+	if err != nil {
+		return err
+	}
+	runtimes := make([]providerClientRuntime, 0, len(configs))
+	closeListeners := func() {
+		for _, runtime := range runtimes {
+			if runtime.listener != nil {
+				_ = runtime.listener.Close()
+			}
+		}
+	}
+
+	for _, config := range configs {
+		providerLogger := logger.With("provider", config.name, "listener", config.listen)
+		profile := config.profile
+		if !noAutoRenew {
+			profile, err = renewClientProfile(ctx, config.profilePath, profile, opts, providerLogger)
+			if err != nil {
+				providerLogger.Warn("automatic certificate renewal failed; continuing with current valid identity", "error", err)
+				profile = config.profile
+			}
+		}
+		config.profile = profile
+		client, err := newRuntimeClient(profile, config.listen, opts, providerLogger, registry, sessionLimit)
+		if err != nil {
+			return fmt.Errorf("configure provider %q: %w", config.name, err)
+		}
+		providerOpts := opts
+		providerOpts.listen = config.listen
+		logRuntimeConfiguration(providerLogger, providerOpts, true)
+		runtimes = append(runtimes, providerClientRuntime{config: config, client: client, logger: providerLogger})
+	}
+
+	lc := net.ListenConfig{KeepAlive: 30 * time.Second}
+	for i := range runtimes {
+		listener, err := lc.Listen(ctx, "tcp", runtimes[i].config.listen)
+		if err != nil {
+			closeListeners()
+			return fmt.Errorf("bind provider %q listener %q: %w", runtimes[i].config.name, runtimes[i].config.listen, err)
+		}
+		runtimes[i].listener = listener
+	}
+	logger.Info("all provider listeners bound", "providers", len(runtimes))
+
+	stopMetrics, err := serveMetrics(opts.metricsListen, registry, logger)
+	if err != nil {
+		closeListeners()
+		return err
+	}
+	defer stopMetrics()
+	stopTelemetry := startTelemetryLog(ctx, opts.telemetryLogInterval, registry, logger)
+	defer stopTelemetry()
+
+	type serveResult struct {
+		name string
+		err  error
+	}
+	results := make(chan serveResult, len(runtimes))
+	for i := range runtimes {
+		runtime := &runtimes[i]
+		if !noAutoRenew {
+			go maintainClientIdentity(ctx, runtime.config.profilePath, runtime.config.profile, runtime.client, opts.handshakeTimeout, opts.localAddress, runtime.logger)
+		}
+		go func() {
+			results <- serveResult{name: runtime.config.name, err: runtime.client.ServeListener(ctx, runtime.listener)}
+		}()
+	}
+
+	remaining := len(runtimes)
+	var firstErr error
+	for remaining > 0 {
+		select {
+		case result := <-results:
+			remaining--
+			if result.err != nil {
+				logger.Error("provider client stopped", "provider", result.name, "error", result.err)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("provider %q stopped: %w", result.name, result.err)
+				}
+			}
+		case <-ctx.Done():
+			for remaining > 0 {
+				<-results
+				remaining--
+			}
+			return firstErr
+		}
+	}
+	return firstErr
+}

--- a/cmd/queqiaod/providers.go
+++ b/cmd/queqiaod/providers.go
@@ -45,6 +45,11 @@ type providerClientRuntime struct {
 	logger   *slog.Logger
 }
 
+type providerServeResult struct {
+	name string
+	err  error
+}
+
 func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
 	manifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
@@ -258,42 +263,39 @@ func runProviderClientsContext(ctx context.Context, manifestPath string, noAutoR
 		return err
 	}
 	defer stopMetrics()
-	stopTelemetry := startTelemetryLog(ctx, opts.telemetryLogInterval, registry, logger)
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	defer cancelServe()
+	stopTelemetry := startTelemetryLog(serveCtx, opts.telemetryLogInterval, registry, logger)
 	defer stopTelemetry()
 
-	type serveResult struct {
-		name string
-		err  error
-	}
-	results := make(chan serveResult, len(runtimes))
+	results := make(chan providerServeResult, len(runtimes))
 	for i := range runtimes {
 		runtime := &runtimes[i]
 		if !noAutoRenew {
-			go maintainClientIdentity(ctx, runtime.config.profilePath, runtime.config.profile, runtime.client, opts.handshakeTimeout, opts.localAddress, runtime.logger)
+			go maintainClientIdentity(serveCtx, runtime.config.profilePath, runtime.config.profile, runtime.client, opts.handshakeTimeout, opts.localAddress, runtime.logger)
 		}
 		go func() {
-			results <- serveResult{name: runtime.config.name, err: runtime.client.ServeListener(ctx, runtime.listener)}
+			results <- providerServeResult{name: runtime.config.name, err: runtime.client.ServeListener(serveCtx, runtime.listener)}
 		}()
 	}
+	return waitProviderClients(serveCtx, cancelServe, results, len(runtimes), logger)
+}
 
-	remaining := len(runtimes)
+func waitProviderClients(ctx context.Context, cancel context.CancelFunc, results <-chan providerServeResult, remaining int, logger *slog.Logger) error {
 	var firstErr error
 	for remaining > 0 {
-		select {
-		case result := <-results:
-			remaining--
-			if result.err != nil {
-				logger.Error("provider client stopped", "provider", result.name, "error", result.err)
-				if firstErr == nil {
-					firstErr = fmt.Errorf("provider %q stopped: %w", result.name, result.err)
-				}
+		result := <-results
+		remaining--
+		if result.err == nil {
+			if ctx.Err() != nil {
+				continue
 			}
-		case <-ctx.Done():
-			for remaining > 0 {
-				<-results
-				remaining--
-			}
-			return firstErr
+			result.err = errors.New("listener stopped unexpectedly")
+		}
+		logger.Error("provider client stopped", "provider", result.name, "error", result.err)
+		if firstErr == nil {
+			firstErr = fmt.Errorf("provider %q stopped: %w", result.name, result.err)
+			cancel()
 		}
 	}
 	return firstErr

--- a/cmd/queqiaod/providers.go
+++ b/cmd/queqiaod/providers.go
@@ -14,10 +14,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/limiter"
 	"github.com/bojieli/queqiao/internal/metrics"
 	"github.com/bojieli/queqiao/internal/pep"
 )
@@ -50,6 +52,33 @@ type providerServeResult struct {
 	err  error
 }
 
+// decodeProviderManifest reads the version with a permissive pass before the
+// strict one. Decoding strictly first would report an unrecognised field from a
+// newer manifest as an unknown-field error, pointing the operator at a field
+// name instead of at the version they need to downgrade or upgrade.
+func decodeProviderManifest(data []byte) (providerManifest, error) {
+	var envelope struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return providerManifest{}, fmt.Errorf("decode provider manifest: %w", err)
+	}
+	if envelope.Version != 1 {
+		return providerManifest{}, fmt.Errorf("unsupported provider manifest version %d", envelope.Version)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest providerManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return providerManifest{}, fmt.Errorf("decode provider manifest: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return providerManifest{}, errors.New("provider manifest contains trailing data")
+	}
+	return manifest, nil
+}
+
 func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
 	manifestPath, err := filepath.Abs(manifestPath)
 	if err != nil {
@@ -59,18 +88,9 @@ func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read provider manifest %q: %w", manifestPath, err)
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	var manifest providerManifest
-	if err := decoder.Decode(&manifest); err != nil {
-		return nil, fmt.Errorf("decode provider manifest: %w", err)
-	}
-	var trailing any
-	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return nil, errors.New("provider manifest contains trailing data")
-	}
-	if manifest.Version != 1 {
-		return nil, fmt.Errorf("unsupported provider manifest version %d", manifest.Version)
+	manifest, err := decodeProviderManifest(data)
+	if err != nil {
+		return nil, err
 	}
 	if len(manifest.Providers) == 0 {
 		return nil, errors.New("provider manifest must contain at least one provider")
@@ -105,11 +125,11 @@ func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
 		if !filepath.IsAbs(profilePath) {
 			profilePath = filepath.Join(filepath.Dir(manifestPath), profilePath)
 		}
+		// filepath.Abs cleans its result, so no separate Clean is needed.
 		profilePath, err = filepath.Abs(profilePath)
 		if err != nil {
 			return nil, fmt.Errorf("resolve provider %q profile path: %w", entry.Name, err)
 		}
-		profilePath = filepath.Clean(profilePath)
 		if _, exists := profilePaths[profilePath]; exists {
 			return nil, fmt.Errorf("duplicate provider profile path %q", profilePath)
 		}
@@ -119,23 +139,24 @@ func loadProviderClients(manifestPath string) ([]providerClientConfig, error) {
 		})
 	}
 
-	profileInfos := make([]os.FileInfo, 0, len(configs))
-	for _, config := range configs {
-		info, err := os.Stat(config.profilePath)
-		if err != nil {
-			return nil, fmt.Errorf("inspect provider %q profile: %w", config.name, err)
-		}
-		for _, previous := range profileInfos {
-			if os.SameFile(previous, info) {
-				return nil, fmt.Errorf("provider %q profile duplicates another profile file", config.name)
-			}
-		}
-		profileInfos = append(profileInfos, info)
-	}
+	// Distinct paths can still name one enrolled device: a copied profile, a
+	// symlink, a hard link. Running both would put two clients on a single
+	// device certificate and leave two renewal loops racing to save one
+	// identity into two files, so compare the loaded identity rather than the
+	// file. Reading each profile once also closes the window a separate stat
+	// pass would leave between the check and the read.
+	devices := make(map[string]string, len(configs))
 	for i := range configs {
 		profile, err := identity.LoadClientProfile(configs[i].profilePath)
 		if err != nil {
 			return nil, fmt.Errorf("load provider %q profile %q: %w", configs[i].name, configs[i].profilePath, err)
+		}
+		if profile.ProviderID != "" && profile.DeviceID != "" {
+			device := profile.ProviderID + "/" + profile.DeviceID
+			if previous, exists := devices[device]; exists {
+				return nil, fmt.Errorf("provider %q uses the same enrolled device as provider %q; enroll a separate device for each provider entry", configs[i].name, previous)
+			}
+			devices[device] = configs[i].name
 		}
 		configs[i].profile = profile
 	}
@@ -151,14 +172,16 @@ func normalizeProviderListener(address string) (string, error) {
 	if ip == nil || !ip.IsLoopback() {
 		return "", errors.New("must use a literal loopback IP; SOCKS has no remote authentication")
 	}
+	// Port 0 would bind whatever the kernel handed out, which no proxy client
+	// can be configured against.
 	port, err := strconv.Atoi(portText)
-	if err != nil || port < 0 || port > 65535 {
-		return "", errors.New("must use a numeric port between 0 and 65535")
+	if err != nil || port < 1 || port > 65535 {
+		return "", errors.New("must use a numeric port between 1 and 65535")
 	}
 	return net.JoinHostPort(ip.String(), strconv.Itoa(port)), nil
 }
 
-func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtimeOptions, logger *slog.Logger, registry *metrics.Registry, sessionLimit *pep.SessionLimit) (*pep.Client, error) {
+func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtimeOptions, logger *slog.Logger, registry *metrics.Registry, sessionLimit *pep.SessionLimit, budget *limiter.Budget) (*pep.Client, error) {
 	credentials, err := profile.Credentials()
 	if err != nil {
 		return nil, err
@@ -174,16 +197,23 @@ func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtim
 		Congestion: pep.CongestionControlKind(opts.congestion), BrutalBytesPerSec: opts.brutalBytesPerSec,
 		AdaptiveMinBytesSec: opts.adaptiveMinBytesSec, AdaptiveMaxBytesSec: opts.adaptiveMaxBytesSec,
 		AggregateBytesPerSec: opts.aggregateBytesPerSec, InteractiveReserveBytesPerSec: opts.interactiveReserveBytesPerSec,
+		Budget:        budget,
 		FallbackDelay: opts.fallbackDelay, FallbackGrace: opts.fallbackGrace,
 		UDPFailureThreshold: opts.udpFailureThreshold, UDPCooldown: opts.udpCooldown,
 		Metrics: registry, Logger: logger,
 	})
 }
 
+// renewClientProfile refreshes a device certificate which is close to expiry.
+// A gateway which cannot be reached is not an error: the current identity is
+// still valid, and the maintenance loop will try again. A profile which was
+// renewed but could not be written is returned with its error so the caller can
+// decide, and the fresh identity is returned rather than the stale one so a
+// caller which continues does so on the better certificate.
 func renewClientProfile(ctx context.Context, profilePath string, profile identity.ClientProfile, opts runtimeOptions, logger *slog.Logger) (identity.ClientProfile, error) {
 	needs, err := profile.NeedsRenewal(time.Now(), 7*24*time.Hour)
 	if err != nil {
-		return profile, err
+		return profile, fmt.Errorf("check device identity lifetime: %w", err)
 	}
 	if !needs {
 		return profile, nil
@@ -194,7 +224,7 @@ func renewClientProfile(ctx context.Context, profilePath string, profile identit
 		return profile, nil
 	}
 	if err := renewed.Save(profilePath); err != nil {
-		return profile, fmt.Errorf("save renewed profile: %w", err)
+		return renewed, fmt.Errorf("save renewed profile %q: %w", profilePath, err)
 	}
 	logger.Info("device identity renewed")
 	return renewed, nil
@@ -206,56 +236,94 @@ func runProviderClients(manifestPath string, noAutoRenew bool, opts runtimeOptio
 	return runProviderClientsContext(ctx, manifestPath, noAutoRenew, opts, logger)
 }
 
+// logProviderRuntimeConfiguration records the process-wide controls once and
+// then only what differs per provider. Repeating the whole record per provider
+// would print the shared session budget once per listener and read as if each
+// provider owned that many sessions.
+func logProviderRuntimeConfiguration(logger *slog.Logger, opts runtimeOptions, configs []providerClientConfig, limits []*pep.SessionLimit) {
+	shared := opts
+	// There is no single listener in this mode; each provider logs its own.
+	shared.listen = ""
+	logRuntimeConfiguration(logger, shared, true)
+	for i := range configs {
+		logger.LogAttrs(context.Background(), slog.LevelInfo, "provider configuration",
+			slog.Int("config_schema", 1),
+			slog.String("provider", configs[i].name),
+			slog.String("listen", configs[i].listen),
+			slog.Int("reserved_sessions", limits[i].Reserved()),
+		)
+	}
+}
+
 func runProviderClientsContext(ctx context.Context, manifestPath string, noAutoRenew bool, opts runtimeOptions, logger *slog.Logger) error {
 	configs, err := loadProviderClients(manifestPath)
 	if err != nil {
 		return err
 	}
 	registry := metrics.New()
-	sessionLimit, err := pep.NewSessionLimit(opts.maxSessions)
+	sessionLimits, err := pep.NewSharedSessionLimits(opts.maxSessions, len(configs))
 	if err != nil {
 		return err
 	}
-	runtimes := make([]providerClientRuntime, 0, len(configs))
+	// One budget for the process. A budget per provider would offer the
+	// configured aggregate rate once per provider onto a single uplink.
+	budget := pep.NewAggregateBudget(opts.aggregateBytesPerSec, opts.interactiveReserveBytesPerSec)
+
+	loggers := make([]*slog.Logger, len(configs))
+	for i := range configs {
+		loggers[i] = logger.With("provider", configs[i].name, "listener", configs[i].listen)
+	}
+
+	// Bind every listener before the first gateway dial. Startup renewal can
+	// block for a handshake timeout, and holding a healthy provider's listener
+	// down while an unrelated provider's gateway times out is the outage a
+	// multi-provider client exists to avoid.
+	listeners := make([]net.Listener, 0, len(configs))
 	closeListeners := func() {
-		for _, runtime := range runtimes {
-			if runtime.listener != nil {
-				_ = runtime.listener.Close()
-			}
+		for _, listener := range listeners {
+			_ = listener.Close()
 		}
 	}
-
-	for _, config := range configs {
-		providerLogger := logger.With("provider", config.name, "listener", config.listen)
-		profile := config.profile
-		if !noAutoRenew {
-			profile, err = renewClientProfile(ctx, config.profilePath, profile, opts, providerLogger)
-			if err != nil {
-				providerLogger.Warn("automatic certificate renewal failed; continuing with current valid identity", "error", err)
-				profile = config.profile
-			}
-		}
-		config.profile = profile
-		client, err := newRuntimeClient(profile, config.listen, opts, providerLogger, registry, sessionLimit)
-		if err != nil {
-			return fmt.Errorf("configure provider %q: %w", config.name, err)
-		}
-		providerOpts := opts
-		providerOpts.listen = config.listen
-		logRuntimeConfiguration(providerLogger, providerOpts, true)
-		runtimes = append(runtimes, providerClientRuntime{config: config, client: client, logger: providerLogger})
-	}
-
-	lc := net.ListenConfig{KeepAlive: 30 * time.Second}
-	for i := range runtimes {
-		listener, err := lc.Listen(ctx, "tcp", runtimes[i].config.listen)
+	for i := range configs {
+		listener, err := pep.ListenLocal(ctx, configs[i].listen)
 		if err != nil {
 			closeListeners()
-			return fmt.Errorf("bind provider %q listener %q: %w", runtimes[i].config.name, runtimes[i].config.listen, err)
+			return fmt.Errorf("bind provider %q listener %q: %w", configs[i].name, configs[i].listen, err)
 		}
-		runtimes[i].listener = listener
+		listeners = append(listeners, listener)
 	}
-	logger.Info("all provider listeners bound", "providers", len(runtimes))
+	logger.Info("all provider listeners bound", "providers", len(configs))
+
+	// Renew concurrently so an unreachable gateway costs the process one
+	// handshake timeout rather than one per provider.
+	if !noAutoRenew {
+		var wg sync.WaitGroup
+		for i := range configs {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				profile, err := renewClientProfile(ctx, configs[i].profilePath, configs[i].profile, opts, loggers[i])
+				if err != nil {
+					loggers[i].Error("provider identity maintenance failed; continuing", "error", err)
+				}
+				configs[i].profile = profile
+			}()
+		}
+		wg.Wait()
+	}
+
+	runtimes := make([]providerClientRuntime, 0, len(configs))
+	for i := range configs {
+		client, err := newRuntimeClient(configs[i].profile, configs[i].listen, opts, loggers[i], registry, sessionLimits[i], budget)
+		if err != nil {
+			closeListeners()
+			return fmt.Errorf("configure provider %q: %w", configs[i].name, err)
+		}
+		runtimes = append(runtimes, providerClientRuntime{
+			config: configs[i], client: client, listener: listeners[i], logger: loggers[i],
+		})
+	}
+	logProviderRuntimeConfiguration(logger, opts, configs, sessionLimits)
 
 	stopMetrics, err := serveMetrics(opts.metricsListen, registry, logger)
 	if err != nil {
@@ -288,6 +356,10 @@ func waitProviderClients(ctx context.Context, cancel context.CancelFunc, results
 		remaining--
 		if result.err == nil {
 			if ctx.Err() != nil {
+				// Cancellation may be this process shutting down or a sibling
+				// which already failed. Either way the stop is recorded, so a
+				// provider is never dropped silently from the operator's log.
+				logger.Info("provider client stopped during shutdown", "provider", result.name)
 				continue
 			}
 			result.err = errors.New("listener stopped unexpectedly")

--- a/cmd/queqiaod/providers_test.go
+++ b/cmd/queqiaod/providers_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/binary"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/pep"
+)
+
+func writeProviderManifest(t *testing.T, directory string, manifest providerManifest) string {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "providers.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestProviderManifestRejectsDuplicateIdentityAndListeners(t *testing.T) {
+	directory := t.TempDir()
+	for name, entries := range map[string][]providerManifestEntry{
+		"name": {
+			{Name: "same", Profile: "one.json", Listen: "127.0.0.1:1081"},
+			{Name: "same", Profile: "two.json", Listen: "127.0.0.1:1082"},
+		},
+		"listener": {
+			{Name: "one", Profile: "one.json", Listen: "[::1]:1081"},
+			{Name: "two", Profile: "two.json", Listen: "[0:0:0:0:0:0:0:1]:1081"},
+		},
+		"profile": {
+			{Name: "one", Profile: "same.json", Listen: "127.0.0.1:1081"},
+			{Name: "two", Profile: "same.json", Listen: "127.0.0.1:1082"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := writeProviderManifest(t, directory, providerManifest{Version: 1, Providers: entries})
+			if _, err := loadProviderClients(path); err == nil || !strings.Contains(err.Error(), "duplicate") {
+				t.Fatalf("duplicate %s was not rejected: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestProviderManifestIsStrictAndRequiresLoopback(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "providers.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"unknown":true,"providers":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadProviderClients(path); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("unknown manifest field was accepted: %v", err)
+	}
+	for _, address := range []string{"0.0.0.0:1080", "localhost:1080", "127.0.0.1:http"} {
+		if _, err := normalizeProviderListener(address); err == nil {
+			t.Errorf("unsafe provider listener %q was accepted", address)
+		}
+	}
+}
+
+func TestTwoProviderClientsReachIndependentGateways(t *testing.T) {
+	directory := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	destination, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer destination.Close()
+	go echoProviderTestDestination(destination)
+
+	servers := make([]*pep.Server, 2)
+	stopServers := make([]context.CancelFunc, 2)
+	defer func() {
+		for _, stop := range stopServers {
+			if stop != nil {
+				stop()
+			}
+		}
+	}()
+	profiles := make([]string, 2)
+	for i := range servers {
+		gatewayListener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		provider, profile := providerTestProfile(t, directory, i, gatewayListener.Addr().String())
+		profiles[i] = profile
+		servers[i], err = pep.NewServer(pep.ServerConfig{
+			ListenAddr: gatewayListener.Addr().String(), Credentials: provider.ServerCredentials(),
+			EnableTCP: true, DestinationPolicy: pep.DestinationPolicy{AllowPrivate: true}, Logger: logger,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		serverCtx, stopServer := context.WithCancel(context.Background())
+		stopServers[i] = stopServer
+		go func(server *pep.Server, listener net.Listener) {
+			_ = server.ServeListener(serverCtx, listener)
+		}(servers[i], gatewayListener)
+	}
+
+	clientAddresses := []string{unusedProviderTestAddress(t), unusedProviderTestAddress(t)}
+	manifestPath := writeProviderManifest(t, directory, providerManifest{Version: 1, Providers: []providerManifestEntry{
+		{Name: "one", Profile: filepath.Base(profiles[0]), Listen: clientAddresses[0]},
+		{Name: "two", Profile: filepath.Base(profiles[1]), Listen: clientAddresses[1]},
+	}})
+	opts := parseRuntimeForTest(t, true, "--transport", "tcp", "--local-address", "127.0.0.1", "--telemetry-log-interval", "0")
+	clientCtx, stopClients := context.WithCancel(context.Background())
+	clientDone := make(chan error, 1)
+	go func() { clientDone <- runProviderClientsContext(clientCtx, manifestPath, true, opts, logger) }()
+
+	for i, address := range clientAddresses {
+		runProviderTestFlow(t, address, destination.Addr().String())
+		deadline := time.Now().Add(5 * time.Second)
+		for servers[i].Metrics().Snapshot().FlowsCompleted == 0 && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if servers[i].Metrics().Snapshot().FlowsCompleted != 1 {
+			t.Fatalf("provider %d did not carry its SOCKS flow", i+1)
+		}
+		if i == 0 && servers[1].Metrics().Snapshot().FlowsStarted != 0 {
+			t.Fatal("first provider SOCKS port sent traffic through the second gateway")
+		}
+		if i == 0 {
+			stopServers[0]()
+		}
+	}
+	stopClients()
+	select {
+	case err := <-clientDone:
+		if err != nil {
+			t.Fatalf("multi-provider client shutdown failed: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("multi-provider client did not close all listeners and pools")
+	}
+}
+
+func TestProviderStartupClosesPreviouslyBoundListenersOnFailure(t *testing.T) {
+	directory := t.TempDir()
+	_, firstProfile := providerTestProfile(t, directory, 0, "127.0.0.1:1")
+	_, secondProfile := providerTestProfile(t, directory, 1, "127.0.0.1:2")
+	firstAddress := unusedProviderTestAddress(t)
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.Close()
+	manifestPath := writeProviderManifest(t, directory, providerManifest{Version: 1, Providers: []providerManifestEntry{
+		{Name: "one", Profile: filepath.Base(firstProfile), Listen: firstAddress},
+		{Name: "two", Profile: filepath.Base(secondProfile), Listen: occupied.Addr().String()},
+	}})
+	opts := parseRuntimeForTest(t, true, "--transport", "tcp", "--telemetry-log-interval", "0")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := runProviderClientsContext(context.Background(), manifestPath, true, opts, logger); err == nil || !strings.Contains(err.Error(), "bind provider") {
+		t.Fatalf("occupied provider listener did not fail startup: %v", err)
+	}
+	rebound, err := net.Listen("tcp", firstAddress)
+	if err != nil {
+		t.Fatalf("first provider listener was not rolled back: %v", err)
+	}
+	_ = rebound.Close()
+}
+
+func providerTestProfile(t *testing.T, directory string, index int, endpoint string) (*identity.Provider, string) {
+	t.Helper()
+	now := time.Now()
+	provider, err := identity.InitProvider(filepath.Join(directory, "provider-"+string(rune('a'+index))), "Provider", endpoint, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, err := provider.Store.AddAccount("user", time.Time{}, 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, invitation, err := provider.CreateInvitation(account.ID, time.Hour, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, device, err := provider.Store.ConsumeInvite(invitation.Token, "device", publicKey, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certificate, err := provider.IssueDevice(account.ID, device.ID, publicKey, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := identity.ClientProfile{
+		Version: identity.ProfileVersion, Name: provider.Metadata.Name,
+		ProviderID: provider.Metadata.ProviderID, Endpoint: endpoint,
+		GatewayID: provider.Metadata.GatewayID, RootPin: provider.Metadata.RootPin,
+		RootCertificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: provider.RootCert.Raw})),
+		AccountID:       account.ID, DeviceID: device.ID, DeviceName: "device",
+		DeviceCertificate: string(certificate),
+		DevicePrivateKey:  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateDER})),
+		CreatedAt:         now.UTC().Format(time.RFC3339),
+	}
+	path := filepath.Join(directory, "profile-"+string(rune('a'+index))+".json")
+	if err := profile.SaveNew(path); err != nil {
+		t.Fatal(err)
+	}
+	return provider, path
+}
+
+func unusedProviderTestAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return address
+}
+
+func echoProviderTestDestination(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer conn.Close()
+			_, _ = io.Copy(conn, conn)
+		}()
+	}
+}
+
+func runProviderTestFlow(t *testing.T, socksAddress, destination string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var conn net.Conn
+	var err error
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", socksAddress, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("connect to SOCKS listener %s: %v", socksAddress, err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
+		t.Fatal(err)
+	}
+	var method [2]byte
+	if _, err := io.ReadFull(conn, method[:]); err != nil || method != [2]byte{5, 0} {
+		t.Fatalf("SOCKS method negotiation failed: %v, %v", method, err)
+	}
+	host, portText, err := net.SplitHostPort(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := net.LookupPort("tcp", portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := []byte{5, 1, 0, 1}
+	request = append(request, net.ParseIP(host).To4()...)
+	request = binary.BigEndian.AppendUint16(request, uint16(port))
+	if _, err := conn.Write(request); err != nil {
+		t.Fatal(err)
+	}
+	var reply [10]byte
+	if _, err := io.ReadFull(conn, reply[:]); err != nil || reply[1] != 0 {
+		t.Fatalf("SOCKS connect failed: %x, %v", reply, err)
+	}
+	payload := []byte("provider-isolation")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil || string(got) != string(payload) {
+		t.Fatalf("SOCKS payload round trip failed: %q, %v", got, err)
+	}
+}

--- a/cmd/queqiaod/providers_test.go
+++ b/cmd/queqiaod/providers_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -178,6 +179,41 @@ func TestProviderStartupClosesPreviouslyBoundListenersOnFailure(t *testing.T) {
 		t.Fatalf("first provider listener was not rolled back: %v", err)
 	}
 	_ = rebound.Close()
+}
+
+func TestProviderRuntimeStopCancelsSiblingClients(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		firstErr error
+		want     string
+	}{
+		{name: "listener error", firstErr: errors.New("accept failed"), want: "accept failed"},
+		{name: "unexpected clean stop", want: "listener stopped unexpectedly"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			results := make(chan providerServeResult, 2)
+			done := make(chan error, 1)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			go func() { done <- waitProviderClients(ctx, cancel, results, 2, logger) }()
+
+			results <- providerServeResult{name: "one", err: test.firstErr}
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Second):
+				t.Fatal("first stopped provider did not cancel its sibling")
+			}
+			results <- providerServeResult{name: "two"}
+			select {
+			case err := <-done:
+				if err == nil || !strings.Contains(err.Error(), `provider "one" stopped`) || !strings.Contains(err.Error(), test.want) {
+					t.Fatalf("runtime stop error = %v, want provider and cause", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("provider supervisor did not finish after sibling shutdown")
+			}
+		})
+	}
 }
 
 func providerTestProfile(t *testing.T, directory string, index int, endpoint string) (*identity.Provider, string) {

--- a/cmd/queqiaod/providers_test.go
+++ b/cmd/queqiaod/providers_test.go
@@ -69,7 +69,7 @@ func TestProviderManifestIsStrictAndRequiresLoopback(t *testing.T) {
 	if _, err := loadProviderClients(path); err == nil || !strings.Contains(err.Error(), "unknown") {
 		t.Fatalf("unknown manifest field was accepted: %v", err)
 	}
-	for _, address := range []string{"0.0.0.0:1080", "localhost:1080", "127.0.0.1:http"} {
+	for _, address := range []string{"0.0.0.0:1080", "localhost:1080", "127.0.0.1:http", "127.0.0.1:0", "127.0.0.1:65536"} {
 		if _, err := normalizeProviderListener(address); err == nil {
 			t.Errorf("unsafe provider listener %q was accepted", address)
 		}
@@ -125,6 +125,10 @@ func TestTwoProviderClientsReachIndependentGateways(t *testing.T) {
 	}})
 	opts := parseRuntimeForTest(t, true, "--transport", "tcp", "--local-address", "127.0.0.1", "--telemetry-log-interval", "0")
 	clientCtx, stopClients := context.WithCancel(context.Background())
+	// Deferred as well as called below: a t.Fatalf between here and the
+	// explicit stop would otherwise leave both SOCKS listeners bound for the
+	// rest of the test binary and turn one failure into a cascade.
+	defer stopClients()
 	clientDone := make(chan error, 1)
 	go func() { clientDone <- runProviderClientsContext(clientCtx, manifestPath, true, opts, logger) }()
 
@@ -339,5 +343,98 @@ func runProviderTestFlow(t *testing.T, socksAddress, destination string) {
 	got := make([]byte, len(payload))
 	if _, err := io.ReadFull(conn, got); err != nil || string(got) != string(payload) {
 		t.Fatalf("SOCKS payload round trip failed: %q, %v", got, err)
+	}
+}
+
+func TestProviderManifestRejectsOneDeviceUnderTwoNames(t *testing.T) {
+	for name, clone := range map[string]func(t *testing.T, source, target string){
+		"copy": func(t *testing.T, source, target string) {
+			data, err := os.ReadFile(source)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(target, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"symlink": func(t *testing.T, source, target string) {
+			if err := os.Symlink(source, target); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+		},
+		"hardlink": func(t *testing.T, source, target string) {
+			if err := os.Link(source, target); err != nil {
+				t.Skipf("hard links unavailable: %v", err)
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			directory := t.TempDir()
+			_, profile := providerTestProfile(t, directory, 0, "127.0.0.1:1")
+			duplicate := filepath.Join(directory, "duplicate.json")
+			clone(t, profile, duplicate)
+			manifestPath := writeProviderManifest(t, directory, providerManifest{Version: 1, Providers: []providerManifestEntry{
+				{Name: "one", Profile: filepath.Base(profile), Listen: "127.0.0.1:1081"},
+				{Name: "two", Profile: filepath.Base(duplicate), Listen: "127.0.0.1:1082"},
+			}})
+			if _, err := loadProviderClients(manifestPath); err == nil || !strings.Contains(err.Error(), "same enrolled device") {
+				t.Fatalf("one device under two provider names was accepted: %v", err)
+			}
+		})
+	}
+}
+
+func TestProviderManifestReportsUnsupportedVersionBeforeUnknownFields(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "providers.json")
+	// A manifest from a future build carries fields this build has never heard
+	// of. The operator needs to be told the version is wrong, not the name of
+	// whichever new field happened to be decoded first.
+	if err := os.WriteFile(path, []byte(`{"version":2,"providers":[],"routing":"latency"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadProviderClients(path); err == nil || !strings.Contains(err.Error(), "unsupported provider manifest version 2") {
+		t.Fatalf("future manifest version was misreported: %v", err)
+	}
+}
+
+func TestProviderClientsShareOneAggregateBudgetAndSessionBudget(t *testing.T) {
+	directory := t.TempDir()
+	_, first := providerTestProfile(t, directory, 0, "127.0.0.1:1")
+	_, second := providerTestProfile(t, directory, 1, "127.0.0.1:2")
+	manifestPath := writeProviderManifest(t, directory, providerManifest{Version: 1, Providers: []providerManifestEntry{
+		{Name: "one", Profile: filepath.Base(first), Listen: unusedProviderTestAddress(t)},
+		{Name: "two", Profile: filepath.Base(second), Listen: unusedProviderTestAddress(t)},
+	}})
+	configs, err := loadProviderClients(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := parseRuntimeForTest(t, true, "--transport", "tcp", "--aggregate-bytes-per-sec", "1000000", "--max-sessions", "8")
+	limits, err := pep.NewSharedSessionLimits(opts.maxSessions, len(configs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget := pep.NewAggregateBudget(opts.aggregateBytesPerSec, opts.interactiveReserveBytesPerSec)
+	if budget == nil {
+		t.Fatal("aggregate budget was not built from the runtime options")
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	clients := make([]*pep.Client, len(configs))
+	for i := range configs {
+		clients[i], err = newRuntimeClient(configs[i].profile, configs[i].listen, opts, logger, nil, limits[i], budget)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Two providers must not each be handed the whole session budget. Budget
+	// sharing itself is asserted in the pep package, which can see the field.
+	for i := range clients {
+		if clients[i] == nil {
+			t.Fatalf("provider %d client was not built", i)
+		}
+	}
+	if limits[0].Reserved() != 2 || limits[1].Reserved() != 2 {
+		t.Fatalf("session reservations = %d and %d, want the shared budget divided", limits[0].Reserved(), limits[1].Reserved())
 	}
 }

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -297,11 +297,39 @@ queqiaod client \
 
 Manifest version 1 requires a nonempty, unique name, profile, and listener for
 every provider. Relative profile paths are resolved from the manifest
-directory. Each listener must use a literal loopback IP and a numeric port;
-`--listen` cannot be combined with `--providers`. Other client runtime flags
-apply to every provider. `--max-sessions` is shared across all provider
-listeners, and the metrics endpoint aggregates their activity. Logs add the
-manifest name and listener to each provider record.
+directory. Each listener must use a literal loopback IP and a port between 1
+and 65535; `--listen` cannot be combined with `--providers`.
+
+Every entry must name a separately enrolled device. Two entries which resolve
+to one device — a copied profile, a symlink, a hard link — are rejected at
+startup: two clients on one certificate would leave two renewal loops racing to
+save a single identity into two files.
+
+Process-wide budgets stay process-wide rather than being granted once per
+provider:
+
+- `--max-sessions` is the combined admission limit. Half of it is reserved in
+  equal shares, one share per provider, and half stays common. The reservation
+  is what keeps a standby provider able to accept a connection while a busy one
+  holds most of the common pool — without it a saturated primary starves the
+  failover target that is supposed to replace it.
+- `--aggregate-bytes-per-sec` and `--interactive-reserve-bytes-per-sec` pace
+  the whole process. Providers share one budget, so the configured rate is the
+  rate the uplink sees no matter how many providers are configured.
+- `--metrics-listen` aggregates every provider's activity into one endpoint.
+  Per-provider counters are not exported today; use the runtime log, which tags
+  each record with the manifest name and listener, to attribute activity.
+
+Other client runtime flags apply to each provider independently.
+
+All listeners bind before the first gateway is dialled, so a provider whose
+gateway is unreachable at startup cannot hold a healthy provider's SOCKS port
+down. Certificate renewal then runs for every provider concurrently.
+
+The process exits if any provider's listener stops, so a partially working
+client never looks healthy to a service manager. Run it under a supervisor
+that restarts it — a bare foreground `queqiaod client --providers` will not
+come back on its own.
 
 To let Clash/mihomo choose between these endpoints, define one SOCKS5 proxy for
 each listener and put them in a health-checked group. This `fallback` example

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -2,13 +2,13 @@
 
 > [!NOTE]
 > **Status:** Current operational guide for public protocol 1
-> **Last reviewed:** 2026-08-20
+> **Last reviewed:** 2026-08-21
 
 This guide takes you from an empty host to a working paired deployment: a
 provider gateway, one-time user enrollment, a desktop SOCKS client, and
-Clash/mihomo integration. It also covers service operation, upgrades, and
-rollback. Protocol 1 is the only supported wire protocol, so client and server
-must be upgraded together.
+Clash/mihomo integration. It also covers multi-provider clients, service
+operation, upgrades, and rollback. Protocol 1 is the only supported wire
+protocol, so client and server must be upgraded together.
 
 For a quick overview, start with the [repository README](../README.md). Use
 [known limitations](KNOWN-LIMITATIONS.md) to check whether the paired-gateway
@@ -256,6 +256,86 @@ The empty `--noproxy` is deliberate. Environments with `NO_PROXY=*` otherwise
 bypass even an explicitly supplied curl proxy and can produce a convincing but
 irrelevant result. Confirm that client and server `flows_started_total`
 counters increase during the request.
+
+## Connect to multiple providers
+
+One client process can maintain independent connections to several providers
+and expose one loopback SOCKS5 listener for each. Obtain a separate invitation
+from every provider and enroll each one into a clearly named profile:
+
+```sh
+# Use the Hong Kong provider's invitation in the first command.
+queqiaod enroll 'queqiao://enroll/…' \
+  --profile ~/.config/queqiao/hk.json \
+  --device-name alice-laptop
+
+# Use the US West provider's invitation in the second command.
+queqiaod enroll 'queqiao://enroll/…' \
+  --profile ~/.config/queqiao/us.json \
+  --device-name alice-laptop
+```
+
+Save the following manifest as `~/.config/queqiao/providers.json`:
+
+```json
+{
+  "version": 1,
+  "providers": [
+    {"name": "hong-kong", "profile": "hk.json", "listen": "127.0.0.1:1081"},
+    {"name": "us-west", "profile": "us.json", "listen": "127.0.0.1:1082"}
+  ]
+}
+```
+
+Start all configured providers together:
+
+```sh
+queqiaod client \
+  --providers ~/.config/queqiao/providers.json \
+  --metrics-listen 127.0.0.1:12090
+```
+
+Manifest version 1 requires a nonempty, unique name, profile, and listener for
+every provider. Relative profile paths are resolved from the manifest
+directory. Each listener must use a literal loopback IP and a numeric port;
+`--listen` cannot be combined with `--providers`. Other client runtime flags
+apply to every provider. `--max-sessions` is shared across all provider
+listeners, and the metrics endpoint aggregates their activity. Logs add the
+manifest name and listener to each provider record.
+
+To let Clash/mihomo choose between these endpoints, define one SOCKS5 proxy for
+each listener and put them in a health-checked group. This `fallback` example
+prefers Hong Kong while it is healthy and sends new connections to US West
+when its health check fails:
+
+```yaml
+proxies:
+  - name: queqiao-hong-kong
+    type: socks5
+    server: 127.0.0.1
+    port: 1081
+    udp: true
+  - name: queqiao-us-west
+    type: socks5
+    server: 127.0.0.1
+    port: 1082
+    udp: true
+
+proxy-groups:
+  - name: Queqiao
+    type: fallback
+    url: https://www.gstatic.com/generate_204
+    interval: 300
+    proxies:
+      - queqiao-hong-kong
+      - queqiao-us-west
+```
+
+Point the relevant Clash/mihomo rules at the `Queqiao` group. Queqiao itself
+does not select providers. Clash/mihomo can switch only new connections;
+existing connections are not migrated and fail if their provider becomes
+unavailable. Use a `url-test` group instead when lowest measured latency is
+more important than provider order.
 
 ## Upgrade an existing deployment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@ you choose the next document based on what you want to do.
 ## Use and operate Queqiao
 
 - [Deployment guide](DEPLOYING.md) — provider setup, invitations, desktop
-  enrollment, Clash/mihomo, service installation, monitoring, upgrades, and
-  rollback.
+  enrollment, multi-provider clients, Clash/mihomo, service installation,
+  monitoring, upgrades, and rollback.
 - [Runtime logging](LOGGING.md) — log locations, rotation, telemetry, and safe
   evidence collection.
 - [Mobile clients](MOBILE.md) — Android and iOS builds, product boundaries,

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -41,7 +41,7 @@ limitations](KNOWN-LIMITATIONS.md) before deploying it.
 | Contention | behavioral flow state, priority queues, reactive bulk isolation, and bounded opt-in TCP fallback striping |
 | Identity | one-time invitations, provider-pinned gateway identity, per-device mutual TLS, renewal, revocation, and per-user limits |
 | Operations | bounded JSON logs, metrics, local visualizer, service examples, release packaging, SBOMs, and rollback procedure |
-| Clients | macOS/Linux desktop and gateway builds available from source; Windows targets built but under testing; Android SOCKS export and iOS packet-tunnel clients under testing, all using the protocol-1 core |
+| Clients | one process per provider or one process serving several providers on separate loopback SOCKS5 listeners; macOS/Linux desktop and gateway builds available from source; Windows targets built but under testing; Android SOCKS export and iOS packet-tunnel clients under testing, all using the protocol-1 core |
 | Conformance | committed protocol-1 vectors for framing, acknowledgement, destinations, UDP, coding, and enrollment, replayed by the test suite |
 
 ## Evidence and open work

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -85,6 +85,12 @@ type ClientConfig struct {
 	// SessionLimit optionally shares admission across several clients in one
 	// process. Nil gives this client its own MaxSessions-sized limit.
 	SessionLimit *SessionLimit
+	// Budget optionally shares the aggregate byte budget across several
+	// clients in one process. Nil derives a private budget from
+	// AggregateBytesPerSec, which paces this client alone; a multi-provider
+	// process must share one budget or it offers the configured total once
+	// per provider.
+	Budget *limiter.Budget
 	// MaxPendingOpens bounds flows that are still establishing their remote
 	// transport. Keeping this separate from MaxSessions prevents a failed
 	// endpoint and its retries from occupying every healthy-flow slot.
@@ -233,27 +239,87 @@ type Client struct {
 // SessionLimit bounds concurrent local SOCKS sessions across one or more
 // clients. Admission is deliberately non-blocking so an overloaded listener
 // can reject promptly instead of accumulating unauthenticated local sockets.
+//
+// A limit may hold a private reservation as well as a share of a pool common
+// to every client. The reservation is what keeps a quiet provider able to
+// admit new flows while a busy sibling holds most of the common pool: a
+// failover target which cannot accept a session is not a failover target.
 type SessionLimit struct {
-	slots chan struct{}
+	reserved chan struct{}
+	shared   chan struct{}
+}
+
+// sessionSlot returns one admitted session to the pool it came from.
+type sessionSlot struct {
+	pool chan struct{}
+}
+
+func (s sessionSlot) release() {
+	if s.pool != nil {
+		<-s.pool
+	}
 }
 
 func NewSessionLimit(max int) (*SessionLimit, error) {
 	if max < 1 || max > maxConfiguredSessions {
 		return nil, fmt.Errorf("maximum sessions must be between 1 and %d", maxConfiguredSessions)
 	}
-	return &SessionLimit{slots: make(chan struct{}, max)}, nil
+	return &SessionLimit{shared: make(chan struct{}, max)}, nil
 }
 
-func (l *SessionLimit) acquire() bool {
+// NewSharedSessionLimits divides max across clients so their combined
+// admission never exceeds max while each client keeps a private reservation.
+// Half the budget is reserved in equal shares and half stays common, so an
+// idle provider can still burst into capacity its siblings are not using. When
+// max is too small to reserve a slot per client the whole budget stays common.
+func NewSharedSessionLimits(max, clients int) ([]*SessionLimit, error) {
+	if clients < 1 {
+		return nil, errors.New("shared session limits require at least one client")
+	}
+	if max < 1 || max > maxConfiguredSessions {
+		return nil, fmt.Errorf("maximum sessions must be between 1 and %d", maxConfiguredSessions)
+	}
+	reserve := max / (2 * clients)
+	shared := make(chan struct{}, max-reserve*clients)
+	limits := make([]*SessionLimit, clients)
+	for i := range limits {
+		limits[i] = &SessionLimit{shared: shared}
+		if reserve > 0 {
+			limits[i].reserved = make(chan struct{}, reserve)
+		}
+	}
+	return limits, nil
+}
+
+// Reserved reports the slots this limit holds for its own client alone.
+func (l *SessionLimit) Reserved() int {
+	if l == nil {
+		return 0
+	}
+	return cap(l.reserved)
+}
+
+// acquire takes the private reservation first so a client's own capacity is
+// never spent on a sibling. A nil limit admits: callers which never configured
+// one are unlimited rather than dead.
+func (l *SessionLimit) acquire() (sessionSlot, bool) {
+	if l == nil {
+		return sessionSlot{}, true
+	}
+	if l.reserved != nil {
+		select {
+		case l.reserved <- struct{}{}:
+			return sessionSlot{pool: l.reserved}, true
+		default:
+		}
+	}
 	select {
-	case l.slots <- struct{}{}:
-		return true
+	case l.shared <- struct{}{}:
+		return sessionSlot{pool: l.shared}, true
 	default:
-		return false
+		return sessionSlot{}, false
 	}
 }
-
-func (l *SessionLimit) release() { <-l.slots }
 
 // bulkConn is one pre-authenticated secondary QUIC connection reserved for
 // bulk lane joins.
@@ -367,9 +433,16 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		return nil, fmt.Errorf("maximum sessions must not exceed %d", maxConfiguredSessions)
 	}
 	if cfg.SessionLimit == nil {
-		cfg.SessionLimit, _ = NewSessionLimit(cfg.MaxSessions)
-	} else if cfg.SessionLimit.slots == nil {
+		limit, err := NewSessionLimit(cfg.MaxSessions)
+		if err != nil {
+			return nil, err
+		}
+		cfg.SessionLimit = limit
+	} else if cfg.SessionLimit.shared == nil {
 		return nil, errors.New("shared session limit is not initialized")
+	}
+	if cfg.Budget == nil {
+		cfg.Budget = NewAggregateBudget(cfg.AggregateBytesPerSec, cfg.InteractiveReserveBytesPerSec)
 	}
 	if cfg.MaxPendingOpens <= 0 {
 		cfg.MaxPendingOpens = defaultMaxPendingOpens
@@ -439,10 +512,8 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	return &Client{
 		cfg: cfg, udpHealth: newUDPHealth(cfg.UDPFailureThreshold, cfg.UDPCooldown),
 		credentials: cfg.Credentials,
-		budget: limiter.New(limiter.Config{
-			TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec,
-		}),
-		metrics: cfg.Metrics, sessionLimit: cfg.SessionLimit, pendingOpens: make(chan struct{}, cfg.MaxPendingOpens),
+		budget:      cfg.Budget,
+		metrics:     cfg.Metrics, sessionLimit: cfg.SessionLimit, pendingOpens: make(chan struct{}, cfg.MaxPendingOpens),
 		sendMemory: sendMemory, receiveMemory: receiveMemory, memoryLimits: memoryLimits,
 	}, nil
 }
@@ -512,12 +583,27 @@ func (c *Client) windows() flowWindows {
 }
 
 func (c *Client) Serve(ctx context.Context) error {
-	lc := net.ListenConfig{KeepAlive: 30 * time.Second}
-	listener, err := lc.Listen(ctx, "tcp", c.cfg.ListenAddr)
+	listener, err := ListenLocal(ctx, c.cfg.ListenAddr)
 	if err != nil {
 		return fmt.Errorf("listen on local SOCKS5 address: %w", err)
 	}
 	return c.ServeListener(ctx, listener)
+}
+
+// ListenLocal binds a local SOCKS5 listener. Serve and any caller which binds
+// ahead of ServeListener share it so both get identical socket options.
+func ListenLocal(ctx context.Context, address string) (net.Listener, error) {
+	lc := net.ListenConfig{KeepAlive: 30 * time.Second}
+	return lc.Listen(ctx, "tcp", address)
+}
+
+// NewAggregateBudget builds one byte budget several clients can share, so a
+// process running many clients paces to the configured total instead of
+// offering that total once per client. A zero rate means unpaced.
+func NewAggregateBudget(totalBytesPerSec, reserveBytesPerSec uint64) *limiter.Budget {
+	return limiter.New(limiter.Config{
+		TotalBytesPerSec: totalBytesPerSec, ReserveBytesPerSec: reserveBytesPerSec,
+	})
 }
 
 // Metrics exposes aggregate counters for an optional operator endpoint.
@@ -588,11 +674,11 @@ func (c *Client) ServeListener(ctx context.Context, listener net.Listener) error
 			}
 			return fmt.Errorf("accept local connection: %w", acceptErr)
 		}
-		if c.sessionLimit.acquire() {
+		if slot, admitted := c.sessionLimit.acquire(); admitted {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				defer c.sessionLimit.release()
+				defer slot.release()
 				c.handleLocal(ctx, conn)
 			}()
 		} else {

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -82,6 +82,9 @@ type ClientConfig struct {
 	FlowIdleTimeout  time.Duration
 	FlowMaxLifetime  time.Duration
 	MaxSessions      int
+	// SessionLimit optionally shares admission across several clients in one
+	// process. Nil gives this client its own MaxSessions-sized limit.
+	SessionLimit *SessionLimit
 	// MaxPendingOpens bounds flows that are still establishing their remote
 	// transport. Keeping this separate from MaxSessions prevents a failed
 	// endpoint and its retries from occupying every healthy-flow slot.
@@ -167,6 +170,7 @@ type Client struct {
 	cfg           ClientConfig
 	udpHealth     *udpHealth
 	budget        *limiter.Budget
+	sessionLimit  *SessionLimit
 	sendMemory    *memlimit.Budget
 	receiveMemory *memlimit.Budget
 	memoryLimits  flowMemoryLimits
@@ -225,6 +229,31 @@ type Client struct {
 	// their total-session slot, and leave capacity for established flows.
 	pendingOpens chan struct{}
 }
+
+// SessionLimit bounds concurrent local SOCKS sessions across one or more
+// clients. Admission is deliberately non-blocking so an overloaded listener
+// can reject promptly instead of accumulating unauthenticated local sockets.
+type SessionLimit struct {
+	slots chan struct{}
+}
+
+func NewSessionLimit(max int) (*SessionLimit, error) {
+	if max < 1 || max > maxConfiguredSessions {
+		return nil, fmt.Errorf("maximum sessions must be between 1 and %d", maxConfiguredSessions)
+	}
+	return &SessionLimit{slots: make(chan struct{}, max)}, nil
+}
+
+func (l *SessionLimit) acquire() bool {
+	select {
+	case l.slots <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *SessionLimit) release() { <-l.slots }
 
 // bulkConn is one pre-authenticated secondary QUIC connection reserved for
 // bulk lane joins.
@@ -337,6 +366,11 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	if cfg.MaxSessions > maxConfiguredSessions {
 		return nil, fmt.Errorf("maximum sessions must not exceed %d", maxConfiguredSessions)
 	}
+	if cfg.SessionLimit == nil {
+		cfg.SessionLimit, _ = NewSessionLimit(cfg.MaxSessions)
+	} else if cfg.SessionLimit.slots == nil {
+		return nil, errors.New("shared session limit is not initialized")
+	}
 	if cfg.MaxPendingOpens <= 0 {
 		cfg.MaxPendingOpens = defaultMaxPendingOpens
 	}
@@ -408,7 +442,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		budget: limiter.New(limiter.Config{
 			TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec,
 		}),
-		metrics: cfg.Metrics, pendingOpens: make(chan struct{}, cfg.MaxPendingOpens),
+		metrics: cfg.Metrics, sessionLimit: cfg.SessionLimit, pendingOpens: make(chan struct{}, cfg.MaxPendingOpens),
 		sendMemory: sendMemory, receiveMemory: receiveMemory, memoryLimits: memoryLimits,
 	}, nil
 }
@@ -536,7 +570,6 @@ func (c *Client) ServeListener(ctx context.Context, listener net.Listener) error
 	go c.watchUplink(ctx, uplink)
 
 	var wg sync.WaitGroup
-	semaphore := make(chan struct{}, c.cfg.MaxSessions)
 	go func() {
 		<-ctx.Done()
 		_ = listener.Close()
@@ -555,15 +588,14 @@ func (c *Client) ServeListener(ctx context.Context, listener net.Listener) error
 			}
 			return fmt.Errorf("accept local connection: %w", acceptErr)
 		}
-		select {
-		case semaphore <- struct{}{}:
+		if c.sessionLimit.acquire() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				defer func() { <-semaphore }()
+				defer c.sessionLimit.release()
 				c.handleLocal(ctx, conn)
 			}()
-		default:
+		} else {
 			// The client may still be waiting for the two-byte SOCKS greeting
 			// response. A request-level reply starts with 0x05, 0x01 and is then
 			// misread as "unsupported authentication method 0x01" by the mobile

--- a/internal/pep/config_test.go
+++ b/internal/pep/config_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,17 +90,108 @@ func TestClientSessionLimitCanBeShared(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if !clients[0].sessionLimit.acquire() {
+	slot, admitted := clients[0].sessionLimit.acquire()
+	if !admitted {
 		t.Fatal("first client was not admitted")
 	}
-	if clients[1].sessionLimit.acquire() {
+	if _, admitted := clients[1].sessionLimit.acquire(); admitted {
 		t.Fatal("second client exceeded the shared session limit")
 	}
-	clients[0].sessionLimit.release()
-	if !clients[1].sessionLimit.acquire() {
+	slot.release()
+	sibling, admitted := clients[1].sessionLimit.acquire()
+	if !admitted {
 		t.Fatal("released shared session slot was not reusable")
 	}
-	clients[1].sessionLimit.release()
+	sibling.release()
+}
+
+func TestSharedSessionLimitsReserveCapacityPerClient(t *testing.T) {
+	limits, err := NewSharedSessionLimits(8, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if limits[0].Reserved() != 2 || limits[1].Reserved() != 2 {
+		t.Fatalf("reservations = %d and %d, want 2 each", limits[0].Reserved(), limits[1].Reserved())
+	}
+	// The first client drains its own reservation and then the common pool.
+	var held []sessionSlot
+	for range 6 {
+		slot, admitted := limits[0].acquire()
+		if !admitted {
+			t.Fatalf("greedy client was capped at %d sessions, want its reservation plus the common pool", len(held))
+		}
+		held = append(held, slot)
+	}
+	if _, admitted := limits[0].acquire(); admitted {
+		t.Fatal("greedy client exceeded the combined limit")
+	}
+	// Its sibling still has its own reservation, which is the whole point: a
+	// failover target which cannot accept a session is not a failover target.
+	for i := range 2 {
+		if _, admitted := limits[1].acquire(); !admitted {
+			t.Fatalf("reserved slot %d was consumed by the busy sibling", i+1)
+		}
+	}
+	if _, admitted := limits[1].acquire(); admitted {
+		t.Fatal("sibling exceeded its reservation while the common pool was empty")
+	}
+	for _, slot := range held {
+		slot.release()
+	}
+}
+
+func TestSharedSessionLimitsStayCommonWhenTooSmallToReserve(t *testing.T) {
+	limits, err := NewSharedSessionLimits(3, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, limit := range limits {
+		if limit.Reserved() != 0 {
+			t.Fatalf("client %d reserved %d slots from a budget too small to divide", i, limit.Reserved())
+		}
+	}
+	admitted := 0
+	for _, limit := range limits {
+		if _, ok := limit.acquire(); ok {
+			admitted++
+		}
+	}
+	if admitted != 3 {
+		t.Fatalf("admitted %d sessions, want the whole common budget of 3", admitted)
+	}
+}
+
+func TestNewClientRejectsUninitializedSharedSessionLimit(t *testing.T) {
+	_, credentials := testCertificate(t)
+	_, err := NewClient(ClientConfig{
+		ListenAddr: "127.0.0.1:0", RemoteAddr: "127.0.0.1:1",
+		Credentials: credentials, SessionLimit: &SessionLimit{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("uninitialized shared session limit was accepted: %v", err)
+	}
+}
+
+func TestClientsCanShareOneAggregateBudget(t *testing.T) {
+	_, credentials := testCertificate(t)
+	budget := NewAggregateBudget(1<<20, 0)
+	if budget == nil {
+		t.Fatal("aggregate budget was not built")
+	}
+	clients := make([]*Client, 2)
+	for i := range clients {
+		client, err := NewClient(ClientConfig{
+			ListenAddr: "127.0.0.1:0", RemoteAddr: "127.0.0.1:1",
+			Credentials: credentials, AggregateBytesPerSec: 1 << 20, Budget: budget,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients[i] = client
+	}
+	if clients[0].budget != budget || clients[1].budget != budget {
+		t.Fatal("clients did not share the supplied aggregate budget")
+	}
 }
 
 func TestClientCredentialUpdateCannotChangeIdentity(t *testing.T) {

--- a/internal/pep/config_test.go
+++ b/internal/pep/config_test.go
@@ -73,6 +73,35 @@ func TestClientAdmissionDefaultsAndPendingOpenBound(t *testing.T) {
 	}
 }
 
+func TestClientSessionLimitCanBeShared(t *testing.T) {
+	_, credentials := testCertificate(t)
+	limit, err := NewSessionLimit(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clients := make([]*Client, 2)
+	for i := range clients {
+		clients[i], err = NewClient(ClientConfig{
+			ListenAddr: "127.0.0.1:0", RemoteAddr: "127.0.0.1:1",
+			Credentials: credentials, SessionLimit: limit,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !clients[0].sessionLimit.acquire() {
+		t.Fatal("first client was not admitted")
+	}
+	if clients[1].sessionLimit.acquire() {
+		t.Fatal("second client exceeded the shared session limit")
+	}
+	clients[0].sessionLimit.release()
+	if !clients[1].sessionLimit.acquire() {
+		t.Fatal("released shared session slot was not reusable")
+	}
+	clients[1].sessionLimit.release()
+}
+
 func TestClientCredentialUpdateCannotChangeIdentity(t *testing.T) {
 	_, credentials := testCertificate(t)
 	client, err := NewClient(ClientConfig{

--- a/scripts/check_gosec.py
+++ b/scripts/check_gosec.py
@@ -50,6 +50,9 @@ BASELINE = {
     ("G301", "mobile/tools/notices/main.go"): 1,
     ("G302", "cmd/queqiaopack/main.go"): 2,
     ("G304", "cmd/queqiaod/main.go"): 2,
+    # The multi-provider manifest is opened from the operator's own --providers
+    # path, on the same footing as the reviewed --profile reads above it.
+    ("G304", "cmd/queqiaod/providers.go"): 1,
     ("G304", "cmd/queqiaopack/main.go"): 6,
     ("G304", "cmd/queqiaoref/main.go"): 2,
     ("G304", "internal/identity/enrollment.go"): 1,


### PR DESCRIPTION
## Summary

- add `queqiaod client --providers` with a versioned manifest that maps each client profile to a dedicated loopback SOCKS5 listener, validates the complete manifest, and binds every listener before startup
- run an independent `pep.Client` and certificate-renewal loop per provider while sharing the process-wide session limit and metrics registry; tag provider logs and stop the service if any listener exits unexpectedly
- document multi-provider enrollment, manifest setup, and Clash/mihomo routing, including that provider selection applies to new flows and does not change the server or wire protocol

## Testing

- `go test ./cmd/queqiaod ./internal/pep -count=1`
- `go vet ./...`
- `test -z "$(gofmt -l .)"`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 -checks=all,-U1000 ./...`
- `go test -short -timeout 20m ./...` — modified packages pass, but the full command fails locally in the unchanged `internal/pathsim.TestPerFlowPolicerBucketFollowsItsOwnRate`: the UDP burst reaches only 185–488 of 2,000 packets and records no relay-side drop
