### PR TITLE
test: move the forwarding-capacity floor to the deep runs

### DIFF
--- a/internal/pathsim/capacity_test.go
+++ b/internal/pathsim/capacity_test.go
@@ -140,6 +140,15 @@ func blast(t *testing.T, cfg Config, duration time.Duration, offeredMbits float6
 // TestForwardingCapacity measures what the emulator itself can forward with no
 // rate limiter, which bounds every transport number taken through it.
 func TestForwardingCapacity(t *testing.T) {
+	if testing.Short() {
+		// The floor below is a statement about the host, not about the
+		// emulator: a runner sharing its cores can forward under 100 Mbit/s
+		// while the emulator is perfectly correct. Unlike the calibration
+		// below, this one has no load guard that could tell those apart, so
+		// on the per-PR matrix it is the more fragile of the two. It belongs
+		// with the calibration it bounds, in the serialised deep runs.
+		t.Skip("forwarding capacity measures the host; runs in deep.yml")
+	}
 	for _, rtt := range []time.Duration{0, 20 * time.Millisecond, 200 * time.Millisecond} {
 		got := blast(t, Config{OneWayDelay: rtt / 2}, 3*time.Second, 0).deliveredMbits
 		t.Logf("rtt=%v unlimited capacity=%.0f Mbit/s", rtt, got)


### PR DESCRIPTION
## Summary

Follow-on to #14. `TestForwardingCapacity` is the sibling of the calibration moved there, and the last host-speed-dependent assertion left in the `-short` path.

Its floor is a statement about the host, not about the emulator — a runner sharing its cores can forward under 100 Mbit/s while the emulator is entirely correct.

It is in fact **the more fragile of the two**. `TestRateLimiterDeliversItsConfiguredRate` has an unshaped-headroom guard and an offered-load guard, either of which can skip a cell the host cannot support. This one has neither, so a contended runner has no way to report anything but failure. It simply had not gone red yet, which is the only reason #14 left it alone.

Skipped under `-short` alongside the calibration it bounds. `deep.yml` (weekly + on demand) and `release-candidate.yml` keep running both, serialised under `-p=1`.

## Checked the rest of the package

The remaining `pathsim` tests in the `-short` path are seeded statistics and ordering checks — deterministic. The one timing assertion, `TestRelayAppliesRoundTripDelay`, is a *lower* bound on delay, so a slow host makes it pass more easily rather than less. After this, nothing in `pathsim`'s `-short` path depends on how fast the runner is.

## Side benefit

`internal/pathsim` under `-short` drops from ~12s to ~1.2s, on each of the six matrix runners.

## Trade

Same as #14, and deliberate: the emulator's forwarding floor is now checked weekly and before each release candidate rather than on every PR.

## Testing

- `go test -short ./internal/pathsim` — both calibrations skip, package passes in 1.2s
- `go test -run TestForwardingCapacity ./internal/pathsim` — runs and passes
- `go test -short -timeout 20m ./...` — clean
- `go vet ./...`, `gofmt -l .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2N6DGePAKmKHfssRk1GP