### PR TITLE
fix: end the replacement grace when nothing will replace the lane

### DIFF
--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -1807,6 +1807,12 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 	_, controlReserve := bulkLaneBudget(flow.reserveControlLane)
 	manageCtx, manageCancel := context.WithCancel(ctx)
 	defer manageCancel()
+	// This goroutine is the only thing that opens a replacement lane for this
+	// flow. When it returns -- budget spent, context gone, or handed off to the
+	// bundle manager below, which marks the flow again when it returns in turn
+	// -- the flow's replacement grace is waiting for something nobody will
+	// send, and it should stop rather than leave the application in silence.
+	defer flow.noteReplacementAbandoned()
 	go func() {
 		select {
 		case <-flow.doneChan():
@@ -1890,7 +1896,14 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 			snapshot := flow.snapshot()
 			now := time.Now()
 			if snapshot.HealthyLanes == 0 {
-				if flow.doneChanClosed() || recoveryAttempts >= maxLaneRecoveryAttempts {
+				if flow.doneChanClosed() {
+					return
+				}
+				if recoveryAttempts >= maxLaneRecoveryAttempts {
+					// Say so once, at the level a failing flow is reported at:
+					// from here the flow fails immediately rather than waiting
+					// out a grace nothing will arrive during.
+					c.cfg.Logger.Info("lane recovery abandoned", "attempts", recoveryAttempts, "flow_id", flowID)
 					return
 				}
 				if !nextRecovery.IsZero() && now.Before(nextRecovery) {
@@ -2019,6 +2032,9 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) {
 	manageCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	// As in manageQUICLanes: once this returns, nothing will open another lane
+	// for the flow, and its replacement grace has nothing left to wait for.
+	defer flow.noteReplacementAbandoned()
 	go func() {
 		select {
 		case <-flow.doneChan():

--- a/internal/pep/lanegrace_test.go
+++ b/internal/pep/lanegrace_test.go
@@ -1,0 +1,93 @@
+package pep
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/protocol"
+)
+
+// The replacement grace covers the time a replacement lane needs to arrive.
+// The flow used to end it only on an explicit refusal, which arrives when a
+// rescue handshake completes -- and on a path lossy enough to have killed
+// every lane, the rescue handshake is usually what fails instead. So the
+// answer often never came and the application waited in silence: 25s on
+// average and 573s at worst in the reported incident.
+func TestWaitEndsWhenNoReplacementWillBeAttempted(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	waits := make(chan error, 1)
+	go func() { waits <- flow.waitForHealthyLane(context.Background(), laneReplacementWait) }()
+
+	select {
+	case err := <-waits:
+		t.Fatalf("the wait ended with no evidence at all: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	flow.noteReplacementAbandoned()
+	select {
+	case err := <-waits:
+		if !errors.Is(err, errReplacementAbandoned) {
+			t.Fatalf("wait error = %v, want %v", err, errReplacementAbandoned)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("the flow waited out its grace after replacement was abandoned")
+	}
+}
+
+// A flow that already knows nothing is coming must not enter the wait at all.
+func TestWaitIsNotEnteredOnceReplacementIsAbandoned(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	flow.noteReplacementAbandoned()
+	start := time.Now()
+	if err := flow.waitForHealthyLane(context.Background(), laneReplacementWait); !errors.Is(err, errReplacementAbandoned) {
+		t.Fatalf("wait error = %v, want %v", err, errReplacementAbandoned)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("the wait took %s to report what it already knew", elapsed)
+	}
+}
+
+// A healthy lane is still the answer, whatever the manager has stopped doing.
+func TestAbandonedReplacementDoesNotFailAFlowWithALane(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	flow.lanes[1] = &mpLane{id: 1, kind: TransportQUIC, fc: newFrameConn(local)}
+	flow.noteReplacementAbandoned()
+	if err := flow.waitForHealthyLane(context.Background(), laneReplacementWait); err != nil {
+		t.Fatalf("a flow with a healthy lane failed: %v", err)
+	}
+}
+
+// The wait is a client-side conclusion drawn from the client's own behaviour.
+// A server flow never draws it: the rescue is still somebody's to send, and
+// its grace is what gives the peer time to send it.
+func TestTheLaneManagerIsWhatAbandonsReplacement(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	if flow.replacementAbandoned.Load() {
+		t.Fatal("a fresh flow starts with its replacement grace already spent")
+	}
+	client := &Client{cfg: ClientConfig{Logger: slog.New(slog.NewTextHandler(discardWriter{}, nil))}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client.manageQUICLanes(ctx, flow, flow.sessionID, flow.flowID)
+	if !flow.replacementAbandoned.Load() {
+		t.Fatal("the lane manager returned without ending the flow's replacement grace")
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func newGraceTestFlow(t *testing.T) *multipathFlow {
+	t.Helper()
+	inner, peer := net.Pipe()
+	t.Cleanup(func() { _ = inner.Close(); _ = peer.Close() })
+	return newMultipathFlow(context.Background(), inner, [16]byte{2}, 3, defaultChunkSize, protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -232,6 +232,14 @@ type multipathFlow struct {
 	// does not know this session. That answer is permanent, so it ends the
 	// replacement grace rather than being retried.
 	resumeRefused atomic.Bool
+	// replacementAbandoned records that whatever opens replacement lanes for
+	// this flow has stopped: its attempt budget is spent, or its manager has
+	// returned. The grace exists to cover the time a replacement needs to
+	// arrive, so once nothing is going to attempt one it is only silence the
+	// application is waiting through. It is set on the endpoint that opens
+	// replacements; the other end keeps waiting for a rescue that is still
+	// somebody's to send.
+	replacementAbandoned atomic.Bool
 	// controlLaneShared reports whether another flow is currently using the
 	// pooled control connection. Nil means "no", which is what a flow on a
 	// dedicated connection should answer.
@@ -1617,12 +1625,23 @@ func (f *multipathFlow) tryEnqueueFrameClass(lane *mpLane, frame protocol.Frame,
 	}
 }
 
+// noteReplacementAbandoned records that no further replacement lane will be
+// attempted for this flow.
+//
+// It is a statement about this endpoint's own behaviour rather than a guess
+// about the path or the peer, which is what makes it safe to act on: waiting
+// longer cannot produce a lane nobody is going to open.
+func (f *multipathFlow) noteReplacementAbandoned() { f.replacementAbandoned.Store(true) }
+
 func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Duration) error {
 	if len(f.healthyLanes()) > 0 {
 		return nil
 	}
 	if f.resumeRefused.Load() {
 		return errResumeRefused
+	}
+	if f.replacementAbandoned.Load() {
+		return errReplacementAbandoned
 	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -1642,6 +1661,17 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 				// the handshake itself often fails, this was 45 seconds of
 				// silence per lost flow.
 				return errResumeRefused
+			}
+			if f.replacementAbandoned.Load() {
+				// The refusal above is the answer this flow gets when a rescue
+				// handshake completes. On a path lossy enough to kill every
+				// lane, the rescue handshake is usually what fails instead, so
+				// that answer often never arrives and the flow used to wait out
+				// the whole grace -- and then, once the attempt budget reset,
+				// several more of them. This is the same conclusion reached
+				// from evidence this endpoint already has: it has stopped
+				// trying to replace the lane.
+				return errReplacementAbandoned
 			}
 		case <-timer.C:
 			return errors.New("lane replacement timeout")
@@ -2437,6 +2467,10 @@ func (f *multipathFlow) takeReceivedRanges(cumulative uint64) [][2]uint64 {
 // errResumeRefused reports that the peer cannot resume this association: it
 // has no such session, so no replacement lane can be attached to it.
 var errResumeRefused = errors.New("peer does not hold this session")
+
+// errReplacementAbandoned reports that this endpoint has stopped attempting
+// replacement lanes for the flow, so its grace has nothing left to wait for.
+var errReplacementAbandoned = errors.New("no replacement lane will be attempted")
 
 // retainClose keeps this flow's half-close so a replacement lane can be given
 // it when the lane that carried it dies first.


### PR DESCRIPTION
Fixes #23.

## The wait outlived the thing it was waiting for

`waitForHealthyLane` short-circuits on `resumeRefused`, and `resumeRefused` is only set when a rescue handshake *completes* and returns `errLaneJoinRejected`. On a path lossy enough to have killed every lane, the rescue handshake is itself what fails — so that answer arrives late or never, and the flow burns the full 45s grace, then another one after the recovery backoff, and another after `laneRecoveryResetAfter` hands the attempt budget back. That is the reported 25.1s mean and 573.5s maximum.

Meanwhile `manageQUICLanes` had already given up: it returns once `recoveryAttempts >= maxLaneRecoveryAttempts`. It is the only thing that opens a replacement lane for the flow, so from that moment the grace is waiting for something nobody will send.

## What changed

- `multipathFlow.replacementAbandoned` + `noteReplacementAbandoned()`, checked by `waitForHealthyLane` on entry and on each tick, alongside `resumeRefused`.
- `manageQUICLanes` and `manageTCPBundle` mark the flow with a `defer`, so *every* exit counts — budget spent, context gone, or the QUIC manager handing off to the bundle manager (which marks again when it returns in turn).
- The give-up branch logs `lane recovery abandoned` with the attempt count at info, so the operator can see why a flow now fails early.

## Answering the discussion points

- **Should repeated rescue failures progressively shorten the grace?** This is that, without a schedule guessed in advance: the grace ends when the attempts do. The attempt budget already encodes how many failures are worth tolerating, so a second decaying policy on top would just be a slower way of reaching the same conclusion.
- **Should a refusal for one flow fail sibling flows sharing the dead lanes?** Not done here, deliberately. A refusal proves the peer does not hold *that* session; sessions are per flow, and the sibling's session may still be registered. That inference would fail healthy flows on a guess, whereas "my own lane manager has stopped" is a fact about this endpoint and cannot end a grace during which a replacement was still coming.
- **Is 9.5 minutes ever right?** No, and it is now unreachable by this route. The grace itself is unchanged for the case it was sized for — a replacement genuinely in flight — and the server keeps its full grace, since there the rescue is still the peer's to send.

## Checks

Four tests in `internal/pep/lanegrace_test.go`: the wait does not end without evidence, ends promptly once replacement is abandoned, is not entered at all when the flow already knows, does not fail a flow that still has a healthy lane, and the lane manager is verified to be what marks the flow.

`go test -short -timeout 20m ./...`, `go vet ./...`, `gofmt -l .`, `staticcheck -checks=all,-U1000 ./internal/pep/`, and `go test -race` on the new tests are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jidJ9KKtHtTbWUX2sgKf5