### PR TITLE
chore: publish without a deployment approval prompt

### DIFF
--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -42,9 +42,11 @@ exact commit. Production-ready language has additional gates below.
   paired fixed-egress public preview.
 - [ ] The maintainer has reviewed the candidate artifacts and explicitly
   approved publication.
-- [x] The GitHub `public-release` environment requires the approving reviewer,
-  and the release is triggered either by pushing the reviewed `v*` tag or by
-  manual workflow inputs naming the reviewed commit and candidate run.
+- [x] The GitHub `public-release` environment holds the signing secrets and
+  scopes them to the jobs that name it, and the release is triggered either by
+  pushing the reviewed `v*` tag or by manual workflow inputs naming the
+  reviewed commit and candidate run. The tag push is the approval; the
+  environment carries no deployment prompt.
 
 ### Repository settings
 
@@ -66,8 +68,11 @@ Applied and read back on 2026-08-19:
 - the `protect release tags` ruleset blocks deletion, non-fast-forward, and
   update across `refs/tags/v*`, so a published tag cannot be moved out from
   under the attestation that names it; and
-- the `public-release` environment requires the maintainer as reviewer, which
-  is what makes the deployment gate in `release.yml` mean anything.
+- the `public-release` environment scopes the six Apple signing secrets to the
+  jobs that name it, so no other workflow can read them. It carries no
+  deployment approval: what makes publication mean anything is the authorize
+  job in `release.yml`, which refuses any tag whose commit has no successful
+  candidate run.
 
 Confirm them in repository settings as well. From inside a workflow file an
 unconfigured gate looks exactly like a satisfied one.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -153,10 +153,11 @@ run while the repository is private.
 
 1. Review the candidate commit, all candidate workflow jobs, checksums, SBOMs,
    secret-scan report, native smokes, and release checklist.
-2. Configure the GitHub `public-release` environment with the required human
-   reviewer and prevent administrator bypass where the repository plan permits.
-3. After approval, create an immutable `v*` tag on the reviewed commit. Do not
-   move a tag; replace a bad candidate with a new version.
+2. Confirm the `public-release` environment still holds the six signing
+   secrets, so only the jobs naming it can read them.
+3. Create an immutable `v*` tag on the reviewed commit. Pushing it is the
+   approval: everything after it runs unattended. Do not move a tag; replace a
+   bad candidate with a new version.
 4. Publish either way:
    - Push the `v*` tag. The push runs `.github/workflows/release.yml`
      automatically: the version and approved commit come from the tag itself,
@@ -171,8 +172,7 @@ candidate run. It rebuilds the final version twice from clean Go build caches
 and requires byte-identical output, executes the downloaded archive on native
 Linux, macOS, and Windows runners for amd64 and arm64, creates build-provenance
 attestations for every published file and CycloneDX attestations for every
-binary, waits at the `public-release` environment, and only then creates the
-GitHub Release.
+binary, and then creates the GitHub Release.
 
 Verify provenance after downloading:
 
@@ -254,10 +254,19 @@ If any of the six secrets is absent, candidate qualification and final
 publication stop at the signing job. Missing credentials can never silently
 produce a release with a different or unsigned macOS asset set.
 
-Because the signing keys live in `public-release` and publication does too, a
-release asks for reviewer approval twice: once to release the keys to the
-signing job, and once to publish after that job has reported. This is not a
-misconfiguration to work around. Moving the keys to repository-level secrets
-would collapse it to one prompt and would also hand them to every workflow that
-runs; keeping them environment-scoped means the second approval is given by
-someone who can already see whether notarization was accepted.
+The signing keys live in `public-release` and publication does too, so both
+jobs name that environment. Keep them there: an environment scopes its secrets
+to the jobs that name it, and moving them to repository-level secrets would
+hand them to every workflow that runs.
+
+The environment carries no deployment approval. Publication is gated, but by
+the tag rather than by a prompt: only a maintainer can create a `v*` tag, the
+`protect release tags` ruleset makes it immutable once created, and
+`release.yml`'s authorize job refuses any tag whose commit has no successful
+candidate run. A reviewer prompt on top of that asked a maintainer to approve
+a pipeline they had already approved by pushing the tag.
+
+What that trades away is worth naming: nobody now inspects the notarization
+result between signing and publishing. If that inspection matters to you,
+restore the approval on the `publish` job alone -- it is the one placed after
+signing has reported -- rather than on both.

--- a/scripts/apply_release_settings.sh
+++ b/scripts/apply_release_settings.sh
@@ -3,7 +3,7 @@
 # Apply the four repository settings that RELEASE-CHECKLIST.md requires and
 # that GitHub refuses to accept while the repository is private: private
 # vulnerability reporting, protection for main, protection for release tags,
-# and the reviewer the public-release environment gate depends on.
+# and the public-release environment the signing secrets are scoped to.
 #
 # Run this once, immediately after the repository is made public and before the
 # release tag is pushed. Every step verifies itself by reading the setting back,
@@ -26,12 +26,9 @@ visibility=$(gh api "repos/$repository" --jq .visibility)
 if [ "$visibility" != public ]; then
   fail "$repository is $visibility. GitHub offers none of these settings on a
 private repository at this plan: rulesets and branch protection answer 403,
-required reviewers answer 422, and private vulnerability reporting answers 404.
+environment settings answer 422, and private vulnerability reporting answers 404.
 Make the repository public first; release.yml refuses to publish otherwise."
 fi
-
-owner=${repository%%/*}
-reviewer=$(gh api "users/$owner" --jq .id)
 
 # 1. Private vulnerability reporting. Until this is on, the advisory URL in
 # SECURITY.md returns a 404 to an outside reporter, so the email channel in that
@@ -70,18 +67,21 @@ apply_ruleset "$branch_ruleset" 'refs/heads/main' \
 apply_ruleset "$tag_ruleset" 'refs/tags/v*' \
   '[{"type":"deletion"},{"type":"non_fast_forward"},{"type":"update"}]' tag
 
-# 4. The environment gate. release.yml's publish job already names this
-# environment, so this is the setting that turns the checklist's
-# maintainer-approval item from a declaration into something GitHub enforces.
-# prevent_self_review stays false deliberately: the maintainer is the only
-# reviewer, and true would make the gate impossible to satisfy rather than
-# strict.
-echo "requiring a reviewer on the $environment environment"
-printf '{"prevent_self_review":false,"reviewers":[{"type":"User","id":%s}],"deployment_branch_policy":null}' \
-  "$reviewer" | gh api -X PUT "repos/$repository/environments/$environment" --input - --silent
+# 4. The environment itself, with no deployment approval on it. What the
+# environment is still for is scope: the six Apple signing secrets live here
+# and only the jobs that name this environment can read them, which is the
+# property worth keeping. Approval is not that property.
+#
+# The human decision is the tag push. Only a maintainer can create a v* tag,
+# the tag ruleset above makes it immutable once created, and release.yml's
+# authorize job independently refuses any tag whose commit lacks a successful
+# candidate run. A reviewer prompt on top of that gated an already-gated path.
+echo "clearing deployment approval on the $environment environment"
+printf '{"prevent_self_review":false,"reviewers":[],"deployment_branch_policy":null}' |
+  gh api -X PUT "repos/$repository/environments/$environment" --input - --silent
 gh api "repos/$repository/environments/$environment" \
   --jq '.protection_rules | map(select(.type == "required_reviewers")) | length' |
-  grep -qx 1 || fail "$environment still has no required reviewer"
+  grep -qx 0 || fail "$environment still has a required reviewer"
 
 echo "done. Confirm in repository settings as well: an API that answered 200 is"
 echo "evidence the call was accepted, not that the gate reads the way you meant."


### PR DESCRIPTION
## What

Releasing asked for **three** reviewer approvals — one in the candidate, two in the release, all on the `public-release` environment. This removes them.

## What is kept

The environment stays, and so does the reason it exists: it **scopes the six Apple signing secrets** to the jobs that name it, so no other workflow can read them. That property is untouched. Approval was never that property.

Publication also stays gated — by the tag rather than by a prompt:

- only a maintainer can create a `v*` tag;
- `protect release tags` makes it immutable once created, so it cannot be moved out from under the attestation naming it;
- `release.yml`'s `authorize` job independently refuses any tag whose commit has no successful, manually-dispatched candidate run.

The prompt asked a maintainer to approve a pipeline they had already approved by pushing the tag.

## Why this is more than an API call

`scripts/apply_release_settings.sh` **set** the reviewer and verified it was present. Changing only the environment via the API would have been silently reverted the next time anyone ran that script. It now clears the reviewers and verifies their absence, and the `reviewer`/`owner` id lookup it no longer needs is removed (`shellcheck` clean).

`docs/RELEASING.md` argued the opposite position outright — *"This is not a misconfiguration to work around."* Leaving that in place would have left the repo contradicting itself, so it is rewritten.

## The trade, stated in the docs rather than buried

The old argument had one real point: the second approval sat *after* notarization reported, so whoever clicked it could see whether signing had actually succeeded before anything went public. With no prompt, nobody inspects that.

`RELEASING.md` now says this plainly and names the remedy — restore the approval on the `publish` job alone, not both — rather than pretending nothing was given up.

## Follow-up

After merge I will apply the environment change itself (`reviewers: []`), which is what actually removes the prompts. v0.1.1 was published before this change, under the gate as it stood.

## Testing

- `bash -n` and `shellcheck` clean on `apply_release_settings.sh`
- docs reviewed for internal consistency; no remaining text asserts a required reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2N6DGePAKmKHfssRk1GP