### PR TITLE
test: run the rate calibration where it can measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
 
   # Run the portable suite on every advertised native OS and architecture.
   # -short skips the tests that bring QUIC up across an emulated 300 ms
-  # erasure path. Those run natively in deep.yml and release-candidate.yml.
+  # erasure path, and the emulator calibrations that need an uncontended host
+  # to measure anything. Those run natively in deep.yml and
+  # release-candidate.yml.
   test:
     timeout-minutes: 30
     strategy:

--- a/internal/pathsim/capacity_test.go
+++ b/internal/pathsim/capacity_test.go
@@ -157,6 +157,20 @@ func TestForwardingCapacity(t *testing.T) {
 // limiter's queue is sized from the product and is exactly where a fault would
 // hide.
 func TestRateLimiterDeliversItsConfiguredRate(t *testing.T) {
+	if testing.Short() {
+		// This calibration needs a host that can generate several hundred
+		// Mbit/s while it simultaneously paces, shapes and polices the same
+		// traffic. The per-PR matrix is the wrong place to ask for that: six
+		// runners, packages in parallel, and no control over what else shares
+		// the core. A cell there can clear both load guards and still
+		// under-deliver because the generator and the shaper are competing,
+		// which reports a limiter fault the limiter did not commit --
+		// observed on windows-11-arm and on macos-15-intel, a different
+		// runner each time. deep.yml and release-candidate.yml run this
+		// without -short and with -p=1, which is the serialised, uncontended
+		// condition a measurement of this kind has to have to mean anything.
+		t.Skip("rate calibration is meaningful only on an uncontended host; runs in deep.yml")
+	}
 	rates := []float64{50, 200, 400}
 	if raceDetectorEnabled {
 		// Race instrumentation capped the two-core hosted runner near 180


### PR DESCRIPTION
## Summary

`internal/pathsim.TestRateLimiterDeliversItsConfiguredRate` has been the only thing making `main` red. It fails on a different runner each time — `windows-11-arm` on #11's first CI, `macos-15-intel` on the merges of #9 and #12 — which is the signature of contention, not of a defect.

It is not a broken test, and it is not one to delete. It asks whether the emulator's own rate limiter delivers the rate it was configured for. Every utilisation claim taken through that emulator rests on the answer: without it, "the transport under-used the link" and "the emulator never supplied the link" are indistinguishable.

The problem is where it runs, not what it checks. To answer its question it must generate several hundred Mbit/s while simultaneously pacing, shaping and policing the same traffic. The per-PR matrix cannot offer that — six runners, packages in parallel, nothing owning a core. Its two existing guards (unshaped headroom, and offered load) can both pass while the generator and the shaper still compete for cores, and the cell then reports a limiter fault the limiter did not commit. That is exactly what the `windows-11-arm` failure looked like: 791 Mbit/s unshaped, 71 of 75 Mbit/s offered — both guards cleared — and 0.69 delivered.

So it is skipped under `-short`, which is what `ci.yml` runs.

## What still runs it

`deep.yml` (weekly + on demand) and `release-candidate.yml` (before every RC) run without `-short` and with `-p=1`. The full nine-cell matrix keeps running there, serialised — the only condition under which the measurement means anything. Verified locally: all nine cells pass in 50s without `-short`, and the test skips cleanly with it.

This is the split those workflows exist for, and the one the sibling emulator sweeps in `tworegime_test.go` already use.

## Trade

Coverage moves from every PR to weekly and pre-release. That is deliberate: it is the intended trade for a measurement the per-PR environment is not capable of making.

## Not changed

`TestForwardingCapacity`, in the same file, is the same class of host-speed-dependent calibration with a hard 100 Mbit/s floor and no skip guard at all. It has not been observed failing, so I left it alone — but it is the next candidate if CI goes red again.

## Testing

- `go test -short ./internal/pathsim` — calibration skips, package passes
- `go test -run TestRateLimiterDeliversItsConfiguredRate ./internal/pathsim` — all 9 cells pass
- `go test -short -timeout 20m ./...` — clean
- `go vet ./...`, `gofmt -l .`, `actionlint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2N6DGePAKmKHfssRk1GP