### PR TITLE
fix: keep the chunk size inside the aggregate budget's burst

### DIFF
--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -511,7 +511,11 @@ func validateRuntime(opts runtimeOptions, client bool) error {
 	if opts.dialTimeout <= 0 || opts.handshakeTimeout <= 0 {
 		return errors.New("dial and handshake timeouts must be positive")
 	}
-	if opts.aggregateBytesPerSec == 0 && opts.interactiveReserveBytesPerSec != 0 || opts.interactiveReserveBytesPerSec > opts.aggregateBytesPerSec {
+	// The reserve is withheld from bulk traffic, so it has to leave some of
+	// the budget behind: a reserve equal to the whole of it would stop bulk
+	// entirely rather than slow it down.
+	if opts.aggregateBytesPerSec == 0 && opts.interactiveReserveBytesPerSec != 0 ||
+		opts.aggregateBytesPerSec != 0 && opts.interactiveReserveBytesPerSec >= opts.aggregateBytesPerSec {
 		return errors.New("invalid aggregate/interactive byte budget")
 	}
 	if opts.adaptiveMinBytesSec == 0 || opts.adaptiveMaxBytesSec < opts.adaptiveMinBytesSec {

--- a/internal/limiter/budget.go
+++ b/internal/limiter/budget.go
@@ -72,6 +72,34 @@ func (b *Budget) refill(now time.Time) {
 	b.last = now
 }
 
+// capacity is the largest single request this budget can ever admit for one
+// class.  Bulk is confined to bulk capacity; interactive may also draw on
+// whatever bulk capacity is idle, so its ceiling is the sum.  These fields are
+// fixed by New and never written afterwards, so reading them needs no lock.
+func (b *Budget) capacity(interactive bool) float64 {
+	total := b.bulkCap
+	if interactive {
+		total += b.intCap
+	}
+	return total
+}
+
+// MaxRequest reports the largest single request Wait can ever admit for this
+// class.  Anything above it is refused outright with ErrInvalidRequest rather
+// than slept on, so a caller that chooses its own request sizes -- a sending
+// chunk size, say -- has to stay at or below this to be paced rather than
+// rejected.  A nil Budget paces nothing and so imposes no ceiling.
+func (b *Budget) MaxRequest(interactive bool) int {
+	if b == nil {
+		return math.MaxInt
+	}
+	total := b.capacity(interactive)
+	if total >= float64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(total)
+}
+
 // Wait reserves n bytes.  A nil Budget disables pacing.  Interactive traffic
 // can consume its reserve and any currently idle bulk capacity; bulk traffic
 // can consume only bulk capacity.  The request is never partially released,
@@ -85,11 +113,7 @@ func (b *Budget) Wait(ctx context.Context, n int, interactive bool) error {
 	// configuration (for example a 1 MiB frame on a 10 KiB/s budget) would
 	// sleep and retry forever, retaining application and replay buffers until
 	// the caller's much longer timeout expires.
-	maxCapacity := b.bulkCap
-	if interactive {
-		maxCapacity += b.intCap
-	}
-	if float64(n) > maxCapacity {
+	if float64(n) > b.capacity(interactive) {
 		return ErrInvalidRequest
 	}
 	for {

--- a/internal/limiter/budget_test.go
+++ b/internal/limiter/budget_test.go
@@ -2,6 +2,7 @@ package limiter
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 )
@@ -59,5 +60,49 @@ func TestRequestLargerThanBurstFailsImmediately(t *testing.T) {
 	}
 	if err := b.Wait(context.Background(), int(b.bulkCap)+1, false); err != ErrInvalidRequest {
 		t.Fatalf("large bulk request error = %v, want %v", err, ErrInvalidRequest)
+	}
+}
+
+// MaxRequest exists so a caller that picks its own request sizes can stay
+// inside what Wait will admit instead of discovering the refusal at send time,
+// which makes agreement with Wait the whole point of it.
+func TestMaxRequestIsTheAdmissionCeiling(t *testing.T) {
+	if got := (*Budget)(nil).MaxRequest(false); got != math.MaxInt {
+		t.Fatalf("disabled budget ceiling = %d, want no ceiling", got)
+	}
+	cfg := Config{TotalBytesPerSec: 1024, ReserveBytesPerSec: 512, Burst: time.Millisecond}
+	b := New(cfg)
+	if b == nil {
+		t.Fatal("expected enabled budget")
+	}
+	for _, interactive := range []bool{false, true} {
+		ceiling := b.MaxRequest(interactive)
+		if err := b.Wait(context.Background(), ceiling+1, interactive); err != ErrInvalidRequest {
+			t.Fatalf("interactive=%v above ceiling error = %v, want %v", interactive, err, ErrInvalidRequest)
+		}
+		// A full bucket, so a request at the ceiling is admitted without
+		// waiting rather than merely being admissible in principle.
+		if err := New(cfg).Wait(context.Background(), ceiling, interactive); err != nil {
+			t.Fatalf("interactive=%v at ceiling %d was refused: %v", interactive, ceiling, err)
+		}
+	}
+}
+
+// Bulk is the tighter class, and every budget that admits bulk at all admits a
+// whole 64 KiB frame of it. Endpoints size their chunks against this floor, so
+// it is a promise rather than an implementation detail.
+func TestBulkCeilingNeverFallsBelowTheBurstFloor(t *testing.T) {
+	for _, cfg := range []Config{
+		{TotalBytesPerSec: 1},
+		{TotalBytesPerSec: 2, ReserveBytesPerSec: 1},
+		{TotalBytesPerSec: 1 << 20, ReserveBytesPerSec: 1<<20 - 1, Burst: time.Microsecond},
+	} {
+		b := New(cfg)
+		if b == nil {
+			t.Fatalf("%+v: expected enabled budget", cfg)
+		}
+		if got := b.MaxRequest(false); got < 64*1024 {
+			t.Fatalf("%+v: bulk ceiling = %d, want at least 64 KiB", cfg, got)
+		}
 	}
 }

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -382,9 +382,19 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	if cfg.AggregateBytesPerSec == 0 && cfg.InteractiveReserveBytesPerSec != 0 {
 		return nil, errors.New("interactive reserve requires an aggregate byte budget")
 	}
-	if cfg.InteractiveReserveBytesPerSec > cfg.AggregateBytesPerSec {
-		return nil, errors.New("interactive reserve cannot exceed aggregate byte budget")
+	// The reserve is withheld from bulk traffic, so a reserve equal to the
+	// whole budget leaves bulk not merely slow but unable to send a byte: the
+	// budget has no bulk capacity to admit against and refuses every bulk
+	// request outright. Require the reserve to leave something behind.
+	if cfg.AggregateBytesPerSec != 0 && cfg.InteractiveReserveBytesPerSec >= cfg.AggregateBytesPerSec {
+		return nil, errors.New("interactive reserve must leave bulk capacity below the aggregate byte budget")
 	}
+	budget := limiter.New(limiter.Config{
+		TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec,
+	})
+	// Before resolveMemoryLimits: the per-flow send budget is checked against
+	// the chunk size, and the chunk that has to fit there is the corrected one.
+	cfg.ChunkSize = chunkSizeForBudget(cfg.ChunkSize, budget)
 	if cfg.FallbackDelay <= 0 {
 		cfg.FallbackDelay = 300 * time.Millisecond
 	}
@@ -404,10 +414,7 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 	return &Client{
 		cfg: cfg, udpHealth: newUDPHealth(cfg.UDPFailureThreshold, cfg.UDPCooldown),
-		credentials: cfg.Credentials,
-		budget: limiter.New(limiter.Config{
-			TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec,
-		}),
+		credentials: cfg.Credentials, budget: budget,
 		metrics: cfg.Metrics, pendingOpens: make(chan struct{}, cfg.MaxPendingOpens),
 		sendMemory: sendMemory, receiveMemory: receiveMemory, memoryLimits: memoryLimits,
 	}, nil

--- a/internal/pep/config_test.go
+++ b/internal/pep/config_test.go
@@ -1,6 +1,7 @@
 package pep
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/limiter"
 	"github.com/bojieli/queqiao/internal/protocol"
 )
 
@@ -26,6 +28,10 @@ func TestClientRejectsUnserviceableConfiguration(t *testing.T) {
 		},
 		"reserve above budget": func(c *ClientConfig) {
 			c.AggregateBytesPerSec = 1
+			c.InteractiveReserveBytesPerSec = 2
+		},
+		"reserve consumes whole budget": func(c *ClientConfig) {
+			c.AggregateBytesPerSec = 2
 			c.InteractiveReserveBytesPerSec = 2
 		},
 		"idle exceeds lifetime": func(c *ClientConfig) {
@@ -166,6 +172,10 @@ func TestServerRejectsUnserviceableConfiguration(t *testing.T) {
 			c.AggregateBytesPerSec = 1
 			c.InteractiveReserveBytesPerSec = 2
 		},
+		"reserve consumes whole budget": func(c *ServerConfig) {
+			c.AggregateBytesPerSec = 2
+			c.InteractiveReserveBytesPerSec = 2
+		},
 		"idle exceeds lifetime": func(c *ServerConfig) {
 			c.FlowIdleTimeout = 2 * time.Second
 			c.FlowMaxLifetime = time.Second
@@ -243,5 +253,68 @@ func TestServerQUICStreamCapacitySupportsMobileSessions(t *testing.T) {
 	config := quicServerConfig(flowWindows{})
 	if config.MaxIncomingStreams < 1024 {
 		t.Fatalf("server QUIC stream capacity = %d, want at least 1024", config.MaxIncomingStreams)
+	}
+}
+
+// A chunk larger than the aggregate budget's burst can never be admitted: the
+// budget refuses it outright rather than pacing it, the DATA frame carrying it
+// fails to enqueue, and the lane that was carrying it is failed and retired.
+// The configured chunk size is corrected to what the budget can carry so that
+// an operator's rate limit slows the endpoint down instead of taking its lanes
+// apart.
+func TestChunkSizeIsCappedByAggregateBurst(t *testing.T) {
+	serverCredentials, clientCredentials := testCertificate(t)
+	// 128 KiB chunks against 64 KiB/s: a quarter-second burst is well under
+	// the 64 KiB floor, so the floor is the ceiling and every chunk as
+	// configured would have been refused.
+	const rate = 64 * 1024
+	newEndpoints := func(t *testing.T, aggregate uint64) (int, *limiter.Budget, int, *limiter.Budget) {
+		t.Helper()
+		client, err := NewClient(ClientConfig{
+			ListenAddr: "127.0.0.1:0", RemoteAddr: "127.0.0.1:1", Credentials: clientCredentials,
+			ChunkSize: protocol.MaxPayload, AggregateBytesPerSec: aggregate,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		server, err := NewServer(ServerConfig{
+			ListenAddr: "127.0.0.1:0", Credentials: serverCredentials,
+			ChunkSize: protocol.MaxPayload, AggregateBytesPerSec: aggregate,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return client.cfg.ChunkSize, client.budget, server.cfg.ChunkSize, server.budget
+	}
+
+	clientChunk, clientBudget, serverChunk, serverBudget := newEndpoints(t, rate)
+	for name, endpoint := range map[string]struct {
+		chunkSize int
+		budget    *limiter.Budget
+	}{
+		"client": {clientChunk, clientBudget},
+		"server": {serverChunk, serverBudget},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if endpoint.chunkSize >= protocol.MaxPayload {
+				t.Fatalf("chunk size %d was not capped by the aggregate burst", endpoint.chunkSize)
+			}
+			// A cap, not a collapse: a budget that admits bulk at all admits a
+			// whole 64 KiB frame of it, so the correction never leaves the
+			// endpoint sending uselessly small chunks.
+			if endpoint.chunkSize < 64*1024 {
+				t.Fatalf("chunk size %d narrowed below the burst floor", endpoint.chunkSize)
+			}
+			if err := endpoint.budget.Wait(context.Background(), endpoint.chunkSize, false); err != nil {
+				t.Fatalf("a full chunk was not admitted by its own budget: %v", err)
+			}
+		})
+	}
+
+	// Without a budget there is nothing to fit inside, and the chunk size the
+	// operator asked for is the one they get.
+	unpacedClient, _, unpacedServer, _ := newEndpoints(t, 0)
+	if unpacedClient != protocol.MaxPayload || unpacedServer != protocol.MaxPayload {
+		t.Fatalf("unpaced chunk sizes = %d/%d, want %d", unpacedClient, unpacedServer, protocol.MaxPayload)
 	}
 }

--- a/internal/pep/flow.go
+++ b/internal/pep/flow.go
@@ -5,9 +5,33 @@ import (
 	"io"
 	"net"
 	"time"
+
+	"github.com/bojieli/queqiao/internal/limiter"
 )
 
 const defaultChunkSize = 32 * 1024
+
+// chunkSizeForBudget caps a configured chunk size at what the endpoint's
+// aggregate budget can admit in one request.
+//
+// The budget refuses a request larger than its burst outright instead of
+// sleeping on one it can never satisfy, and that refusal now reaches the data
+// plane: a DATA frame above the burst fails its enqueue, and a lane whose
+// chunk fails to send is failed and retired. So an oversized chunk does not
+// pace the endpoint slowly, it tears its lanes down. Correct it here, where
+// the chunk size is a sending policy the endpoint chooses, rather than let it
+// be discovered one lane at a time.
+//
+// Bulk is the tighter of the two classes and any flow may be classified bulk,
+// so size every chunk to fit there. A budget that admits bulk at all admits at
+// least 64 KiB of it, so this never narrows a chunk to something pathological,
+// and a disabled budget imposes no ceiling at all.
+func chunkSizeForBudget(chunkSize int, budget *limiter.Budget) int {
+	if capacity := budget.MaxRequest(false); capacity < chunkSize {
+		return capacity
+	}
+	return chunkSize
+}
 
 type FlowStats struct {
 	Started   time.Time

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -233,8 +233,12 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.AggregateBytesPerSec == 0 && cfg.InteractiveReserveBytesPerSec != 0 {
 		return nil, errors.New("interactive reserve requires an aggregate byte budget")
 	}
-	if cfg.InteractiveReserveBytesPerSec > cfg.AggregateBytesPerSec {
-		return nil, errors.New("interactive reserve cannot exceed aggregate byte budget")
+	// The reserve is withheld from bulk traffic, so a reserve equal to the
+	// whole budget leaves bulk not merely slow but unable to send a byte: the
+	// budget has no bulk capacity to admit against and refuses every bulk
+	// request outright. Require the reserve to leave something behind.
+	if cfg.AggregateBytesPerSec != 0 && cfg.InteractiveReserveBytesPerSec >= cfg.AggregateBytesPerSec {
+		return nil, errors.New("interactive reserve must leave bulk capacity below the aggregate byte budget")
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -245,6 +249,8 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if !cfg.EnableTCP && !cfg.EnableQUIC {
 		cfg.EnableTCP = true
 	}
+	budget := limiter.New(limiter.Config{TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec})
+	cfg.ChunkSize = chunkSizeForBudget(cfg.ChunkSize, budget)
 	server := &Server{
 		cfg:             cfg,
 		semaphore:       make(chan struct{}, cfg.MaxSessions),
@@ -252,7 +258,7 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		enrollments:     make(chan struct{}, min(cfg.MaxSessions, 64)),
 		sessions:        make(map[[16]byte]*serverFlow),
 		accountSessions: make(map[string]int),
-		budget:          limiter.New(limiter.Config{TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec}),
+		budget:          budget,
 		metrics:         cfg.Metrics,
 		udpRelays:       newUDPRelayStore(),
 	}


### PR DESCRIPTION
## Summary

- cap the configured chunk size at what the endpoint's aggregate budget can admit in one request
- reject an interactive reserve equal to the whole aggregate budget, which leaves bulk unable to send at all
- add `limiter.Budget.MaxRequest`, the admission ceiling `Wait` already enforces, so callers can size their own writes against it

Follow-up to #9.

## Problem

`Budget.Wait` refuses a request larger than its burst capacity outright, on purpose: sleeping on a request it can never satisfy would hold application and replay buffers until a much longer timeout expired. Before #9 the budget never saw an application byte, so that refusal was unreachable. Now that admission runs in `enqueueFrameWritten`, it is on the data path — and a refusal there is not a slowdown, it is a teardown:

`sendChunk` returns the error → `runLanePuller` calls `sched.Fail` and returns → the lane stops carrying data.

So an oversized chunk does not pace the endpoint slowly, it takes its lanes apart, one after another, for as long as the configuration stands.

Two configurations reach it:

- **Chunk above the burst.** `ChunkSize` is accepted up to `protocol.MaxPayload` (128 KiB), while bulk burst capacity floors at 64 KiB. A chunk above 64 KiB with an aggregate cap under ~256 KiB/s is refused every time.
- **Reserve equal to the budget.** `InteractiveReserveBytesPerSec == AggregateBytesPerSec` passes validation today and makes `bulkCap` zero, so *every* bulk request is refused whatever the chunk size. No chunk size fixes this one.

Defaults reach neither: a 32 KiB chunk against a 64 KiB floor, and no reserve.

## Solution

Correct the chunk size where it is chosen rather than discover it one lane at a time. `chunkSizeForBudget` caps it at `budget.MaxRequest(false)` — bulk, the tighter of the two classes, since any flow may be classified bulk. A budget that admits bulk at all admits at least 64 KiB of it, so the correction is a cap and never a collapse; a disabled budget imposes no ceiling. This matches how an out-of-range `ChunkSize` is already handled: corrected as the sending policy it is, not allowed onto the wire.

The reserve case cannot be capped into working, so it is rejected at config time in `NewClient`, `NewServer`, and `queqiaod`'s own flag validation.

`MaxRequest` is factored out of the check `Wait` was already making, and `Wait` now calls the same helper, so the two cannot drift.

No wire protocol change.

## Testing

- `go test -short -timeout 20m ./...`
- `go vet ./...`
- `python3 -m unittest discover -s scripts -p 'test_*.py'`
- `test -z "$(gofmt -l .)"`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 -checks=all,-U1000 ./...`
- `go test -race -count=1 -timeout 30m ./internal/pep ./internal/limiter`

`TestChunkSizeIsCappedByAggregateBurst` was confirmed to fail without the cap (`chunk size 131072 was not capped by the aggregate burst`, both endpoints) and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmY3X161p6YUz1ozCN7ZrT
