### PR TITLE
chore: let the candidate gate accept any release version

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Non-publishing v0.1.0 release-candidate version
+        description: Non-publishing release-candidate version, vX.Y.Z-rc.N
         required: true
-        default: v0.1.0-rc.1
+        default: v0.1.1-rc.1
         type: string
 
 permissions:
@@ -189,8 +189,12 @@ jobs:
           GOARM64: v8.0
         run: |
           set -euo pipefail
-          [[ "$VERSION" =~ ^v0\.1\.0-rc\.([0-9]|[1-9][0-9]*)$ ]] || {
-            echo "candidate version must be v0.1.0-rc.N with a numeric N" >&2
+          # Any release-safe candidate version, not one pinned release. The
+          # gate that matters is release.yml's: it publishes only a tag whose
+          # commit already has a successful candidate run, and that check is
+          # on the commit, not on the string used to stamp the build.
+          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.(0|[1-9][0-9]*)$ ]] || {
+            echo "candidate version must be vX.Y.Z-rc.N with a numeric N" >&2
             exit 1
           }
           build_date=$(git show -s --format=%cI "$GITHUB_SHA")


### PR DESCRIPTION
## Why

`release-candidate.yml` pinned its version input to `v0.1.0-rc.N`:

```bash
[[ "$VERSION" =~ ^v0\.1\.0-rc\.([0-9]|[1-9][0-9]*)$ ]] || {
  echo "candidate version must be v0.1.0-rc.N with a numeric N" >&2
```

`v0.1.0` is already published, so as it stands **no subsequent release can pass through its own gate** — `release.yml` requires a successful candidate run for the commit being tagged, and no valid candidate version exists for anything past v0.1.0.

This is the only version-specific thing in the release path. `cmd/queqiaopack` and `scripts/validate_release.py` are both version-agnostic.

## What changed

Accept any `vX.Y.Z-rc.N`. Description and default updated to match.

## This does not loosen publication

The gate that decides what ships is `release.yml`'s `authorize` job, which publishes a tag only when a successful `workflow_dispatch` candidate run exists **for that tag's exact commit**. That check is on the commit, not on the string used to stamp the build — so widening the candidate's accepted version does not widen what can be released.

## Testing

Regex verified against accept/reject cases, including injection-shaped input:

```
ACCEPT  v0.1.1-rc.1        reject  v0.1.1
ACCEPT  v0.1.0-rc.1        reject  v0.1.1-rc
ACCEPT  v1.2.3-rc.10       reject  v0.1.1-rc.x
                           reject  'v0.1.1-rc.1; rm -rf /'
                           reject  ''
```

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2N6DGePAKmKHfssRk1GP