### PR TITLE
docs: define the contract for adding an external benchmark transport

### DIFF
--- a/cmd/queqiaobench/main.go
+++ b/cmd/queqiaobench/main.go
@@ -579,7 +579,10 @@ func startStackOn(ctx context.Context, stack string, opts options, pathCfg paths
 		}
 		if opts.singBox == "" {
 			h.Close()
-			return nil, fmt.Errorf("stack %q requires --sing-box", stack)
+			// The registry says which implementation provides the stack, so a
+			// transport added later asks for its own binary rather than for
+			// the one the first four happened to use.
+			return nil, fmt.Errorf("stack %q requires a %s binary (--sing-box)", stack, kind.Implementation())
 		}
 		// The third-party implementation needs its TLS material on disk, and
 		// the SOCKS listener has to be free for it to bind itself.
@@ -997,7 +1000,7 @@ func writeCertificateFiles(dir string) (certPath, keyPath string, err error) {
 // segment, so the caller is told rather than given a silently lossless result.
 func startTCPStack(ctx context.Context, kind extproxy.Kind, opts options, pathCfg pathsim.Config, logger *slog.Logger) (*harness, error) {
 	if opts.singBox == "" {
-		return nil, fmt.Errorf("stack %q requires --sing-box", kind)
+		return nil, fmt.Errorf("stack %q requires a %s binary (--sing-box)", kind, kind.Implementation())
 	}
 	if pathCfg.LossRate > 0 || pathCfg.UpstreamLossRate > 0 {
 		return nil, fmt.Errorf("stack %q is TCP based and cannot be measured under emulated loss; "+

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -92,7 +92,8 @@ benchmark gains four more stacks:
 
 Each runs as a server the emulator forwards to and a client exposing SOCKS5,
 over exactly the same seeded path as queqiao. The client trusts exactly the
-server's certificate, so nothing disables verification.
+server's certificate, so nothing disables verification. The four are registry
+entries rather than special cases; see the contract below for adding another.
 
 **`cmd/queqiaobench`** — runs the selected stacks over one emulated path in a
 single process and reports per-trial rows, a summary, optional JSON, and an
@@ -116,6 +117,92 @@ WebSocket's framing cost — and `tuic` against `queqiao` is a fair comparison.
 `vless-tcp` against `tuic` is not. Emulating loss for a stream transport needs
 an IP-layer facility such as dummynet, which needs privilege this harness does
 not take.
+
+## Adding an external transport
+
+A stack is a pair of processes the harness starts, waits for, and stops. The
+harness owns the emulated path, the addresses, the TLS material, the work
+directory and the process lifetime. A stack answers two questions: what
+configuration to write, and what to run. `internal/extproxy` keeps those apart
+so a transport is added by registering it rather than by editing the launcher:
+
+```go
+// internal/extproxy/extproxy.go
+var stacks = map[Kind]stack{
+    TUIC: {transport: "udp", implementation: "sing-box", launch: singBoxLaunch},
+    ...
+}
+
+// A launch builder returns what to write and what to run.
+func singBoxLaunch(cfg Config) (Launch, error)
+```
+
+`Launch` carries `Files` (written before either process starts, keyed by a path
+under `Config.WorkDir`), `ServerArgs` and `ClientArgs`, and optionally
+`ServerBinary`/`ClientBinary` for an implementation that ships one program per
+side. `Plan` resolves it without running anything, which is how a stack's
+wiring is tested with nothing installed.
+
+What the running pair must satisfy:
+
+1. **The server binds `ServerListen` exactly.** That is the address the
+   emulator forwards to. A server that binds anything else produces a working
+   measurement that never crosses the emulated path, which is worse than a
+   failure because it looks like a result.
+2. **The client dials `ClientRemote`**, which is the emulator, never the server
+   directly.
+3. **The client exposes SOCKS5 at `SOCKSListen`.** SOCKS5 is the whole contract
+   with the benchmark, and the pair is considered ready when that address
+   accepts a TCP connection.
+4. **TLS material is the harness's.** The server uses `CertificatePath` and
+   `KeyPath`; the client trusts exactly `CertificatePath`. No verification
+   bypass, and the client's configuration must never reference the private key.
+   Both are tested.
+5. **Configuration goes in `WorkDir` and nowhere else.** The harness creates it
+   and removes it.
+6. **The processes must die with their process group.** The harness starts each
+   side in its own group and escalates if it does not exit; an implementation
+   that daemonizes or leaves a helper behind holds its ports and silently
+   contaminates every later trial.
+7. **Declare the relay honestly.** `transport: "udp"` puts the stack behind the
+   packet emulator, where loss, delay and rate apply. `"tcp"` means it can only
+   be measured with `--loss 0`, for the reason in the section above.
+
+A tunnel rather than a proxy -- kcptun is the obvious example -- has no SOCKS5
+of its own: it forwards a local TCP port to a target. Such a stack is three
+processes, because the target has to be a SOCKS5 server on the server side, and
+the tunnel's local port is then the endpoint the benchmark speaks to. `Launch`
+describes two sides today; a stack of that shape should extend it with the
+third process rather than starting one outside the harness, so teardown keeps a
+single owner and no listener outlives the run.
+
+### Comparing a fixed-parity transport
+
+A transport with FEC in the matrix is worth having, and it needs one thing said
+about the comparison before the numbers are taken. Queqiao chooses its parity
+from a measured erasure floor, and it revises that choice while a flow runs; a
+kcptun-style code rate is a constant chosen in advance. A single configuration
+is therefore a comparison against one guess, and whichever way it lands the
+result is mostly about the guess.
+
+So a submitted comparison should carry:
+
+- **A parity sweep, not a point.** Several `-datashard`/`-parityshard` ratios
+  spanning above and below the emulated erasure rate, with the best one shown
+  against queqiao rather than an arbitrary one.
+- **The cost alongside the rate.** Parity is bandwidth spent on the same
+  bottleneck, so report the parity share of bytes sent on both sides. Queqiao's
+  is `fec_repairs_total` over `fec_sent_total` in its runtime log; a transport
+  buying more of the wire can finish sooner while delivering fewer useful bytes
+  per byte sent, and a goodput column alone hides that.
+- **Every parameter that moves the answer.** Implementation version, `-mode` or
+  the explicit `-nodelay/-interval/-resend/-nc`, `-sndwnd`/`-rcvwnd`, `-mtu`,
+  compression, and whatever the SOCKS5 target adds. The window settings are the
+  congestion control in practice, so a run that does not state them is not
+  reproducible.
+- **The same rules as every other cell**: one seeded path, alternating trial
+  order, medians over all trials counting failures at their partial rate, and a
+  check against the calibration bound below.
 
 ## Reading the numbers
 

--- a/internal/extproxy/extproxy.go
+++ b/internal/extproxy/extproxy.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -43,15 +43,73 @@ const (
 	VLESSTCP       Kind = "vless-tcp"
 )
 
-// Transport reports whether a kind runs over UDP, which decides whether the
-// UDP path emulator can carry it.
-func (k Kind) Transport() string {
-	switch k {
-	case TUIC, Hysteria2:
-		return "udp"
-	default:
-		return "tcp"
+// Launch is what a stack asks the harness to run for one measured pair.
+//
+// The harness owns the path, the addresses, the certificate, the work
+// directory and the process lifetime. A stack owns exactly two answers: what
+// to write, and what to run. Keeping those apart is what lets a transport be
+// added without touching Start -- sing-box takes a JSON file per side, an
+// implementation configured entirely by flags returns no files at all, and one
+// shipping separate client and server programs names a binary per side.
+type Launch struct {
+	// Files is configuration written before either process starts, keyed by
+	// path and marshalled as JSON. Build the paths from Config.WorkDir, which
+	// the caller creates and removes.
+	Files map[string]any
+	// ServerBinary and ClientBinary default to Config.Binary, which is the
+	// usual case: one implementation serving both sides.
+	ServerBinary, ClientBinary string
+	// ServerArgs and ClientArgs are what each side is run with.
+	ServerArgs, ClientArgs []string
+}
+
+// stack is one third-party transport this package can measure.
+type stack struct {
+	// transport is the relay that can carry it, "udp" or "tcp". It decides
+	// whether the packet emulator can carry the stack at all: a userspace
+	// relay cannot drop a segment out of a byte stream, so a TCP transport
+	// cannot be measured under emulated loss. See docs/BENCHMARKING.md.
+	transport string
+	// implementation is the program that provides it, which is what a caller
+	// missing its path has to be told to supply.
+	implementation string
+	launch         func(Config) (Launch, error)
+}
+
+// stacks is the registry a new transport is added to. Everything else in this
+// package is written against the registry rather than against sing-box.
+var stacks = map[Kind]stack{
+	TUIC:           {transport: "udp", implementation: "sing-box", launch: singBoxLaunch},
+	Hysteria2:      {transport: "udp", implementation: "sing-box", launch: singBoxLaunch},
+	VLESSTCP:       {transport: "tcp", implementation: "sing-box", launch: singBoxLaunch},
+	VLESSWebSocket: {transport: "tcp", implementation: "sing-box", launch: singBoxLaunch},
+}
+
+// Kinds lists the transports this package can launch, in a stable order.
+func Kinds() []Kind {
+	kinds := make([]Kind, 0, len(stacks))
+	for kind := range stacks {
+		kinds = append(kinds, kind)
 	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i] < kinds[j] })
+	return kinds
+}
+
+// Transport reports whether a kind runs over UDP, which decides whether the
+// UDP path emulator can carry it. An unregistered kind is reported as TCP,
+// which is the conservative answer: it keeps an unknown name away from the
+// packet relay rather than measuring it there.
+func (k Kind) Transport() string {
+	if s, ok := stacks[k]; ok {
+		return s.transport
+	}
+	return "tcp"
+}
+
+// Implementation names the program that provides a kind, so a caller that was
+// not given its path can say which one is missing.
+func (k Kind) Implementation() string {
+	return stacks[k].implementation
 }
 
 // Config describes one measured pair.
@@ -121,26 +179,22 @@ func (p *Pair) Logs() string {
 // connections, so a benchmark never measures a process that is still starting.
 func Start(ctx context.Context, cfg Config) (*Pair, error) {
 	cfg = cfg.withDefaults()
-	if cfg.Binary == "" {
-		return nil, errors.New("a proxy binary is required")
-	}
-	if _, err := os.Stat(cfg.Binary); err != nil {
-		return nil, fmt.Errorf("proxy binary: %w", err)
-	}
-	serverConfig, clientConfig, err := buildConfigs(cfg)
+	launch, err := Plan(cfg)
 	if err != nil {
 		return nil, err
 	}
-	serverPath := filepath.Join(cfg.WorkDir, string(cfg.Kind)+"-server.json")
-	clientPath := filepath.Join(cfg.WorkDir, string(cfg.Kind)+"-client.json")
-	if err := writeJSON(serverPath, serverConfig); err != nil {
-		return nil, err
+	for _, binary := range []string{launch.ServerBinary, launch.ClientBinary} {
+		if _, err := os.Stat(binary); err != nil {
+			return nil, fmt.Errorf("proxy binary: %w", err)
+		}
 	}
-	if err := writeJSON(clientPath, clientConfig); err != nil {
-		return nil, err
+	for path, value := range launch.Files {
+		if err := writeJSON(path, value); err != nil {
+			return nil, err
+		}
 	}
 
-	server, err := startProcess(ctx, cfg.Binary, "run", "-c", serverPath)
+	server, err := startProcess(ctx, launch.ServerBinary, launch.ServerArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -150,17 +204,48 @@ func Start(ctx context.Context, cfg Config) (*Pair, error) {
 		server.stop()
 		return nil, fmt.Errorf("%s server did not listen: %w\n%s", cfg.Kind, err, server.output())
 	}
-	client, err := startProcess(ctx, cfg.Binary, "run", "-c", clientPath)
+	client, err := startProcess(ctx, launch.ClientBinary, launch.ClientArgs...)
 	if err != nil {
 		server.stop()
 		return nil, err
 	}
+	// SOCKS5 is the contract with the benchmark: whatever the transport is,
+	// the measured client is a SOCKS5 endpoint at this address, and it is
+	// ready when that address accepts a connection.
 	if err := waitForListener(ctx, cfg.SOCKSListen, "tcp", 10*time.Second); err != nil {
 		client.stop()
 		server.stop()
 		return nil, fmt.Errorf("%s client did not listen: %w\n%s", cfg.Kind, err, client.output())
 	}
 	return &Pair{server: server, client: client}, nil
+}
+
+// Plan resolves what a stack would write and run, without running it. Start
+// uses it, and a test can read it to check a stack's wiring without needing
+// the implementation installed.
+func Plan(cfg Config) (Launch, error) {
+	cfg = cfg.withDefaults()
+	registered, ok := stacks[cfg.Kind]
+	if !ok {
+		return Launch{}, fmt.Errorf("unsupported transport %q", cfg.Kind)
+	}
+	if cfg.Binary == "" {
+		return Launch{}, fmt.Errorf("a %s binary is required for %s", registered.implementation, cfg.Kind)
+	}
+	launch, err := registered.launch(cfg)
+	if err != nil {
+		return Launch{}, err
+	}
+	if launch.ServerBinary == "" {
+		launch.ServerBinary = cfg.Binary
+	}
+	if launch.ClientBinary == "" {
+		launch.ClientBinary = cfg.Binary
+	}
+	if len(launch.ServerArgs) == 0 || len(launch.ClientArgs) == 0 {
+		return Launch{}, fmt.Errorf("%s launch plan is missing a side", cfg.Kind)
+	}
+	return launch, nil
 }
 
 func writeJSON(path string, value any) error {

--- a/internal/extproxy/extproxy_test.go
+++ b/internal/extproxy/extproxy_test.go
@@ -133,3 +133,90 @@ func TestInvalidAddressesAreRejected(t *testing.T) {
 		t.Fatal("a malformed listen address was accepted")
 	}
 }
+
+func planFor(t *testing.T, kind Kind) Launch {
+	t.Helper()
+	launch, err := Plan(Config{
+		Kind: kind, Binary: "/usr/local/bin/sing-box",
+		ServerListen: "127.0.0.1:11111", ClientRemote: "127.0.0.1:22222",
+		SOCKSListen:     "127.0.0.1:33333",
+		CertificatePath: "/tmp/cert.pem", KeyPath: "/tmp/key.pem",
+		WorkDir: "/tmp/bench",
+	})
+	if err != nil {
+		t.Fatalf("plan %s: %v", kind, err)
+	}
+	return launch
+}
+
+// A stack answers two questions -- what to write and what to run -- and the
+// harness owns everything else. That split is the contract a new transport is
+// added against, so it is checked here rather than left to be discovered by
+// whoever adds the next one.
+func TestEveryRegisteredStackPlansBothSides(t *testing.T) {
+	kinds := Kinds()
+	if len(kinds) == 0 {
+		t.Fatal("no stacks are registered")
+	}
+	for _, kind := range kinds {
+		t.Run(string(kind), func(t *testing.T) {
+			if transport := kind.Transport(); transport != "udp" && transport != "tcp" {
+				t.Fatalf("transport = %q, want udp or tcp", transport)
+			}
+			if kind.Implementation() == "" {
+				t.Fatal("no implementation is named, so a caller cannot be told what to install")
+			}
+			launch := planFor(t, kind)
+			if launch.ServerBinary != "/usr/local/bin/sing-box" || launch.ClientBinary != "/usr/local/bin/sing-box" {
+				t.Fatalf("binaries = %q and %q, want the configured one on both sides",
+					launch.ServerBinary, launch.ClientBinary)
+			}
+			if len(launch.ServerArgs) == 0 || len(launch.ClientArgs) == 0 {
+				t.Fatalf("launch = %+v, want arguments for both sides", launch)
+			}
+			// Every file a side is told to read must be one the plan also
+			// writes, or the process starts against nothing.
+			for _, args := range [][]string{launch.ServerArgs, launch.ClientArgs} {
+				for _, arg := range args {
+					if !strings.HasPrefix(arg, "/tmp/bench/") {
+						continue
+					}
+					if _, ok := launch.Files[arg]; !ok {
+						t.Fatalf("%q is passed to a process but never written: %v", arg, launch.Files)
+					}
+				}
+			}
+		})
+	}
+}
+
+// The two errors a contributor meets first must say what is wrong.
+func TestPlanRejectsAnUnknownStackAndAMissingBinary(t *testing.T) {
+	if _, err := Plan(Config{Kind: "kcptun", Binary: "/bin/true", WorkDir: "/tmp"}); err == nil {
+		t.Fatal("an unregistered stack was planned")
+	} else if !strings.Contains(err.Error(), "kcptun") {
+		t.Fatalf("error = %v, want the stack named", err)
+	}
+	if _, err := Plan(Config{Kind: TUIC, WorkDir: "/tmp"}); err == nil {
+		t.Fatal("a stack was planned with no binary")
+	} else if !strings.Contains(err.Error(), "sing-box") {
+		t.Fatalf("error = %v, want the implementation named", err)
+	}
+}
+
+// Kinds is what a caller lists stacks from, so its order must not depend on
+// map iteration.
+func TestKindsIsStablyOrdered(t *testing.T) {
+	first := Kinds()
+	for i := 0; i < 10; i++ {
+		got := Kinds()
+		if len(got) != len(first) {
+			t.Fatalf("Kinds() length changed: %v then %v", first, got)
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("Kinds() order changed: %v then %v", first, got)
+			}
+		}
+	}
+}

--- a/internal/extproxy/singbox.go
+++ b/internal/extproxy/singbox.go
@@ -3,8 +3,25 @@ package extproxy
 import (
 	"fmt"
 	"net"
+	"path/filepath"
 	"strconv"
 )
+
+// singBoxLaunch answers the two questions in Launch for every sing-box stack:
+// one JSON configuration per side, and "run -c" over each of them.
+func singBoxLaunch(cfg Config) (Launch, error) {
+	server, client, err := buildConfigs(cfg)
+	if err != nil {
+		return Launch{}, err
+	}
+	serverPath := filepath.Join(cfg.WorkDir, string(cfg.Kind)+"-server.json")
+	clientPath := filepath.Join(cfg.WorkDir, string(cfg.Kind)+"-client.json")
+	return Launch{
+		Files:      map[string]any{serverPath: server, clientPath: client},
+		ServerArgs: []string{"run", "-c", serverPath},
+		ClientArgs: []string{"run", "-c", clientPath},
+	}, nil
+}
 
 // The configurations below are sing-box's schema. They are written as plain
 // maps rather than typed structs because the schema is the other project's and


### PR DESCRIPTION
Answers the second half of #19: *"would you be interested in defining/documenting a standardized interface for adding external transports to queqiaobench?"*

It does not add kcptun. That needs the binary, a real measurement campaign, and a call on the matrix that belongs to the maintainer — this makes the contribution possible and says what it has to satisfy.

## The seam was not one

`internal/extproxy` presented itself as "any binary that can be configured to expose SOCKS5", but `Start` ran `sing-box run -c <json>` for both sides and `Kind.Transport()` switched over the four known names. Adding a transport meant editing the launcher rather than adding to it, and nothing could express an implementation that ships separate client and server programs — which is exactly kcptun's shape.

Each stack is now a registry entry:

```go
var stacks = map[Kind]stack{
    TUIC: {transport: "udp", implementation: "sing-box", launch: singBoxLaunch},
    ...
}
```

A launch builder returns `Launch{Files, ServerBinary, ClientBinary, ServerArgs, ClientArgs}` — what to write and what to run. `Plan` resolves it without starting anything, so a stack's wiring is testable with nothing installed. `Kind.Transport()` and the new `Kind.Implementation()` read the registry, so the "requires --sing-box" message now names whatever implementation the stack declares.

**Behaviour is unchanged**: the same four stacks produce the same sing-box configurations and the same commands. The existing config tests pass untouched.

## The contract, in docs/BENCHMARKING.md

A new "Adding an external transport" section states what a pair must satisfy: the server binds `ServerListen` exactly (binding elsewhere produces a measurement that never crosses the emulated path — worse than a failure, because it looks like a result); the client dials the emulator; SOCKS5 at `SOCKSListen` is the whole interface with the benchmark; the harness's certificate with no verification bypass and no private key on the client; configuration confined to `WorkDir`; teardown by process group, because a leaked helper holds its ports and contaminates later trials; and an honest `udp`/`tcp` declaration, since a TCP stack can only be measured with `--loss 0`.

It also notes what a *tunnel* rather than a proxy needs — kcptun forwards a local TCP port, so it is three processes with a SOCKS5 server as the target, and the third belongs inside the harness's lifetime rather than outside it.

## On KCP fairness

The issue asks what configuration would be fair. A subsection answers it as requirements rather than a number, because queqiao sizes parity from a measured erasure floor and revises it mid-flow while a kcptun code rate is a constant chosen in advance — a single setting compares against one guess. A submitted comparison should carry a parity sweep spanning above and below the emulated erasure rate, the parity share of bytes sent on **both** sides (a transport buying more of the wire can finish sooner while delivering fewer useful bytes per byte sent), every parameter that moves the answer including the windows that are its congestion control in practice, and the same seeded-path/alternation/median rules as every other cell.

## Checks

New tests: every registered stack plans both sides with a binary, arguments, and no file passed to a process that the plan does not also write; `Plan` names the stack and the implementation in its two rejections; `Kinds()` is stably ordered. `go test -short -timeout 20m ./...`, `go vet ./...`, `gofmt -l .`, `staticcheck -checks=all,-U1000`, and the Python suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jidJ9KKtHtTbWUX2sgKf5