### PR TITLE
fix: stop dead flows freezing the exported RTT estimate

### DIFF
--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -900,6 +900,7 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_quic_packets_sent", s.QUICPacketsSent),
 		slog.Uint64("queqiao_quic_packets_received", s.QUICPacketsReceived),
 		slog.Uint64("queqiao_quic_packets_lost", s.QUICPacketsLost),
+		slog.Uint64("queqiao_quic_observations_expired_total", s.QUICObservationsExpired),
 		slog.String("queqiao_quic_controller_kind", s.QUICControllerKind),
 		slog.Uint64("queqiao_quic_controller_mode", uint64(s.QUICControllerMode)),
 		slog.Uint64("queqiao_quic_controller_max_bandwidth_bytes_per_second", s.QUICControllerMaxBandwidth),

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -107,7 +107,9 @@ Prometheus `/metrics` names. They cover:
 - delivery, ACK, send, pacing, and maximum-bandwidth estimates;
 - congestion window, bytes in flight, controller round/mode/recovery;
 - lanes, failures, replacements, reinjections, fallbacks, and timeouts;
-- transient local UDP send errors absorbed into QUIC loss recovery; and
+- transient local UDP send errors absorbed into QUIC loss recovery;
+- flow telemetry entries expired because nothing refreshed them, which is how
+  a round-trip aggregate frozen at a stale constant announces itself; and
 - the controller's measured erasure floor, sampler diagnostics, and class
   transitions.
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -61,8 +61,33 @@ type Registry struct {
 	// event, while this is a peer whose build disagrees about the wire, and the
 	// two need different responses from whoever is on call.
 	peerProtocolViolations atomic.Uint64
-	telemetryMu            sync.Mutex
-	quicFlows              map[uint64]QUICObservation
+	// quicObservationsExpired counts per-flow QUIC telemetry entries dropped
+	// because nothing refreshed them within quicObservationTTL. The aggregate
+	// below reports round-trip time as a maximum, so an entry that is never
+	// refreshed and never removed pins the exported estimate at whatever it
+	// last held for as long as the process lives. A rising count means some
+	// flow stopped publishing without removing its entry, and it is the only
+	// warning an operator gets that the aggregate is being held up by a
+	// measurement that is no longer being taken.
+	quicObservationsExpired atomic.Uint64
+	telemetryMu             sync.Mutex
+	quicFlows               map[uint64]quicObservation
+	// clock is the time source for observation freshness. Tests replace it;
+	// production leaves it nil and reads the wall clock.
+	clock func() time.Time
+}
+
+// quicObservationTTL is how long one flow's QUIC telemetry keeps contributing
+// to the process aggregate without being refreshed. A live flow republishes
+// every second, so this is generous by an order of magnitude; its purpose is
+// to bound the damage of an entry that is never refreshed again rather than to
+// expire a busy flow that was briefly descheduled.
+const quicObservationTTL = 15 * time.Second
+
+// quicObservation is one flow's telemetry with the time it was recorded.
+type quicObservation struct {
+	QUICObservation
+	updated time.Time
 }
 
 type Snapshot struct {
@@ -94,6 +119,9 @@ type Snapshot struct {
 	QUICControllerMinRTT                                          time.Duration
 	QUICControllerErasureFloor                                    float64
 	QUICControllerInRecovery                                      bool
+	// QUICObservationsExpired counts flow telemetry entries dropped because
+	// they stopped being refreshed. See quicObservationsExpired.
+	QUICObservationsExpired uint64
 }
 
 // QUICObservation is a point-in-time aggregate over the lanes of one logical
@@ -132,7 +160,16 @@ type QUICObservation struct {
 	ControllerInRecovery       bool
 }
 
-func New() *Registry { return &Registry{quicFlows: make(map[uint64]QUICObservation)} }
+func New() *Registry { return &Registry{quicFlows: make(map[uint64]quicObservation)} }
+
+// now reads the registry's time source. A zero-value Registry is a supported
+// "metrics disabled" construction, so this must work without New.
+func (r *Registry) now() time.Time {
+	if r.clock != nil {
+		return r.clock()
+	}
+	return time.Now()
+}
 
 func (r *Registry) FlowStarted() { r.activeFlows.Add(1); r.flowsStarted.Add(1) }
 
@@ -226,11 +263,12 @@ func (r *Registry) ObserveQUIC(key uint64, o QUICObservation) {
 	if o.SmoothedRTT < 0 {
 		o.SmoothedRTT = 0
 	}
+	now := r.now()
 	r.telemetryMu.Lock()
 	if r.quicFlows == nil {
-		r.quicFlows = make(map[uint64]QUICObservation)
+		r.quicFlows = make(map[uint64]quicObservation)
 	}
-	r.quicFlows[key] = o
+	r.quicFlows[key] = quicObservation{QUICObservation: o, updated: now}
 	r.telemetryMu.Unlock()
 }
 
@@ -264,6 +302,8 @@ func (r *Registry) Snapshot() Snapshot {
 	for i := range s.ClassTransitions {
 		s.ClassTransitions[i] = r.classTransitions[i].Load()
 	}
+	now := r.now()
+	var expired uint64
 	r.telemetryMu.Lock()
 	var quicLanes int64
 	var latestRTT, smoothedRTT time.Duration
@@ -278,7 +318,17 @@ func (r *Registry) Snapshot() Snapshot {
 	var controllerMinRTT time.Duration
 	var controllerErasureFloor float64
 	var controllerRecovery bool
-	for _, o := range r.quicFlows {
+	for key, entry := range r.quicFlows {
+		// An entry nobody refreshes is not a measurement of anything. Because
+		// the round-trip aggregate below is a maximum, keeping one would pin
+		// the exported estimate at a value the path stopped having, and every
+		// live flow measuring a faster path would be invisible underneath it.
+		if now.Sub(entry.updated) > quicObservationTTL {
+			delete(r.quicFlows, key)
+			expired++
+			continue
+		}
+		o := entry.QUICObservation
 		quicLanes += int64(o.Lanes)
 		if o.LatestRTT > latestRTT {
 			latestRTT = o.LatestRTT
@@ -342,6 +392,10 @@ func (r *Registry) Snapshot() Snapshot {
 		}
 	}
 	r.telemetryMu.Unlock()
+	if expired > 0 {
+		r.quicObservationsExpired.Add(expired)
+	}
+	s.QUICObservationsExpired = r.quicObservationsExpired.Load()
 	s.QUICLanes = quicLanes
 	s.QUICLatestRTT = latestRTT
 	s.QUICSmoothedRTT = smoothedRTT
@@ -416,6 +470,10 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "queqiao_quic_packets_sent %d\n", s.QUICPacketsSent)
 	fmt.Fprintf(w, "queqiao_quic_packets_received %d\n", s.QUICPacketsReceived)
 	fmt.Fprintf(w, "queqiao_quic_packets_lost %d\n", s.QUICPacketsLost)
+	// A rising expiry count means some flow's telemetry stopped being
+	// refreshed without being removed. The RTT values above are maxima, so
+	// that is the failure mode which freezes them at a stale constant.
+	fmt.Fprintf(w, "queqiao_quic_observations_expired_total %d\n", s.QUICObservationsExpired)
 	if s.QUICControllerKind != "" {
 		fmt.Fprintf(w, "queqiao_quic_controller_kind{kind=\"%s\"} 1\n", s.QUICControllerKind)
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -143,3 +143,60 @@ func TestNilRegistryIsSafe(t *testing.T) {
 	registry.ReplayBytes(10)
 	registry.BulkIsolated()
 }
+
+// The exported round-trip estimate is a maximum over per-flow observations, so
+// an entry that stops being refreshed and is never removed holds the estimate
+// at whatever the path used to be for as long as the process lives. Expiring
+// it is what keeps the aggregate a measurement rather than a record high.
+func TestSnapshotExpiresQUICObservationsNobodyRefreshes(t *testing.T) {
+	registry := New()
+	now := time.Now()
+	registry.clock = func() time.Time { return now }
+
+	registry.ObserveQUIC(1, QUICObservation{Lanes: 2, LatestRTT: 900 * time.Millisecond, SmoothedRTT: 800 * time.Millisecond})
+	now = now.Add(quicObservationTTL + time.Second)
+	registry.ObserveQUIC(2, QUICObservation{Lanes: 1, LatestRTT: 320 * time.Millisecond, SmoothedRTT: 300 * time.Millisecond})
+
+	got := registry.Snapshot()
+	if got.QUICSmoothedRTT != 300*time.Millisecond || got.QUICLatestRTT != 320*time.Millisecond {
+		t.Fatalf("stale observation still steers the aggregate: smoothed=%s latest=%s", got.QUICSmoothedRTT, got.QUICLatestRTT)
+	}
+	if got.QUICLanes != 1 {
+		t.Fatalf("QUIC lanes = %d, want 1", got.QUICLanes)
+	}
+	if got.QUICObservationsExpired != 1 {
+		t.Fatalf("expired observations = %d, want 1", got.QUICObservationsExpired)
+	}
+
+	// The expired entry is gone rather than re-examined on every scrape, and
+	// the counter reports the one expiry instead of counting it again.
+	registry.telemetryMu.Lock()
+	remaining := len(registry.quicFlows)
+	registry.telemetryMu.Unlock()
+	if remaining != 1 {
+		t.Fatalf("registry retains %d observations, want 1", remaining)
+	}
+	if again := registry.Snapshot(); again.QUICObservationsExpired != 1 {
+		t.Fatalf("expired observations = %d on the second scrape, want 1", again.QUICObservationsExpired)
+	}
+
+	recorder := httptest.NewRecorder()
+	registry.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if body := recorder.Body.String(); !strings.Contains(body, "queqiao_quic_observations_expired_total 1") {
+		t.Fatalf("metrics output is missing the expiry counter: %s", body)
+	}
+}
+
+// A flow that keeps publishing keeps its entry, however long it lives.
+func TestSnapshotKeepsRefreshedQUICObservations(t *testing.T) {
+	registry := New()
+	now := time.Now()
+	registry.clock = func() time.Time { return now }
+	for i := 0; i < 10; i++ {
+		registry.ObserveQUIC(1, QUICObservation{Lanes: 1, SmoothedRTT: 250 * time.Millisecond})
+		now = now.Add(quicObservationTTL - time.Second)
+		if got := registry.Snapshot(); got.QUICSmoothedRTT != 250*time.Millisecond || got.QUICObservationsExpired != 0 {
+			t.Fatalf("refreshed observation expired after %d intervals: %+v", i, got)
+		}
+	}
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -672,7 +672,13 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 		f.currentRTTNS.Store(observation.SmoothedRTT.Nanoseconds())
 		f.baselineRTTNS.CompareAndSwap(0, observation.SmoothedRTT.Nanoseconds())
 	}
-	if f.metrics != nil {
+	// A finished flow must not publish again. Its registry entry is removed
+	// during teardown, and the lane managers keep polling this snapshot for a
+	// moment after that; a late publication would reinstate an entry with
+	// nothing left to remove it. The process-wide aggregate reports RTT as a
+	// maximum, so one reinstated entry pins the exported estimate at that
+	// flow's last measurement until the process restarts.
+	if f.metrics != nil && !f.finished.Load() {
 		f.metrics.ObserveQUIC(f.telemetryID, observation)
 	}
 }
@@ -1160,15 +1166,19 @@ func (f *multipathFlow) run(ctx context.Context) (FlowStats, error) {
 	limitsStop := make(chan struct{})
 	limitErr := make(chan error, 1)
 	go f.watchLimits(limitsStop, limitErr)
+	if f.metrics != nil {
+		// Registered before signalDone so that it runs after it: the lane
+		// managers stop on the done channel and poll this flow's telemetry
+		// until they do, so removing the entry first leaves a window in which
+		// one of them republishes it permanently.
+		defer f.metrics.RemoveQUIC(f.telemetryID)
+	}
 	defer f.signalDone()
 	defer func() {
 		cancelACKs()
 		close(limitsStop)
 		close(completionStop)
 		close(telemetryStop)
-		if f.metrics != nil {
-			f.metrics.RemoveQUIC(f.telemetryID)
-		}
 	}()
 	defer f.finished.Store(true)
 	stats := FlowStats{Started: f.started}

--- a/internal/pep/telemetry_test.go
+++ b/internal/pep/telemetry_test.go
@@ -1,0 +1,52 @@
+package pep
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/metrics"
+)
+
+// statsConn is a lane transport that reports fixed QUIC connection statistics.
+type statsConn struct {
+	stats laneTransportStats
+}
+
+func (c *statsConn) Read([]byte) (int, error)           { return 0, io.EOF }
+func (c *statsConn) Write(p []byte) (int, error)        { return len(p), nil }
+func (c *statsConn) Close() error                       { return nil }
+func (c *statsConn) transportStats() laneTransportStats { return c.stats }
+
+// A flow's telemetry entry is removed when the flow ends, but the lane
+// managers poll the same snapshot on a timer and stop only once the flow
+// signals done. A publication from that window reinstates an entry which
+// nothing will ever remove or refresh again, and since the registry reports
+// round-trip time as a maximum over entries, one such entry pins the exported
+// estimate at that flow's final measurement for the life of the process.
+func TestFinishedFlowStopsPublishingQUICTelemetry(t *testing.T) {
+	registry := metrics.New()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	flow := newMultipathFlow(context.Background(), local, [16]byte{1}, 7, 0, 0, 0, nil, registry)
+	flow.lanes[0] = &mpLane{id: 0, kind: TransportQUIC, fc: newFrameConn(&statsConn{
+		stats: laneTransportStats{latestRTT: 900 * time.Millisecond, smoothedRTT: 800 * time.Millisecond},
+	})}
+
+	flow.snapshot()
+	if got := registry.Snapshot(); got.QUICLanes != 1 || got.QUICSmoothedRTT != 800*time.Millisecond {
+		t.Fatalf("live flow telemetry lanes=%d smoothed=%s, want 1 and 800ms", got.QUICLanes, got.QUICSmoothedRTT)
+	}
+
+	// What flow.run does while a lane manager is between its own done check
+	// and its next snapshot.
+	flow.finished.Store(true)
+	registry.RemoveQUIC(flow.telemetryID)
+
+	flow.snapshot()
+	if got := registry.Snapshot(); got.QUICLanes != 0 || got.QUICSmoothedRTT != 0 {
+		t.Fatalf("finished flow republished telemetry: lanes=%d smoothed=%s", got.QUICLanes, got.QUICSmoothedRTT)
+	}
+}


### PR DESCRIPTION
Fixes #20.

## What was happening

`queqiao_quic_smoothed_rtt_seconds` is a **maximum** over per-flow telemetry entries in `metrics.Registry`. A flow publishes its entry every second from `telemetryLoop`, and removes it during teardown.

The removal was not final. `manageQUICLanes` runs in its own goroutine, polls `flow.snapshot()` — which republishes telemetry — every 500ms, and stops only when the flow closes its done channel. In `run()`'s teardown the deferred `RemoveQUIC` ran *before* `signalDone`, so a manager tick landing in that window reinstated the entry after it was removed. Nothing refreshes or removes it again, for the life of the process.

Because the aggregate is a maximum, one reinstated entry becomes a floor. Every live flow measuring a faster path is invisible underneath it, which is exactly the reported shape: bit-identical values across ~8000 consecutive snapshots, never any drift below, only rare spikes above from live flows that were briefly worse, and a restart restoring live estimates immediately.

## What changed

- `internal/pep/mpflow.go`: `RemoveQUIC` is registered before `signalDone` so it runs after it, and `observeTransport` refuses to publish once the flow is finished. That closes the leak at its source.
- `internal/metrics/metrics.go`: each observation is stamped with the time it was recorded, and `Snapshot` drops entries nothing refreshed within `quicObservationTTL` (15s, against a 1s publish cadence). This is the staleness watchdog the issue asks for: no future leak on any path can pin the aggregate for longer than the TTL.
- New counter `queqiao_quic_observations_expired_total`, exported on `/metrics` and in the performance-snapshot log, so the failure mode is visible instead of silent. `docs/LOGGING.md` updated.

## Checks

- `internal/pep`: `TestFinishedFlowStopsPublishingQUICTelemetry` reproduces the leak (fails with `lanes=1 smoothed=800ms` before the fix, passes after).
- `internal/metrics`: `TestSnapshotExpiresQUICObservationsNobodyRefreshes` and `TestSnapshotKeepsRefreshedQUICObservations` cover the TTL from both sides.
- `go test -short -timeout 20m ./...`, `go vet ./...`, `gofmt -l .`, and `staticcheck -checks=all,-U1000` on the changed packages are all clean.

Note this does not change how a lane's RTT is *sampled*; it changes which samples are allowed to represent the process. The per-flow measurement path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jidJ9KKtHtTbWUX2sgKf5