### PR TITLE
fix: keep local casualties out of the measured erasure rate

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -119,7 +119,17 @@ that interval instead of displaying a fabricated negative loss rate.
 Flow-completion records add an opaque session/flow correlation ID, transport,
 duration, directional bytes, class, lane byte
 allocation, coded-versus-stream payload, and the FEC sent/repair/recovered/
-residual/window/rate summary. Failed flows are warning-level records with the
+residual/window/rate summary.
+
+The FEC counters have two directions and they must not be divided into each
+other. `fec_sent_total` and `fec_repairs_total` are what this endpoint
+transmitted; `fec_arrived_total`, `fec_recovered_total` and
+`fec_residual_lost_total` are what it received, so on an asymmetric flow
+`lost` above `sent` is ordinary rather than impossible. The receive direction's
+rates are `fec_measured_erasure`, the share of the peer's source symbols that
+did not arrive, and `fec_residual_loss`, the share the code could not repair
+and the session had to re-issue. Both are taken over `fec_source_symbols_total`
+and are therefore in [0,1]. Failed flows are warning-level records with the
 same performance and FEC fields plus the error, so they remain visible at the
 default `info` level. `QUEQIAO_LANE_TRACE=1` remains an opt-in raw
 per-lane diagnostic. It is not needed for the standard aggregate dashboard.

--- a/internal/coded/casualty_test.go
+++ b/internal/coded/casualty_test.go
@@ -1,0 +1,180 @@
+package coded
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/fec"
+	"github.com/bojieli/queqiao/internal/pathmodel"
+)
+
+// refusingPipe is a carrier that refuses some datagrams outright, which is what
+// a QUIC connection does when its estimate of what fits in a packet moves under
+// a symbol already sized against the old one.
+type refusingPipe struct {
+	*lossyPipe
+	mu      sync.Mutex
+	every   int
+	offered int
+	refused int
+}
+
+func (p *refusingPipe) Send(d []byte) error {
+	p.mu.Lock()
+	p.offered++
+	refuse := p.every > 0 && p.offered%p.every == 0
+	if refuse {
+		p.refused++
+	}
+	p.mu.Unlock()
+	if refuse {
+		return fmt.Errorf("%w: %d bytes offered, 0 accepted", ErrDatagramTooLarge, len(d))
+	}
+	return p.lossyPipe.Send(d)
+}
+
+func (p *refusingPipe) refusals() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.refused
+}
+
+// A datagram this endpoint never managed to transmit is not something the path
+// did. Charging it to the channel raises the measured erasure rate, which sizes
+// more parity, which is more load on the path that was already failing -- so
+// the number a refused datagram took must not become a gap in what the peer
+// receives.
+func TestARefusedDatagramIsNotMeasuredAsWireLoss(t *testing.T) {
+	pa, pb := newPipes(11, 0)
+	refusing := &refusingPipe{lossyPipe: pa, every: 7}
+	cfg := Config{SymbolBytes: 1100, RoundTrip: 60 * time.Millisecond, Path: measuredPath(0.2)}
+	sender, receiver := New(refusing, cfg), New(pb, cfg)
+	t.Cleanup(func() { sender.Close(); receiver.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, err := receiver.Receive(); err != nil {
+				return
+			}
+		}
+	}()
+
+	rng := rand.New(rand.NewSource(12))
+	frame := make([]byte, 900)
+	for i := 0; i < 400; i++ {
+		rng.Read(frame)
+		if err := sender.Send(frame); err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+	}
+	// The receiver decides a sequence number once the newest is a reorder
+	// tolerance past it, so give the last symbols time to arrive and settle.
+	deadline := time.Now().Add(5 * time.Second)
+	var stats Stats
+	for time.Now().Before(deadline) {
+		stats = receiver.Stats()
+		if stats.Snapshot.Decided > 200 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if refusing.refusals() == 0 {
+		t.Fatal("the carrier refused nothing, so this proves nothing")
+	}
+	if stats.Snapshot.Decided == 0 {
+		t.Fatal("the receiver decided no sequence numbers")
+	}
+	if stats.Snapshot.Loss != 0 {
+		t.Fatalf("wire loss = %.4f after %d local refusals and no channel erasure (decided %d)",
+			stats.Snapshot.Loss, refusing.refusals(), stats.Snapshot.Decided)
+	}
+	if sent := sender.Stats().Sent; sent == 0 {
+		t.Fatal("nothing was sent")
+	}
+}
+
+// A refusal still costs the symbol it carried. That casualty belongs to the
+// session above, which re-issues it -- it is only the channel measurement it
+// must stay out of.
+func TestARefusedDatagramStillCostsItsSymbol(t *testing.T) {
+	pa, pb := newPipes(13, 0)
+	refusing := &refusingPipe{lossyPipe: pa, every: 3}
+	// No parity, so a refused symbol has nothing to repair it and the receive
+	// side must account for it as a casualty rather than silently.
+	cfg := Config{SymbolBytes: 1100, RoundTrip: 60 * time.Millisecond, Path: pathmodel.NewPathModel()}
+	sender, receiver := New(refusing, cfg), New(pb, cfg)
+	t.Cleanup(func() { sender.Close(); receiver.Close() })
+
+	arrived := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, err := receiver.Receive(); err != nil {
+				return
+			}
+			arrived++
+		}
+	}()
+
+	// More symbols than the decoder's window, or nothing is ever evicted and
+	// no casualty is ever accounted for.
+	frame := make([]byte, 900)
+	for i := 0; i < 3*fec.MinDecoderWidth; i++ {
+		if err := sender.Send(frame); err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	var stats Stats
+	for time.Now().Before(deadline) {
+		stats = receiver.Stats()
+		if stats.Lost > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if stats.Lost == 0 {
+		t.Fatal("a symbol that never left is not accounted for anywhere")
+	}
+	if stats.Snapshot.Loss != 0 {
+		t.Fatalf("wire loss = %.4f, want the casualty charged to the session and not to the channel", stats.Snapshot.Loss)
+	}
+}
+
+// Lost had no denominator: Sent counts the direction this endpoint transmits
+// into and Lost the direction it receives, so an operator comparing them saw
+// "lost is ten times sent" and concluded the accounting was impossible.
+func TestReceiveDirectionRatesStayRates(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		stats             Stats
+		erasure, residual float64
+	}{
+		{name: "nothing received", stats: Stats{Sent: 116796}},
+		{
+			name:    "asymmetric flow",
+			stats:   Stats{Sent: 100, Sources: 60, Recovered: 20, Lost: 20},
+			erasure: 0.4, residual: 0.2,
+		},
+		{name: "everything lost", stats: Stats{Lost: 50}, erasure: 1, residual: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.stats.Erasure(); got != test.erasure {
+				t.Fatalf("erasure = %v, want %v", got, test.erasure)
+			}
+			if got := test.stats.Residual(); got != test.residual {
+				t.Fatalf("residual = %v, want %v", got, test.residual)
+			}
+			if got := test.stats.Erasure(); got < 0 || got > 1 {
+				t.Fatalf("erasure = %v is not a rate", got)
+			}
+		})
+	}
+}

--- a/internal/coded/coded.go
+++ b/internal/coded/coded.go
@@ -180,6 +180,13 @@ type Path struct {
 	sent     atomic.Uint64
 	repairs  atomic.Uint64
 	oversize atomic.Uint64
+	// arrivals counts datagrams that reached this path, of which sources
+	// carried a source symbol. They are the receive direction's own
+	// denominator: sent above counts what this endpoint put on the wire in the
+	// other direction, so a loss ratio taken against it is not a rate at all
+	// and can exceed one without anything being wrong with the path.
+	arrivals atomic.Uint64
+	sources  atomic.Uint64
 	// malformed counts datagrams a peer sent that protocol 1 does not permit.
 	// It is kept apart from the erasure estimate on purpose: a rejected
 	// datagram is a peer disagreeing about the wire, and folding it into loss
@@ -439,7 +446,8 @@ func (p *Path) sendSource(esi uint32, vector []byte) error {
 	d[4] = kindSource
 	binary.BigEndian.PutUint32(d[5:], esi)
 	copy(d[sourceHeader:], vector)
-	return p.put(d)
+	_, err := p.put(d)
+	return err
 }
 
 // sendRepair emits one repair over the newest count symbols, or over the whole
@@ -457,8 +465,11 @@ func (p *Path) sendRepair(count int) error {
 	binary.BigEndian.PutUint32(d[9:], repair.First)
 	binary.BigEndian.PutUint16(d[13:], uint16(repair.Count))
 	copy(d[repairHeader:], repair.Vector)
-	p.repairs.Add(1)
-	return p.put(d)
+	sent, err := p.put(d)
+	if sent {
+		p.repairs.Add(1)
+	}
+	return err
 }
 
 func (p *Path) take() uint32 {
@@ -467,20 +478,37 @@ func (p *Path) take() uint32 {
 	return seq
 }
 
-func (p *Path) put(d []byte) error {
+// untake returns a transmission sequence that was never transmitted.
+//
+// The peer measures the channel from the gaps between the sequences it
+// receives, so a number spent on a datagram the carrier refused is a hole in
+// its numbering that the wire never made. Charging the channel for a casualty
+// of this endpoint's own transport is how a local failure becomes a measured
+// erasure rate, and that rate sizes the parity which then becomes load on the
+// path that was already failing. Only the send loop takes a sequence, and it
+// takes the next one immediately after this, so handing the number back leaves
+// the numbering describing exactly what went out.
+func (p *Path) untake() { p.nextSeq-- }
+
+// put hands one datagram to the carrier and reports whether it reached it.
+func (p *Path) put(d []byte) (bool, error) {
 	switch err := p.carrier.Send(d); {
 	case err == nil:
 		p.sent.Add(1)
-		return nil
+		return true, nil
 	case errors.Is(err, ErrDatagramTooLarge):
 		// The path's estimate moved under us. Losing this datagram is cheaper
 		// than losing the connection, and the next symbol is sized from the
-		// carrier's revised limit.
+		// carrier's revised limit. The symbol it carried is still lost -- the
+		// session above re-issues it -- but it was lost here rather than on
+		// the wire, so the peer must not be shown a gap for it.
 		p.oversize.Add(1)
-		return nil
+		p.untake()
+		return false, nil
 	default:
+		p.untake()
 		p.fail(err)
-		return err
+		return false, err
 	}
 }
 
@@ -515,6 +543,7 @@ func (p *Path) onDatagram(d []byte) [][]byte {
 	defer p.mu.Unlock()
 	// Every arrival measures the channel, including one carrying nothing new:
 	// the gaps between transmission sequences are what loss is.
+	p.arrivals.Add(1)
 	p.estimator.Observe(uint64(seq))
 
 	var delivered fec.Delivery
@@ -523,6 +552,7 @@ func (p *Path) onDatagram(d []byte) [][]byte {
 	case kindSource:
 		esi := binary.BigEndian.Uint32(d[5:])
 		vector := d[sourceHeader:]
+		p.sources.Add(1)
 		delivered = p.decoder.Source(esi, vector)
 		frames = p.assembler.arrived(esi, vector, frames)
 	case kindRepair:
@@ -829,7 +859,17 @@ type Stats struct {
 	// the window still missing, and whose frames the session must re-issue.
 	Recovered uint64
 	Lost      uint64
-	Oversize  uint64
+	// Arrived is datagrams this path received, of which Sources carried a
+	// source symbol.
+	//
+	// They are here because Lost had no denominator without them. Sent counts
+	// the direction this endpoint transmits into and Lost the direction it
+	// receives, so "lost over sent" is not a rate and reaches ten on a
+	// perfectly ordinary asymmetric flow. Erasure and Residual below are the
+	// rates that can actually be read.
+	Arrived  uint64
+	Sources  uint64
+	Oversize uint64
 	// Malformed is datagrams rejected for breaking the protocol's bounds,
 	// which is a peer problem rather than a path problem.
 	Malformed uint64
@@ -848,9 +888,37 @@ func (p *Path) Stats() Stats {
 	return Stats{
 		Snapshot: snapshot, Plan: current.plan, Window: current.capacity,
 		Sent: p.sent.Load(), Repairs: p.repairs.Load(),
-		Recovered: recovered, Lost: lost, Oversize: p.oversize.Load(),
+		Recovered: recovered, Lost: lost,
+		Arrived: p.arrivals.Load(), Sources: p.sources.Load(),
+		Oversize:  p.oversize.Load(),
 		Malformed: p.malformed.Load(),
 	}
+}
+
+// SourceSymbols is how many of the peer's source symbols this path has
+// accounted for: those that arrived, those the code reconstructed, and those
+// that left the window unrecovered. Every symbol the peer sent ends in exactly
+// one of the three, which is what makes it a denominator.
+func (s Stats) SourceSymbols() uint64 { return s.Sources + s.Recovered + s.Lost }
+
+// Erasure is the share of source symbols that did not arrive, whether the code
+// repaired them or not: the wire loss this receiver measured, in [0,1].
+func (s Stats) Erasure() float64 {
+	total := s.SourceSymbols()
+	if total == 0 {
+		return 0
+	}
+	return float64(s.Recovered+s.Lost) / float64(total)
+}
+
+// Residual is the share of source symbols the code could not repair, which is
+// what the session above has to re-issue. It is in [0,1] by construction.
+func (s Stats) Residual() float64 {
+	total := s.SourceSymbols()
+	if total == 0 {
+		return 0
+	}
+	return float64(s.Lost) / float64(total)
 }
 
 func (p *Path) fail(err error) {

--- a/internal/fec/rate.go
+++ b/internal/fec/rate.go
@@ -106,6 +106,20 @@ func Choose(s lossmodel.Snapshot, p Params) Plan {
 	if loss < minCodedLoss {
 		return Plan{Why: "loss below the parity's cost"}
 	}
+	if !(loss < 1) {
+		// Written as a negation so it also refuses NaN, which passes every
+		// threshold it is compared against.
+		//
+		// A rate of one says nothing arrives, and no code repairs that. Every
+		// honest loss rate is a count of losses over a count of trials and so
+		// cannot reach one here, which makes this an accounting failure rather
+		// than a path: something was charged to the channel that the channel
+		// did not do. Sizing for it would spend the lowest rate this searches
+		// -- eight times the wire per delivered byte -- on the path that
+		// produced the impossible figure, so refuse instead and leave the
+		// counters saying why.
+		return Plan{Why: "loss rate is not a measurement"}
+	}
 	if p.ShardBytes <= 0 || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
 		return Plan{Why: "no usable parameters"}
 	}
@@ -167,7 +181,7 @@ func ShardsFor(k int, s lossmodel.Snapshot, p Params) (int, bool) {
 	if loss <= 0 {
 		loss = s.Loss
 	}
-	if loss < minCodedLoss || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
+	if loss < minCodedLoss || !(loss < 1) || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
 		return k, false
 	}
 	burst := p.effectiveBurst(s)

--- a/internal/fec/rate_test.go
+++ b/internal/fec/rate_test.go
@@ -1,6 +1,7 @@
 package fec
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -192,5 +193,29 @@ func TestBinomialTail(t *testing.T) {
 			t.Errorf("binomialTailBelow(%d, %v, %d) = %.10f, want %.10f",
 				test.n, test.q, test.k, got, test.want)
 		}
+	}
+}
+
+// A loss rate of one or more is not a measurement: every honest rate is a
+// count of losses over a count of trials. Sizing a code for one would spend
+// the lowest rate this search allows -- eight times the wire per delivered
+// byte -- on the path that produced the impossible figure.
+func TestChooseRefusesAnImpossibleLossRate(t *testing.T) {
+	params := Params{ShardBytes: 1200, RateBytesPerSec: 1e6, RoundTrip: 300 * time.Millisecond, TargetResidual: 1e-3}
+	for _, loss := range []float64{1, 1.2527, math.Inf(1), math.NaN()} {
+		t.Run(fmt.Sprintf("%v", loss), func(t *testing.T) {
+			plan := Choose(lossmodel.Snapshot{Loss: loss, Floor: loss, Recent: loss, BurstFactor: 1}, params)
+			if plan.Code {
+				t.Fatalf("coded for a loss rate of %v: %+v", loss, plan)
+			}
+			if _, ok := ShardsFor(8, lossmodel.Snapshot{Loss: loss, Floor: loss, BurstFactor: 1}, params); ok {
+				t.Fatalf("sized a block for a loss rate of %v", loss)
+			}
+		})
+	}
+	// The guard must not touch a rate that is merely high.
+	plan := Choose(lossmodel.Snapshot{Loss: 0.42, Floor: 0.42, Recent: 0.42, BurstFactor: 1}, params)
+	if !plan.Code {
+		t.Fatalf("refused to code a 42%% erasure channel: %+v", plan)
 	}
 }

--- a/internal/lossmodel/lossmodel.go
+++ b/internal/lossmodel/lossmodel.go
@@ -315,19 +315,42 @@ const minMemorylessSamples = 200
 // a path that is losing packets from a peer that is not numbering them.
 func (e *Estimator) Discontinuities() uint64 { return e.discontinuities }
 
+// probability keeps a reported rate a rate.
+//
+// Every quotient below is a count of outcomes over a count of trials, so each
+// is in [0,1] by construction and this clamp should never bind. It is here
+// because the consequence of it binding is silent and expensive: a rate above
+// one reaching Choose sizes parity for a channel that delivers nothing, and
+// parity is load on the path that produced the impossible number. A figure
+// outside [0,1] is not evidence about a path, so it is not passed on as if it
+// were.
+func probability(v float64) float64 {
+	if !(v > 0) {
+		// Also catches NaN, which compares false against everything and would
+		// otherwise travel through every threshold below untouched.
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
 // Snapshot reports the current estimate.
 func (e *Estimator) Snapshot() Snapshot {
 	s := Snapshot{Reordered: e.reordered, Decided: e.decided, Samples: e.samples}
 	if e.samples <= 0 {
 		return s
 	}
-	s.Loss = e.losses / e.samples
+	s.Loss = probability(e.losses / e.samples)
 	if e.fromArrival > 0 {
-		s.LossAfterArrival = e.lossAfterArrival / e.fromArrival
+		s.LossAfterArrival = probability(e.lossAfterArrival / e.fromArrival)
 	}
 	if e.fromLoss > 0 {
-		s.ArrivalAfterLoss = e.arrivalAfterLoss / e.fromLoss
-		s.MeanBurst = 1 / s.ArrivalAfterLoss
+		s.ArrivalAfterLoss = probability(e.arrivalAfterLoss / e.fromLoss)
+		if s.ArrivalAfterLoss > 0 {
+			s.MeanBurst = 1 / s.ArrivalAfterLoss
+		}
 	}
 	// A memoryless channel loses a mean run of 1/(1-Loss), so dividing by that
 	// normalises the burst length to one for independent loss.
@@ -343,6 +366,7 @@ func (e *Estimator) Snapshot() Snapshot {
 	s.Memoryless = e.memoryless(s)
 
 	s.Floor, s.Recent = e.floor()
+	s.Floor, s.Recent = probability(s.Floor), probability(s.Recent)
 	if s.Recent > s.Floor {
 		s.Congestive = s.Recent - s.Floor
 	}

--- a/internal/lossmodel/lossmodel_test.go
+++ b/internal/lossmodel/lossmodel_test.go
@@ -302,3 +302,41 @@ func TestASequenceFarAheadIsADiscontinuityNotFourBillionLosses(t *testing.T) {
 		t.Fatalf("a clean run after the jump measured %.2f loss", loss)
 	}
 }
+
+// Every figure the estimator reports as a probability is a count of outcomes
+// over a count of trials, so none of them can leave [0,1] on its own. What
+// reads them cannot tell a rate from an accounting failure, though, and a
+// figure above one sizes parity for a channel that delivers nothing -- so the
+// reported values are rates whatever the counters behind them say.
+func TestSnapshotReportsProbabilitiesEvenFromInconsistentCounters(t *testing.T) {
+	e := New(Config{})
+	// Counters that cannot arise from Observe, standing in for any future
+	// accounting path that charges a loss to a trial that never happened.
+	e.samples, e.losses = 100, 125.27
+	e.fromArrival, e.lossAfterArrival = 10, 40
+	e.fromLoss, e.arrivalAfterLoss = 10, 30
+	e.rounds = []float64{1.4, 2.2}
+
+	s := e.Snapshot()
+	for name, value := range map[string]float64{
+		"loss": s.Loss, "loss after arrival": s.LossAfterArrival,
+		"arrival after loss": s.ArrivalAfterLoss, "floor": s.Floor,
+		"recent": s.Recent, "congestive": s.Congestive,
+	} {
+		if value < 0 || value > 1 {
+			t.Fatalf("%s = %v is not a probability", name, value)
+		}
+	}
+}
+
+// A path that really erases nothing must still report zero rather than the
+// clamp's bounds, or the guard would be hiding the measurement it protects.
+func TestSnapshotLeavesAnOrdinaryEstimateAlone(t *testing.T) {
+	e := New(Config{RoundSamples: 100})
+	for i := 0; i < 1000; i++ {
+		e.ObserveOutcome(i%4 != 0)
+	}
+	if s := e.Snapshot(); s.Loss < 0.2 || s.Loss > 0.3 {
+		t.Fatalf("loss = %v, want about a quarter", s.Loss)
+	}
+}

--- a/internal/pep/logging_test.go
+++ b/internal/pep/logging_test.go
@@ -13,6 +13,7 @@ func TestCodedSubstrateLogFieldsExposePlanAndEstimator(t *testing.T) {
 		Snapshot: lossmodel.Snapshot{Samples: 800, Loss: .31, Floor: .27, BurstFactor: 1.4, Memoryless: false, Reordered: 4, Decided: 900},
 		Plan:     fec.Plan{Code: true, K: 80, N: 120, Rate: 2.0 / 3, Residual: .001, LossCoded: .27, EffectiveBurst: 1.4, Why: "sized for the loss floor"},
 		Window:   80, Sent: 1200, Repairs: 400, Recovered: 210, Lost: 7, Oversize: 2,
+		Arrived: 1000, Sources: 783,
 	}
 	values := map[string]any{}
 	fields := codedSubstrateLogFields(stats, true)
@@ -25,6 +26,11 @@ func TestCodedSubstrateLogFieldsExposePlanAndEstimator(t *testing.T) {
 		"fec_plan_k": 80, "fec_plan_n": 120, "fec_code_rate": 2.0 / 3,
 		"fec_observed_loss": .31, "fec_erasure_floor": .27, "fec_burst_factor": 1.4,
 		"fec_reason": "sized for the loss floor", "fec_decided_total": uint64(900),
+		"fec_arrived_total": uint64(1000), "fec_source_symbols_total": uint64(1000),
+		// The receive direction's own rates, which is what "lost" needed to be
+		// readable at all: 217 of 1000 source symbols did not arrive, and 7 of
+		// them were still missing when the window moved on.
+		"fec_measured_erasure": 0.217, "fec_residual_loss": 0.007,
 	} {
 		if values[key] != want {
 			t.Fatalf("%s = %#v, want %#v", key, values[key], want)

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -2326,8 +2326,13 @@ func codedSubstrateFields(stats coded.Stats, ok bool) string {
 	if !ok {
 		return "none"
 	}
-	return fmt.Sprintf("sent=%d repairs=%d recovered=%d lost=%d window=%d coding=%t rate=%.2f",
-		stats.Sent, stats.Repairs, stats.Recovered, stats.Lost, stats.Window,
+	// arrived and sources are printed next to lost because without them the
+	// line invites a ratio between opposite directions: sent is what this
+	// endpoint transmitted, lost is what it failed to receive, and "lost is
+	// ten times sent" is an ordinary asymmetric flow rather than a fault.
+	return fmt.Sprintf("sent=%d repairs=%d arrived=%d sources=%d recovered=%d lost=%d residual=%.4f erasure=%.4f window=%d coding=%t rate=%.2f",
+		stats.Sent, stats.Repairs, stats.Arrived, stats.Sources, stats.Recovered, stats.Lost,
+		stats.Residual(), stats.Erasure(), stats.Window,
 		stats.Plan.Code, stats.Plan.Rate)
 }
 
@@ -2345,6 +2350,14 @@ func codedSubstrateLogFields(stats coded.Stats, ok bool) []any {
 		"fec_repairs_total", stats.Repairs,
 		"fec_recovered_total", stats.Recovered,
 		"fec_residual_lost_total", stats.Lost,
+		"fec_arrived_total", stats.Arrived,
+		"fec_source_symbols_total", stats.SourceSymbols(),
+		// The receive direction's own rates. fec_observed_loss below is what
+		// the estimator infers from transmission-sequence gaps; these two are
+		// what the decoder actually accounted for, and both are in [0,1] by
+		// construction.
+		"fec_measured_erasure", stats.Erasure(),
+		"fec_residual_loss", stats.Residual(),
 		"fec_oversize_total", stats.Oversize,
 		"fec_window_symbols", stats.Window,
 		"fec_coding", plan.Code,


### PR DESCRIPTION
Fixes #21.

## Where wire loss and casualties were conflated

`coded.Path` takes a transmission sequence number for every datagram before handing it to the carrier, and the peer measures the channel from the gaps between the sequences it receives. When the carrier refuses a datagram — `ErrDatagramTooLarge`, which happens exactly when the path degrades and QUIC's packet-size estimate moves — the number was spent anyway. The datagram never existed on the wire, but the peer sees a hole and records an erasure.

That is the report's "shard outstanding on a lane that fails is a routing event, not a channel observation", at the point where the two get mixed. The measured rate then sizes the parity, and the parity is load on the path that was already failing.

**Quantified:** in `TestARefusedDatagramIsNotMeasuredAsWireLoss` the channel erases nothing and the carrier refuses one datagram in seven. Before this change the receiver measures **14.2% wire loss** (`wire loss = 0.1423 after 83 local refusals`); after it, zero.

## What changed

- `internal/coded/coded.go`: `put` reports whether the datagram reached the carrier, and a refusal hands the sequence number back (`untake`). The send loop is the only taker, so the numbering ends up describing exactly what went out. The symbol is still a casualty — the session above re-issues it, and `TestARefusedDatagramStillCostsItsSymbol` pins that it is still accounted for — it is only the channel measurement it stays out of. `repairs` is no longer counted for a repair that was refused.
- The counters had no denominator in their own direction: `Sent` is what this endpoint transmits, `Lost` is what it fails to receive, which is why the field report read "`lost` is 10× `sent`" as impossible. It is an ordinary asymmetric flow. Added `Arrived` and `Sources`, plus `Erasure()` and `Residual()` over `Sources + Recovered + Lost` — a complete partition of the peer's source symbols, so both are in [0,1] by construction. Logged as `fec_arrived_total`, `fec_source_symbols_total`, `fec_measured_erasure`, `fec_residual_loss`; `docs/LOGGING.md` explains the two directions.
- `internal/fec/rate.go`: `Choose` and `ShardsFor` refuse a loss rate at or above one (and NaN, hence the negated comparison) instead of sizing the lowest rate the search allows — eight times the wire per delivered byte — for a channel that delivers nothing.
- `internal/lossmodel/lossmodel.go`: reported quotients pass through `probability()`, so an accounting failure upstream cannot present itself to `Choose` as a rate. This is the "at minimum, clamp" ask; the invariant should hold on its own, and `TestSnapshotLeavesAnOrdinaryEstimateAlone` pins that a real estimate is untouched.

## Scope

This does not change the wire format, the code plan, or the estimator's algorithm. It changes which events are allowed to count as channel observations, and gives the receive direction counters that can be read as rates.

## Checks

`go test -short -timeout 20m ./...`, `go vet ./...`, `gofmt -l .`, and `staticcheck -checks=all,-U1000` on the four changed packages are clean; `go test -short -race` passes on `internal/coded`, `internal/lossmodel`, and `internal/pep`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jidJ9KKtHtTbWUX2sgKf5