### PR TITLE
test: stop the UDP associate budget colliding with its fallback delay

### DIFF
--- a/internal/pep/udp_rescue_test.go
+++ b/internal/pep/udp_rescue_test.go
@@ -224,7 +224,13 @@ func TestIntermittentUDPBlockingReturnsToQUIC(t *testing.T) {
 
 func openTestUDPAssociation(t *testing.T, control net.Conn) *net.UDPAddr {
 	t.Helper()
-	_ = control.SetDeadline(time.Now().Add(5 * time.Second))
+	// Comfortably above the FallbackDelay its callers configure. Associating
+	// may legitimately fall back from QUIC to TCP, and a budget equal to the
+	// fallback delay -- which this was -- turns any fallback into a failed
+	// read instead of a slower success. On a contended runner that is the
+	// difference between a green build and an i/o timeout attributed to the
+	// rescue path, which is not where the time went.
+	_ = control.SetDeadline(time.Now().Add(30 * time.Second))
 	if _, err := control.Write([]byte{5, 1, 0}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## The failure

`main` went red on `macos-15/arm64` right after #14:

```
udpresume_test.go:227: read tcp 127.0.0.1:49377->127.0.0.1:49376: i/o timeout
```

## Root cause

`openTestUDPAssociation` gave the SOCKS greeting and UDP ASSOCIATE exchange a **5s deadline**. Both of its callers configure the client with **`FallbackDelay: 5 * time.Second`**. They are equal, so any fallback from QUIC to TCP during association — legitimate, and likelier on a contended runner — converts a slower success into a failed read.

Reproduced under 12-way contention with debug logging. The shape is unmistakeable:

```
19.782 INFO  local SOCKS5 listener ready   address=127.0.0.1:57808
                    ... silence for exactly the deadline ...
```

The listener accepts, answers the greeting, receives the ASSOCIATE — and then nothing for precisely 5s. The time went into a transport fallback the read budget could not outlast, and the failure was then attributed to the rescue path, which is not where it went.

Note the error is the bare one from the helper's reply read, not `method response ...`, so negotiation had already succeeded — this is not the path prewarm.

## Measurement

144 runs at 12-way contention, identical filter and load, discounting `bind: address already in use` (an artifact of running 12 processes that each bind UDP on a TCP-derived port — CI runs one):

| | real failures / 12 shards | `read tcp` timeout |
| --- | --- | --- |
| before | 3 | present |
| after | 2 | **gone** |

The `after-rescue` echo timeout also disappears.

## Deliberately not fixed here

Two rarer modes remain. Both need a maintainer's judgement rather than a wider timeout, so widening the deadline over them would be papering over:

1. **Duplicate delivery.** The destination occasionally receives one datagram more than once, from **two distinct relay source ports**, with `LaneFailures`, `Fallbacks`, `UDPAssociationReconnects` and `TransientUDPSendErrors` all zero — so it is not a rescue or a fallback. The test asserts exactly-once delivery, which UDP does not promise; whether *two source ports* is also expected is the part worth a look, given source stability is precisely what this test exists to check.
2. `no echo for "before-rescue"` against the separate 10s budget in `send()`.

## Testing

- `go test -short ./internal/pep` — passes
- 144-run contention A/B above
- `go vet ./...`, `gofmt -l .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2N6DGePAKmKHfssRk1GP