### PR TITLE
feat: add kcptun to the benchmark matrix

### DIFF
--- a/cmd/queqiaobench/main.go
+++ b/cmd/queqiaobench/main.go
@@ -68,6 +68,9 @@ type options struct {
 	latency      bool
 	interactive  bool
 	singBox      string
+	kcptunClient string
+	kcptunServer string
+	kcp          extproxy.KCPParams
 	jsonOut      string
 	gate         bool
 	contend      string
@@ -108,6 +111,17 @@ func run(args []string) error {
 	fs.BoolVar(&opts.latency, "latency", false, "also measure small-request latency")
 	fs.BoolVar(&opts.interactive, "interactive", false, "issue small requests during the bulk transfer and report their latency")
 	fs.StringVar(&opts.singBox, "sing-box", "", "path to a sing-box binary, enabling the tuic and hysteria2 stacks")
+	fs.StringVar(&opts.kcptunClient, "kcptun-client", "", "path to a kcptun client binary, enabling the kcptun stack")
+	fs.StringVar(&opts.kcptunServer, "kcptun-server", "", "path to a kcptun server binary, which kcptun ships separately from its client")
+	// A fixed code rate is chosen in advance rather than measured, so it is
+	// the parameter a kcptun comparison has to be swept over rather than the
+	// one it can leave at a default. The rest are here for the same reason:
+	// an unstated window is an unreproducible measurement.
+	fs.StringVar(&opts.kcp.Mode, "kcptun-mode", "", "kcptun latency preset: normal, fast, fast2 or fast3 (default fast)")
+	fs.IntVar(&opts.kcp.DataShards, "kcptun-datashard", 0, "kcptun FEC data shards (default 10)")
+	fs.IntVar(&opts.kcp.ParityShards, "kcptun-parityshard", 0, "kcptun FEC parity shards, the fixed code rate to sweep (default 3)")
+	fs.IntVar(&opts.kcp.SendWindow, "kcptun-sndwnd", 0, "kcptun send window in packets (default 128)")
+	fs.IntVar(&opts.kcp.ReceiveWindow, "kcptun-rcvwnd", 0, "kcptun receive window in packets (default 512)")
 	fs.StringVar(&opts.jsonOut, "json", "", "also write the full result set to this path as JSON")
 	fs.StringVar(&opts.contend, "contend", "", "two stacks to run concurrently on one shared bottleneck, e.g. queqiao,baseline; reports each one's share of the link")
 	fs.BoolVar(&opts.gate, "gate", false, "exit non-zero when queqiao is worse than the reference beyond --tolerance")
@@ -577,12 +591,10 @@ func startStackOn(ctx context.Context, stack string, opts options, pathCfg paths
 			h.Close()
 			return nil, fmt.Errorf("stack %q is not carried by the UDP path emulator", stack)
 		}
-		if opts.singBox == "" {
+		clientBinary, serverBinary, err := externalBinaries(kind, opts)
+		if err != nil {
 			h.Close()
-			// The registry says which implementation provides the stack, so a
-			// transport added later asks for its own binary rather than for
-			// the one the first four happened to use.
-			return nil, fmt.Errorf("stack %q requires a %s binary (--sing-box)", stack, kind.Implementation())
+			return nil, err
 		}
 		// The third-party implementation needs its TLS material on disk, and
 		// the SOCKS listener has to be free for it to bind itself.
@@ -597,6 +609,20 @@ func startStackOn(ctx context.Context, stack string, opts options, pathCfg paths
 			_ = os.RemoveAll(workDir)
 			return nil, err
 		}
+		// A tunnel stack forwards a port rather than proxying, so the harness
+		// runs the SOCKS5 endpoint it forwards to. It sits beyond the
+		// emulator, so its own dial is loopback and is not measured.
+		socksTarget := ""
+		if kind.NeedsSOCKSTarget() {
+			target, err := extproxy.StartSOCKSTarget(ctx)
+			if err != nil {
+				h.Close()
+				_ = os.RemoveAll(workDir)
+				return nil, err
+			}
+			socksTarget = target.Address()
+			h.closes = append(h.closes, func() { _ = target.Close() })
+		}
 		// The external implementation binds these itself, so the harness has to
 		// release the addresses it reserved. Without this the server silently
 		// fails to bind and every request fails at SOCKS with a general error.
@@ -605,10 +631,11 @@ func startStackOn(ctx context.Context, stack string, opts options, pathCfg paths
 		socksAddr := h.socks
 		_ = socksListener.Close()
 		pair, err := extproxy.Start(ctx, extproxy.Config{
-			Kind: kind, Binary: opts.singBox,
+			Kind: kind, Binary: clientBinary, ServerBinary: serverBinary,
 			ServerListen: serverAddr, ClientRemote: relay.LocalAddr(),
 			SOCKSListen: socksAddr, CertificatePath: certPath, KeyPath: keyPath,
 			Congestion: externalCongestion(opts.congestion), WorkDir: workDir,
+			SOCKSTarget: socksTarget, KCP: opts.kcp,
 		})
 		if err != nil {
 			h.Close()
@@ -995,12 +1022,38 @@ func writeCertificateFiles(dir string) (certPath, keyPath string, err error) {
 	return certPath, keyPath, nil
 }
 
+// externalBinaries picks the programs one external stack needs, and says which
+// flag is missing when it has not been given them.
+//
+// The registry names the implementation, so a stack added later asks for its
+// own binary rather than for the one the first four happened to use, and an
+// implementation shipping one program per side asks for both.
+func externalBinaries(kind extproxy.Kind, opts options) (client, server string, err error) {
+	switch implementation := kind.Implementation(); implementation {
+	case "sing-box":
+		if opts.singBox == "" {
+			return "", "", fmt.Errorf("stack %q requires a sing-box binary (--sing-box)", kind)
+		}
+		return opts.singBox, "", nil
+	case "kcptun":
+		if opts.kcptunClient == "" || opts.kcptunServer == "" {
+			return "", "", fmt.Errorf("stack %q requires --kcptun-client and --kcptun-server: kcptun ships one program per side", kind)
+		}
+		return opts.kcptunClient, opts.kcptunServer, nil
+	case "":
+		return "", "", fmt.Errorf("stack %q is not a transport this benchmark knows", kind)
+	default:
+		return "", "", fmt.Errorf("stack %q needs a %s binary, and this benchmark has no flag for one", kind, implementation)
+	}
+}
+
 // startTCPStack runs a stream-based transport over the TCP relay. Loss is not
 // available there: a userspace relay carries a byte stream and cannot drop a
 // segment, so the caller is told rather than given a silently lossless result.
 func startTCPStack(ctx context.Context, kind extproxy.Kind, opts options, pathCfg pathsim.Config, logger *slog.Logger) (*harness, error) {
-	if opts.singBox == "" {
-		return nil, fmt.Errorf("stack %q requires a %s binary (--sing-box)", kind, kind.Implementation())
+	clientBinary, serverBinary, err := externalBinaries(kind, opts)
+	if err != nil {
+		return nil, err
 	}
 	if pathCfg.LossRate > 0 || pathCfg.UpstreamLossRate > 0 {
 		return nil, fmt.Errorf("stack %q is TCP based and cannot be measured under emulated loss; "+
@@ -1042,10 +1095,10 @@ func startTCPStack(ctx context.Context, kind extproxy.Kind, opts options, pathCf
 		return nil, err
 	}
 	pair, err := extproxy.Start(ctx, extproxy.Config{
-		Kind: kind, Binary: opts.singBox,
+		Kind: kind, Binary: clientBinary, ServerBinary: serverBinary,
 		ServerListen: serverAddr, ClientRemote: relay.LocalAddr(),
 		SOCKSListen: socksAddr, CertificatePath: certPath, KeyPath: keyPath,
-		WorkDir: workDir,
+		WorkDir: workDir, KCP: opts.kcp,
 	})
 	if err != nil {
 		h.Close()

--- a/cmd/queqiaobench/stacks_test.go
+++ b/cmd/queqiaobench/stacks_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bojieli/queqiao/internal/extproxy"
+)
+
+// Each stack asks for the implementation it actually needs. Before there was a
+// registry every external stack asked for sing-box, which is the wrong thing
+// to tell somebody running a transport that ships its own programs.
+func TestEachStackAsksForItsOwnImplementation(t *testing.T) {
+	opts := options{singBox: "/bin/sing-box", kcptunClient: "/bin/kcptun-client", kcptunServer: "/bin/kcptun-server"}
+	for _, test := range []struct {
+		kind           extproxy.Kind
+		client, server string
+	}{
+		{kind: extproxy.TUIC, client: "/bin/sing-box"},
+		{kind: extproxy.Hysteria2, client: "/bin/sing-box"},
+		{kind: extproxy.VLESSTCP, client: "/bin/sing-box"},
+		{kind: extproxy.KCPTun, client: "/bin/kcptun-client", server: "/bin/kcptun-server"},
+	} {
+		t.Run(string(test.kind), func(t *testing.T) {
+			client, server, err := externalBinaries(test.kind, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if client != test.client || server != test.server {
+				t.Fatalf("binaries = %q and %q, want %q and %q", client, server, test.client, test.server)
+			}
+		})
+	}
+}
+
+// A missing binary has to name what is missing. "requires --sing-box" for a
+// kcptun run sends the operator to install the wrong thing.
+func TestAMissingBinaryNamesTheOneItNeeds(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		kind extproxy.Kind
+		opts options
+		want []string
+	}{
+		{name: "no sing-box", kind: extproxy.TUIC, want: []string{"sing-box"}},
+		{
+			name: "no kcptun at all", kind: extproxy.KCPTun,
+			want: []string{"--kcptun-client", "--kcptun-server", "one program per side"},
+		},
+		{
+			name: "only the kcptun client", kind: extproxy.KCPTun,
+			opts: options{kcptunClient: "/bin/kcptun-client"},
+			want: []string{"--kcptun-server"},
+		},
+		{name: "not a transport", kind: extproxy.Kind("wireguard"), want: []string{"not a transport"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := externalBinaries(test.kind, test.opts)
+			if err == nil {
+				t.Fatal("a stack was started with no implementation")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not mention %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// kcptun is carried by the packet emulator, like the other UDP stacks, and it
+// is the first stack that needs a SOCKS5 endpoint of the harness's own.
+func TestKCPTunIsAUDPTunnel(t *testing.T) {
+	if got := extproxy.KCPTun.Transport(); got != "udp" {
+		t.Fatalf("kcptun transport = %q, want udp", got)
+	}
+	if !extproxy.KCPTun.NeedsSOCKSTarget() {
+		t.Fatal("kcptun does not ask the harness for a SOCKS5 target")
+	}
+	for _, proxy := range []extproxy.Kind{extproxy.TUIC, extproxy.Hysteria2, extproxy.VLESSTCP, extproxy.VLESSWebSocket} {
+		if proxy.NeedsSOCKSTarget() {
+			t.Fatalf("%s asks for a SOCKS5 target it does not need", proxy)
+		}
+	}
+}

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -80,20 +80,44 @@ built Rust implementation conflates the transport design with the language and
 QUIC library; comparing against this isolates the design.
 
 **`internal/extproxy`** — launches third-party implementations so the
-comparison is not limited to an in-tree control. With `--sing-box PATH` the
-benchmark gains four more stacks:
+comparison is not limited to an in-tree control:
 
-| Stack | Implementation | Carried by |
-| --- | --- | --- |
-| `tuic` | sing-box, native TUIC v5 | UDP relay |
-| `hysteria2` | sing-box | UDP relay |
-| `vless-tcp` | sing-box, VLESS over TLS | TCP relay |
-| `vless-ws` | sing-box, VLESS over WebSocket | TCP relay |
+| Stack | Implementation | Carried by | Needs |
+| --- | --- | --- | --- |
+| `tuic` | sing-box, native TUIC v5 | UDP relay | `--sing-box` |
+| `hysteria2` | sing-box | UDP relay | `--sing-box` |
+| `vless-tcp` | sing-box, VLESS over TLS | TCP relay | `--sing-box` |
+| `vless-ws` | sing-box, VLESS over WebSocket | TCP relay | `--sing-box` |
+| `kcptun` | kcptun, KCP with fixed-rate FEC | UDP relay | `--kcptun-client`, `--kcptun-server` |
 
 Each runs as a server the emulator forwards to and a client exposing SOCKS5,
-over exactly the same seeded path as queqiao. The client trusts exactly the
-server's certificate, so nothing disables verification. The four are registry
-entries rather than special cases; see the contract below for adding another.
+over exactly the same seeded path as queqiao. Where the transport has TLS the
+client trusts exactly the server's certificate, so nothing disables
+verification. They are registry entries rather than special cases; see the
+contract below for adding another.
+
+`kcptun` is the one that is not a proxy. It forwards a local TCP port, so the
+harness runs a SOCKS5 server of its own beyond the emulator for the tunnel's
+server to forward to, and the tunnel's local port is what the benchmark speaks
+to:
+
+```
+benchmark -> [kcptun client] -> emulator -> [kcptun server]
+          -> [harness SOCKS5 target] -> destination
+```
+
+The measured path is crossed exactly once, as for every other stack; the two
+extra hops are loopback. kcptun's upstream repository was withdrawn and
+`github.com/xtaci/kcptun` no longer resolves, which is why the stack takes two
+binary paths rather than naming a source: build from whatever copy you trust,
+and record which one and at what commit alongside the run, as for any other
+measured dependency. It is the comparison queqiao's own coding most needs,
+because both transports spend parity to avoid a round trip and choose how much
+in opposite ways — see the fixed-parity section below before quoting a number.
+kcptun ships one program per side, which is why it takes two paths; its
+compression is disabled, because the benchmark's payload is a repeating byte
+ramp that snappy would reduce to almost nothing, and the stack would then
+report the compressor's rate rather than the path's.
 
 **`cmd/queqiaobench`** — runs the selected stacks over one emulated path in a
 single process and reports per-trial rows, a summary, optional JSON, and an
@@ -168,13 +192,17 @@ What the running pair must satisfy:
    packet emulator, where loss, delay and rate apply. `"tcp"` means it can only
    be measured with `--loss 0`, for the reason in the section above.
 
-A tunnel rather than a proxy -- kcptun is the obvious example -- has no SOCKS5
-of its own: it forwards a local TCP port to a target. Such a stack is three
-processes, because the target has to be a SOCKS5 server on the server side, and
-the tunnel's local port is then the endpoint the benchmark speaks to. `Launch`
-describes two sides today; a stack of that shape should extend it with the
-third process rather than starting one outside the harness, so teardown keeps a
-single owner and no listener outlives the run.
+A tunnel rather than a proxy has no SOCKS5 of its own: it forwards a local TCP
+port to a target. Declare `socksTarget: true` in the registry entry and the
+harness runs `extproxy.StartSOCKSTarget` beyond the emulator and passes its
+address as `Config.SOCKSTarget`; forward to that, and expose the tunnel's own
+local port as `SOCKSListen`. The target is in-process on purpose: an external
+SOCKS5 server would be a third implementation in the measurement whose version
+and buffering nobody recorded. `Plan` refuses such a stack when the target is
+missing, because a tunnel forwarding to nothing fails every trial at SOCKS with
+an error that says nothing about why.
+
+`kcptun` is the worked example of all of this.
 
 ### Comparing a fixed-parity transport
 
@@ -185,24 +213,46 @@ kcptun-style code rate is a constant chosen in advance. A single configuration
 is therefore a comparison against one guess, and whichever way it lands the
 result is mostly about the guess.
 
-So a submitted comparison should carry:
+So a comparison should carry:
 
-- **A parity sweep, not a point.** Several `-datashard`/`-parityshard` ratios
-  spanning above and below the emulated erasure rate, with the best one shown
-  against queqiao rather than an arbitrary one.
+- **Size the window before anything else.** This is not a refinement, it is
+  the difference between a measurement and a rigged one. kcptun's default send
+  window of 128 packets caps a 210 ms path at about 6.6 Mbit/s no matter what
+  the code does. Measured live on that path, the same build went from 5.09 to
+  25.36 Mbit/s -- five times faster -- when `--kcptun-sndwnd` and
+  `--kcptun-rcvwnd` were raised to a delay-bandwidth product's worth of
+  packets, and the gap to queqiao fell from 9.6x to 2.1x. A comparison run at
+  the default windows is measuring the window.
+- **A parity sweep, not a point.** `--kcptun-parityshard` against a fixed
+  `--kcptun-datashard`, spanning ratios above and below the erasure rate, with
+  the best one shown against queqiao rather than an arbitrary one. The
+  defaults are kcptun's own (10 data, 3 parity, `fast`, 128/512 windows), which
+  is a starting point rather than an answer.
 - **The cost alongside the rate.** Parity is bandwidth spent on the same
   bottleneck, so report the parity share of bytes sent on both sides. Queqiao's
-  is `fec_repairs_total` over `fec_sent_total` in its runtime log; a transport
-  buying more of the wire can finish sooner while delivering fewer useful bytes
-  per byte sent, and a goodput column alone hides that.
-- **Every parameter that moves the answer.** Implementation version, `-mode` or
-  the explicit `-nodelay/-interval/-resend/-nc`, `-sndwnd`/`-rcvwnd`, `-mtu`,
-  compression, and whatever the SOCKS5 target adds. The window settings are the
-  congestion control in practice, so a run that does not state them is not
-  reproducible.
+  is `fec_repairs_total` over `fec_sent_total` in its runtime log, and kcptun's
+  is the ratio the sweep fixed; a transport buying more of the wire can finish
+  sooner while delivering fewer useful bytes per byte sent, and a goodput
+  column alone hides that.
+- **Every parameter that moves the answer.** The implementation version, and
+  the settings the harness passes: `--kcptun-mode`, `--kcptun-datashard`,
+  `--kcptun-parityshard`, `--kcptun-sndwnd`, `--kcptun-rcvwnd`. The windows are
+  the congestion control in practice, so a run that does not state them is not
+  reproducible. They appear in the archival JSON with the rest of the command.
 - **The same rules as every other cell**: one seeded path, alternating trial
   order, medians over all trials counting failures at their partial rate, and a
   check against the calibration bound below.
+
+```sh
+# One cell of a parity sweep, against queqiao on the same seeded path.
+for parity in 1 3 6 10; do
+  go run ./cmd/queqiaobench --stacks queqiao,kcptun \
+      --kcptun-client ./kcptun/client --kcptun-server ./kcptun/server \
+      --kcptun-mode fast3 --kcptun-datashard 10 --kcptun-parityshard "$parity" \
+      --rtt 200 --loss 20 --rate 50 --bytes $((16*1024*1024)) --trials 5 \
+      --json "/tmp/kcptun-parity-$parity.json"
+done
+```
 
 ## Reading the numbers
 
@@ -239,6 +289,13 @@ go run ./cmd/queqiaobench --rtt 200 --loss 1 --rate 100 \
 # Against real implementations rather than only the in-tree control.
 go run ./cmd/queqiaobench --stacks baseline,queqiao,tuic,hysteria2 \
     --sing-box /path/to/sing-box --rtt 200 --loss 1 --rate 100 --trials 5
+
+# Against a fixed-rate erasure code, which is the comparison queqiao's own
+# coding most needs. Sweep the parity; see the fixed-parity section.
+go run ./cmd/queqiaobench --stacks queqiao,kcptun \
+    --kcptun-client /path/to/kcptun/client --kcptun-server /path/to/kcptun/server \
+    --kcptun-mode fast3 --kcptun-parityshard 3 \
+    --rtt 200 --loss 20 --rate 50 --bytes $((16*1024*1024)) --trials 5
 
 # The TCP family, which cannot be measured under loss.
 go run ./cmd/queqiaobench --stacks vless-tcp,vless-ws \

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -50,12 +50,57 @@ also showing the interactive tail. The campaign itself reported that Queqiao's
 interactive degradation was the worst among the genuinely loaded stacks on
 that path. The table is useful precisely because it includes that counterexample.
 
+## Fixed-rate erasure coding: kcptun
+
+kcptun is the comparator closest to what Queqiao actually does differently.
+Both spend parity to avoid a round trip, and they choose how much in opposite
+ways: Queqiao sizes its code from a measured erasure floor and revises it while
+a flow runs, while a kcptun deployment fixes a ratio in advance. TUIC and
+Hysteria 2 do not cover that axis.
+
+The campaign below ran on 2026-08-23 from a client in China to the same
+maintainer-controlled US egress, both ends on `main-126eb5c` (Go 1.25.13, wire
+1), using `scripts/bench_live_matched.sh` to alternate a 4 MiB object between
+the two SOCKS5 endpoints, twelve rounds each, order swapped every round. The
+path measured 192-276 ms round trip and about 5% ICMP loss during the window.
+kcptun ran `-mode fast3 -datashard 10 -parityshard 3 -nocomp`; its build came
+from a restoration of the upstream repository, which has been withdrawn.
+
+| kcptun send/receive window | Queqiao median | kcptun median | Matched rounds | Ratio |
+| --- | ---: | ---: | ---: | ---: |
+| 128/512, the implementation's default | **48.60 Mbit/s** | 5.09 Mbit/s | 12/12 to Queqiao | 9.64× |
+| 2048/2048, sized to this path | **50.23 Mbit/s** | 25.36 Mbit/s | 12/12 to Queqiao | 2.10× |
+
+Every trial in both campaigns completed with the exact object length; the sign
+test over matched rounds gives p=0.0005 in each. Queqiao's own median moved by
+3% between the two campaigns, which is the internal check that the difference
+between the rows belongs to kcptun's configuration rather than to the path
+moving underneath.
+
+**The window matters more than the parity.** kcptun's default send window of
+128 packets caps a 210 ms path at about 6.6 Mbit/s whatever the transport does,
+and the first row measures that ceiling rather than the code. Quoting it alone
+would be a rigged comparison. Sized to the path's delay-bandwidth product, the
+same build is five times faster and the gap falls from 9.6× to 2.1×.
+
+The limits of this cell are as important as the numbers. It is one path, one
+object size, one direction, and one fifteen-minute window; the parity ratio was
+not swept live; kcptun ran behind a loopback relay so that both transports left
+by the same physical interface, costing it tens of microseconds against a
+210 ms path; and the Queqiao client was simultaneously carrying the operator's
+real traffic, roughly seventy concurrent flows, while the kcptun tunnel carried
+only the benchmark. That asymmetry works against Queqiao, which still led every
+round.
+
 ## What can be claimed today
 
 - Queqiao has a clear architectural difference: it coordinates a known shared
   endpoint-pair bottleneck and can spend measured parity to avoid WAN RTT.
 - The representative campaign is evidence that this approach can produce a
   large bulk-goodput advantage on one real path.
+- Against a fixed-rate code on one real path, the advantage survives giving the
+  comparator a window sized for that path, but it shrinks from 9.6× to 2.1×
+  when it is given one.
 - A current multi-network campaign remains the right next step before making a
   broader performance claim.
 

--- a/internal/extproxy/extproxy.go
+++ b/internal/extproxy/extproxy.go
@@ -41,6 +41,11 @@ const (
 	// and cannot drop a segment; see the TCP note in docs/BENCHMARKING.md.
 	VLESSWebSocket Kind = "vless-ws"
 	VLESSTCP       Kind = "vless-tcp"
+	// KCPTun is a fixed-rate erasure-coded transport, which is the comparison
+	// queqiao's own coding most needs: both spend parity to avoid a round
+	// trip, and they choose how much of it in opposite ways. It is also the
+	// first stack here that is a tunnel rather than a proxy; see SOCKSTarget.
+	KCPTun Kind = "kcptun"
 )
 
 // Launch is what a stack asks the harness to run for one measured pair.
@@ -61,6 +66,11 @@ type Launch struct {
 	ServerBinary, ClientBinary string
 	// ServerArgs and ClientArgs are what each side is run with.
 	ServerArgs, ClientArgs []string
+	// ServerEnv and ClientEnv are added to the environment each side
+	// inherits, for an implementation that takes configuration that way. A
+	// credential belongs here rather than in the arguments, which every other
+	// process on the machine can read.
+	ServerEnv, ClientEnv []string
 }
 
 // stack is one third-party transport this package can measure.
@@ -73,7 +83,12 @@ type stack struct {
 	// implementation is the program that provides it, which is what a caller
 	// missing its path has to be told to supply.
 	implementation string
-	launch         func(Config) (Launch, error)
+	// socksTarget marks a tunnel rather than a proxy. A proxy is the SOCKS5
+	// endpoint itself; a tunnel only forwards a local port, so the harness has
+	// to run a SOCKS5 server on the far side for it to forward to, and the
+	// tunnel's own local port becomes the endpoint the benchmark speaks to.
+	socksTarget bool
+	launch      func(Config) (Launch, error)
 }
 
 // stacks is the registry a new transport is added to. Everything else in this
@@ -83,6 +98,7 @@ var stacks = map[Kind]stack{
 	Hysteria2:      {transport: "udp", implementation: "sing-box", launch: singBoxLaunch},
 	VLESSTCP:       {transport: "tcp", implementation: "sing-box", launch: singBoxLaunch},
 	VLESSWebSocket: {transport: "tcp", implementation: "sing-box", launch: singBoxLaunch},
+	KCPTun:         {transport: "udp", implementation: "kcptun", socksTarget: true, launch: kcpTunLaunch},
 }
 
 // Kinds lists the transports this package can launch, in a stable order.
@@ -112,11 +128,21 @@ func (k Kind) Implementation() string {
 	return stacks[k].implementation
 }
 
+// NeedsSOCKSTarget reports whether the harness must run a SOCKS5 server on the
+// server side for this stack to forward to. It is true for a tunnel, which
+// carries a port rather than proxying, and false for a proxy, which is the
+// endpoint itself.
+func (k Kind) NeedsSOCKSTarget() bool { return stacks[k].socksTarget }
+
 // Config describes one measured pair.
 type Config struct {
 	Kind Kind
-	// Binary is the implementation to run. sing-box serves every kind here.
+	// Binary is the implementation to run, and the client side of it where an
+	// implementation ships one program per side.
 	Binary string
+	// ServerBinary is the server-side program for an implementation that
+	// ships two, as kcptun does. Empty means Binary serves both sides.
+	ServerBinary string
 	// ServerListen is the address the server binds; the emulator forwards to it.
 	ServerListen string
 	// ClientRemote is the emulator address the client dials.
@@ -135,6 +161,68 @@ type Config struct {
 	Credential string
 	// UUID identifies the user for TUIC and VLESS.
 	UUID string
+	// SOCKSTarget is the SOCKS5 endpoint a tunnel's server forwards to. The
+	// harness runs it; see Kind.NeedsSOCKSTarget.
+	SOCKSTarget string
+	// KCP configures a KCP-based stack.
+	KCP KCPParams
+}
+
+// KCPParams is the configuration of a KCP-based stack.
+//
+// Every field is set explicitly rather than left to the implementation's
+// default, because these are the code rate and the windows -- which is where
+// such a transport's behaviour is actually decided -- and a measurement that
+// does not state them cannot be reproduced or compared. The defaults below are
+// kcptun's own, so an unswept run is at least the configuration its users get.
+type KCPParams struct {
+	// Mode is the latency-against-throughput preset: normal, fast, fast2 or
+	// fast3.
+	Mode string
+	// DataShards and ParityShards are the FEC ratio, fixed for the whole run.
+	// Queqiao sizes its parity from a measured erasure floor and revises it
+	// while a flow runs, so one ratio here is a comparison against one guess:
+	// sweep it. See docs/BENCHMARKING.md.
+	DataShards, ParityShards int
+	// SendWindow and ReceiveWindow are in KCP packets, and on a long-haul
+	// lossy path they are the congestion control in practice.
+	SendWindow, ReceiveWindow int
+	MTU                       int
+	// Crypt and Key are the transport's own encryption. It stays on, because
+	// every other stack here runs under TLS and turning it off would measure a
+	// transport nobody deploys.
+	Crypt, Key string
+}
+
+func (p KCPParams) withDefaults() KCPParams {
+	if p.Mode == "" {
+		p.Mode = "fast"
+	}
+	if p.DataShards <= 0 {
+		p.DataShards = 10
+	}
+	if p.ParityShards < 0 {
+		p.ParityShards = 0
+	}
+	if p.ParityShards == 0 {
+		p.ParityShards = 3
+	}
+	if p.SendWindow <= 0 {
+		p.SendWindow = 128
+	}
+	if p.ReceiveWindow <= 0 {
+		p.ReceiveWindow = 512
+	}
+	if p.MTU <= 0 {
+		p.MTU = 1350
+	}
+	if p.Crypt == "" {
+		p.Crypt = "aes"
+	}
+	if p.Key == "" {
+		p.Key = "queqiao-benchmark-credential"
+	}
+	return p
 }
 
 func (c Config) withDefaults() Config {
@@ -147,6 +235,7 @@ func (c Config) withDefaults() Config {
 	if c.UUID == "" {
 		c.UUID = "8c9dbf4a-3e2b-4a1c-9f6d-5b7e0a1c2d3e"
 	}
+	c.KCP = c.KCP.withDefaults()
 	return c
 }
 
@@ -194,7 +283,7 @@ func Start(ctx context.Context, cfg Config) (*Pair, error) {
 		}
 	}
 
-	server, err := startProcess(ctx, launch.ServerBinary, launch.ServerArgs...)
+	server, err := startProcess(ctx, launch.ServerBinary, launch.ServerEnv, launch.ServerArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +293,7 @@ func Start(ctx context.Context, cfg Config) (*Pair, error) {
 		server.stop()
 		return nil, fmt.Errorf("%s server did not listen: %w\n%s", cfg.Kind, err, server.output())
 	}
-	client, err := startProcess(ctx, launch.ClientBinary, launch.ClientArgs...)
+	client, err := startProcess(ctx, launch.ClientBinary, launch.ClientEnv, launch.ClientArgs...)
 	if err != nil {
 		server.stop()
 		return nil, err
@@ -231,6 +320,12 @@ func Plan(cfg Config) (Launch, error) {
 	}
 	if cfg.Binary == "" {
 		return Launch{}, fmt.Errorf("a %s binary is required for %s", registered.implementation, cfg.Kind)
+	}
+	if registered.socksTarget && cfg.SOCKSTarget == "" {
+		// A tunnel forwards to whatever address it is given. Left empty it
+		// would forward to nothing, and every trial would fail at SOCKS with a
+		// general error that says nothing about why.
+		return Launch{}, fmt.Errorf("%s is a tunnel and needs a SOCKS5 target to forward to", cfg.Kind)
 	}
 	launch, err := registered.launch(cfg)
 	if err != nil {

--- a/internal/extproxy/extproxy_test.go
+++ b/internal/extproxy/extproxy_test.go
@@ -134,15 +134,29 @@ func TestInvalidAddressesAreRejected(t *testing.T) {
 	}
 }
 
-func planFor(t *testing.T, kind Kind) Launch {
-	t.Helper()
-	launch, err := Plan(Config{
+// planConfig is what the harness supplies for a stack: the addresses, the
+// certificate, the work directory, a binary per side, and a SOCKS5 target for
+// a stack that is a tunnel rather than a proxy.
+func planConfig(kind Kind) Config {
+	cfg := Config{
 		Kind: kind, Binary: "/usr/local/bin/sing-box",
 		ServerListen: "127.0.0.1:11111", ClientRemote: "127.0.0.1:22222",
 		SOCKSListen:     "127.0.0.1:33333",
 		CertificatePath: "/tmp/cert.pem", KeyPath: "/tmp/key.pem",
 		WorkDir: "/tmp/bench",
-	})
+	}
+	if kind == KCPTun {
+		cfg.Binary, cfg.ServerBinary = "/usr/local/bin/kcptun-client", "/usr/local/bin/kcptun-server"
+	}
+	if kind.NeedsSOCKSTarget() {
+		cfg.SOCKSTarget = "127.0.0.1:44444"
+	}
+	return cfg
+}
+
+func planFor(t *testing.T, kind Kind) Launch {
+	t.Helper()
+	launch, err := Plan(planConfig(kind))
 	if err != nil {
 		t.Fatalf("plan %s: %v", kind, err)
 	}
@@ -166,10 +180,15 @@ func TestEveryRegisteredStackPlansBothSides(t *testing.T) {
 			if kind.Implementation() == "" {
 				t.Fatal("no implementation is named, so a caller cannot be told what to install")
 			}
+			cfg := planConfig(kind)
 			launch := planFor(t, kind)
-			if launch.ServerBinary != "/usr/local/bin/sing-box" || launch.ClientBinary != "/usr/local/bin/sing-box" {
-				t.Fatalf("binaries = %q and %q, want the configured one on both sides",
-					launch.ServerBinary, launch.ClientBinary)
+			wantServer := cfg.ServerBinary
+			if wantServer == "" {
+				wantServer = cfg.Binary
+			}
+			if launch.ServerBinary != wantServer || launch.ClientBinary != cfg.Binary {
+				t.Fatalf("binaries = %q and %q, want %q and %q",
+					launch.ServerBinary, launch.ClientBinary, wantServer, cfg.Binary)
 			}
 			if len(launch.ServerArgs) == 0 || len(launch.ClientArgs) == 0 {
 				t.Fatalf("launch = %+v, want arguments for both sides", launch)

--- a/internal/extproxy/kcptun.go
+++ b/internal/extproxy/kcptun.go
@@ -1,0 +1,53 @@
+package extproxy
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// kcptun is a tunnel, not a proxy, and that is the whole of what makes its
+// integration different.
+//
+// The client listens on a local TCP port and forwards it over KCP to the
+// server, which forwards to one target address. There is no SOCKS5 anywhere in
+// that pair, so the harness runs a SOCKS5 server as the server's target and the
+// client's local port becomes the endpoint the benchmark speaks to:
+//
+//	benchmark -> [kcptun client :SOCKSListen] -> emulator -> [kcptun server]
+//	          -> [harness SOCKS5 target] -> destination
+//
+// Which means the measured path crosses the emulator exactly once, as it does
+// for every other stack, and the two extra hops are loopback.
+func kcpTunLaunch(cfg Config) (Launch, error) {
+	if cfg.ServerBinary == "" {
+		return Launch{}, fmt.Errorf("%s ships one program per side and needs both", cfg.Kind)
+	}
+	p := cfg.KCP
+	// Held identical on both sides. kcptun negotiates none of this: a client
+	// and server disagreeing about the code rate or the key simply fail to
+	// carry anything, and the benchmark would report a transport that cannot
+	// connect rather than one that is slow.
+	shared := []string{
+		"-key", p.Key,
+		"-crypt", p.Crypt,
+		"-mode", p.Mode,
+		"-mtu", strconv.Itoa(p.MTU),
+		"-datashard", strconv.Itoa(p.DataShards),
+		"-parityshard", strconv.Itoa(p.ParityShards),
+		"-sndwnd", strconv.Itoa(p.SendWindow),
+		"-rcvwnd", strconv.Itoa(p.ReceiveWindow),
+		// The benchmark's payload is a repeating byte ramp, which snappy
+		// compresses to almost nothing. Left on, this stack would report the
+		// compressor's rate rather than the path's, and it would beat every
+		// other stack by an order of magnitude while carrying no more bytes.
+		"-nocomp",
+	}
+	client := append([]string{"-l", cfg.SOCKSListen, "-r", cfg.ClientRemote}, shared...)
+	server := append([]string{"-l", cfg.ServerListen, "-t", cfg.SOCKSTarget}, shared...)
+	return Launch{
+		ClientBinary: cfg.Binary,
+		ServerBinary: cfg.ServerBinary,
+		ClientArgs:   client,
+		ServerArgs:   server,
+	}, nil
+}

--- a/internal/extproxy/process.go
+++ b/internal/extproxy/process.go
@@ -3,6 +3,7 @@ package extproxy
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -35,8 +36,13 @@ func (b *lockedBuffer) String() string {
 	return b.buf.String()
 }
 
-func startProcess(ctx context.Context, binary string, args ...string) (*process, error) {
+func startProcess(ctx context.Context, binary string, env []string, args ...string) (*process, error) {
 	cmd := exec.Command(binary, args...)
+	if len(env) > 0 {
+		// Added to the inherited environment rather than replacing it: an
+		// implementation still needs PATH, HOME and the rest to run at all.
+		cmd.Env = append(os.Environ(), env...)
+	}
 	logs := &lockedBuffer{}
 	cmd.Stdout = logs
 	cmd.Stderr = logs

--- a/internal/extproxy/sockstarget.go
+++ b/internal/extproxy/sockstarget.go
@@ -1,0 +1,147 @@
+package extproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/socks5"
+)
+
+// SOCKSTarget is the SOCKS5 endpoint a tunnel stack forwards to.
+//
+// A proxy stack needs nothing like this: its own server is where a destination
+// is dialled. A tunnel carries one port and knows nothing about destinations,
+// so something on the far side has to speak SOCKS5 and dial. This is the
+// smallest thing that does, and it is deliberately in-process: an external
+// SOCKS5 server would be a third implementation in the measurement whose
+// version, buffering and congestion settings nobody recorded.
+//
+// It sits beyond the emulator, so its own dial is loopback and adds no
+// measured delay.
+type SOCKSTarget struct {
+	listener net.Listener
+	wg       sync.WaitGroup
+	closeOne sync.Once
+}
+
+// StartSOCKSTarget begins accepting on loopback. Close stops it and waits for
+// the connections it is relaying, so a finished trial leaves nothing behind to
+// contend with the next one.
+func StartSOCKSTarget(ctx context.Context) (*SOCKSTarget, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	target := &SOCKSTarget{listener: listener}
+	target.wg.Add(1)
+	go target.accept(ctx)
+	return target, nil
+}
+
+// Address is what the tunnel's server should forward to.
+func (t *SOCKSTarget) Address() string {
+	if t == nil {
+		return ""
+	}
+	return t.listener.Addr().String()
+}
+
+func (t *SOCKSTarget) accept(ctx context.Context) {
+	defer t.wg.Done()
+	go func() {
+		<-ctx.Done()
+		_ = t.listener.Close()
+	}()
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			return
+		}
+		t.wg.Add(1)
+		go func() {
+			defer t.wg.Done()
+			t.serve(ctx, conn)
+		}()
+	}
+}
+
+func (t *SOCKSTarget) serve(ctx context.Context, conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	// The handshake is bounded: a tunnel that dies mid-negotiation must not
+	// leave a goroutine holding a connection for the rest of the campaign.
+	_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+	request, err := socks5.ReadRequest(conn, nil)
+	if err != nil {
+		return
+	}
+	if request.Command != socks5.CommandConnect {
+		// UDP association would have to be relayed back through the tunnel,
+		// which carries one TCP port and cannot. Refusing is the honest
+		// answer; the benchmark's UDP measurements do not use this path.
+		_ = socks5.WriteReply(conn, socks5.ReplyCommandNotSupported, nil)
+		return
+	}
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	destination, err := dialer.DialContext(ctx, "tcp", request.Destination)
+	if err != nil {
+		_ = socks5.WriteReply(conn, socks5.ReplyHostUnreachable, nil)
+		return
+	}
+	defer func() { _ = destination.Close() }()
+	if err := socks5.WriteReply(conn, socks5.ReplySucceeded, destination.LocalAddr()); err != nil {
+		return
+	}
+	// The transfer itself is unbounded in time: it is what the benchmark is
+	// measuring, and a deadline here would cap the slowest stack's result at
+	// the deadline rather than reporting it.
+	_ = conn.SetDeadline(time.Time{})
+	relay(conn, destination)
+}
+
+// relay copies in both directions and returns when either is finished. A
+// half-close is forwarded where the connection supports it, so a destination
+// that answers and stops is not held open by a client that has not.
+func relay(client, destination net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(destination, client)
+		closeWrite(destination)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(client, destination)
+		closeWrite(client)
+	}()
+	wg.Wait()
+}
+
+func closeWrite(conn net.Conn) {
+	type writeCloser interface{ CloseWrite() error }
+	if half, ok := conn.(writeCloser); ok {
+		_ = half.CloseWrite()
+		return
+	}
+	_ = conn.Close()
+}
+
+// Close stops accepting and waits for the relays in flight.
+func (t *SOCKSTarget) Close() error {
+	if t == nil {
+		return nil
+	}
+	var err error
+	t.closeOne.Do(func() {
+		err = t.listener.Close()
+		t.wg.Wait()
+	})
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}

--- a/internal/extproxy/tunnel_test.go
+++ b/internal/extproxy/tunnel_test.go
@@ -1,0 +1,378 @@
+package extproxy
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// kcptun is a tunnel: its client listens on a local TCP port and its server
+// forwards to one address, and neither speaks SOCKS5. Getting either end of
+// that wiring wrong produces a benchmark that measures something other than
+// the emulated path, so the plan is checked rather than assumed.
+func TestKCPTunTunnelsSOCKSAcrossTheEmulatedPath(t *testing.T) {
+	launch := planFor(t, KCPTun)
+
+	client := argMap(t, launch.ClientArgs)
+	if client["-l"] != "127.0.0.1:33333" {
+		t.Fatalf("client listens on %q, want the benchmark's SOCKS address", client["-l"])
+	}
+	if client["-r"] != "127.0.0.1:22222" {
+		t.Fatalf("client dials %q, want the emulator", client["-r"])
+	}
+	server := argMap(t, launch.ServerArgs)
+	if server["-l"] != "127.0.0.1:11111" {
+		t.Fatalf("server binds %q, want the address the emulator forwards to", server["-l"])
+	}
+	if server["-t"] != "127.0.0.1:44444" {
+		t.Fatalf("server forwards to %q, want the harness SOCKS5 target", server["-t"])
+	}
+	if launch.ClientBinary != "/usr/local/bin/kcptun-client" || launch.ServerBinary != "/usr/local/bin/kcptun-server" {
+		t.Fatalf("binaries = %q and %q, want one program per side", launch.ClientBinary, launch.ServerBinary)
+	}
+
+	// The two ends negotiate none of this. A disagreement over the code rate
+	// or the key does not degrade the measurement, it stops the tunnel
+	// carrying anything, and the benchmark would report a transport that
+	// cannot connect rather than one that is slow.
+	for _, flag := range []string{"-key", "-crypt", "-mode", "-mtu", "-datashard", "-parityshard", "-sndwnd", "-rcvwnd"} {
+		if client[flag] == "" {
+			t.Fatalf("%s is not set on the client", flag)
+		}
+		if client[flag] != server[flag] {
+			t.Fatalf("%s = %q on the client and %q on the server", flag, client[flag], server[flag])
+		}
+	}
+	// The benchmark's payload is a repeating byte ramp. With compression left
+	// on, this stack would report snappy's rate rather than the path's.
+	for side, args := range map[string][]string{"client": launch.ClientArgs, "server": launch.ServerArgs} {
+		if !hasFlag(args, "-nocomp") {
+			t.Fatalf("%s does not disable compression: %v", side, args)
+		}
+	}
+}
+
+// The parity ratio is the parameter a comparison against a fixed-rate code has
+// to be swept over, so it has to reach the process.
+func TestKCPTunCarriesTheConfiguredParityAndWindows(t *testing.T) {
+	cfg := planConfig(KCPTun)
+	cfg.KCP = KCPParams{Mode: "fast3", DataShards: 20, ParityShards: 15, SendWindow: 1024, ReceiveWindow: 2048, MTU: 1200}
+	launch, err := Plan(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := argMap(t, launch.ClientArgs)
+	for flag, want := range map[string]string{
+		"-mode": "fast3", "-datashard": "20", "-parityshard": "15",
+		"-sndwnd": "1024", "-rcvwnd": "2048", "-mtu": "1200",
+	} {
+		if client[flag] != want {
+			t.Fatalf("%s = %q, want %q", flag, client[flag], want)
+		}
+	}
+	// Encryption stays on by default: every other stack here runs under TLS,
+	// and turning it off would measure a transport nobody deploys.
+	if client["-crypt"] != "aes" {
+		t.Fatalf("crypt = %q, want the implementation's own default", client["-crypt"])
+	}
+}
+
+// A tunnel with nowhere to forward would fail every trial at SOCKS with a
+// general error that says nothing about why, so it is refused up front.
+func TestATunnelWithoutATargetOrASecondBinaryIsRefused(t *testing.T) {
+	cfg := planConfig(KCPTun)
+	cfg.SOCKSTarget = ""
+	if _, err := Plan(cfg); err == nil || !strings.Contains(err.Error(), "SOCKS5 target") {
+		t.Fatalf("error = %v, want a refusal naming the missing target", err)
+	}
+	cfg = planConfig(KCPTun)
+	cfg.ServerBinary = ""
+	if _, err := Plan(cfg); err == nil || !strings.Contains(err.Error(), "one program per side") {
+		t.Fatalf("error = %v, want a refusal naming the missing server binary", err)
+	}
+	if !KCPTun.NeedsSOCKSTarget() {
+		t.Fatal("kcptun does not declare that it needs a SOCKS5 target")
+	}
+	if TUIC.NeedsSOCKSTarget() {
+		t.Fatal("a proxy stack asks for a SOCKS5 target it does not need")
+	}
+	if KCPTun.Transport() != "udp" {
+		t.Fatalf("kcptun transport = %q, want the packet emulator", KCPTun.Transport())
+	}
+}
+
+// The target is what makes a tunnel usable by a benchmark that speaks only
+// SOCKS5, so it has to actually negotiate and relay.
+func TestSOCKSTargetDialsWhatItIsAskedFor(t *testing.T) {
+	origin := startEchoOrigin(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	target, err := StartSOCKSTarget(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = target.Close() }()
+
+	conn, err := net.DialTimeout("tcp", target.Address(), 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := socksConnect(conn, origin); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("queqiao")); err != nil {
+		t.Fatal(err)
+	}
+	echoed := make([]byte, len("queqiao"))
+	if _, err := io.ReadFull(conn, echoed); err != nil {
+		t.Fatal(err)
+	}
+	if string(echoed) != "queqiao" {
+		t.Fatalf("echo = %q", echoed)
+	}
+}
+
+// The three-process shape a tunnel needs, driven end to end: Start launches
+// both sides with the arguments and environment the plan asked for, waits
+// until the SOCKS endpoint accepts, relays through the harness target to a
+// destination, and leaves nothing running afterwards.
+//
+// The tunnel here is this test binary re-executed, because the point being
+// checked is the harness's half of the contract rather than any particular
+// implementation's wire.
+func TestATunnelStackRunsEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("launches processes")
+	}
+	origin := startEchoOrigin(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	target, err := StartSOCKSTarget(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = target.Close() }()
+
+	// The addresses the harness would have reserved and released.
+	tunnelServer, socksListen := reserveAddress(t), reserveAddress(t)
+	pair, err := Start(ctx, Config{
+		Kind: stubTunnel, Binary: os.Args[0],
+		ServerBinary: os.Args[0],
+		ServerListen: tunnelServer, ClientRemote: tunnelServer,
+		SOCKSListen: socksListen, SOCKSTarget: target.Address(),
+		WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("start the tunnel pair: %v", err)
+	}
+
+	conn, err := net.DialTimeout("tcp", socksListen, 5*time.Second)
+	if err != nil {
+		pair.Close()
+		t.Fatalf("the SOCKS endpoint did not accept: %v\n%s", err, pair.Logs())
+	}
+	if err := socksConnect(conn, origin); err != nil {
+		_ = conn.Close()
+		pair.Close()
+		t.Fatalf("SOCKS through the tunnel: %v\n%s", err, pair.Logs())
+	}
+	if _, err := conn.Write([]byte("through")); err != nil {
+		t.Fatal(err)
+	}
+	echoed := make([]byte, len("through"))
+	if _, err := io.ReadFull(conn, echoed); err != nil {
+		t.Fatalf("read through the tunnel: %v\n%s", err, pair.Logs())
+	}
+	if string(echoed) != "through" {
+		t.Fatalf("echo = %q", echoed)
+	}
+	_ = conn.Close()
+
+	pair.Close()
+	// A leaked proxy process holds its ports and silently contaminates every
+	// later trial, so teardown is part of the contract rather than tidiness.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		probe, err := net.DialTimeout("tcp", socksListen, 200*time.Millisecond)
+		if err != nil {
+			return
+		}
+		_ = probe.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("the tunnel's SOCKS endpoint is still accepting after Close")
+}
+
+// stubTunnel is a tunnel stack whose implementation is this test binary. It is
+// registered here rather than in the package so nothing outside the test can
+// select it.
+const stubTunnel Kind = "stub-tunnel"
+
+func init() {
+	stacks[stubTunnel] = stack{
+		transport: "tcp", implementation: "stub", socksTarget: true,
+		launch: func(cfg Config) (Launch, error) {
+			helper := []string{"-test.run=^TestStubTunnelHelper$", "-test.timeout=0"}
+			return Launch{
+				ServerArgs: helper, ClientArgs: helper,
+				ServerEnv: []string{
+					stubTunnelListen + "=" + cfg.ServerListen,
+					stubTunnelForward + "=" + cfg.SOCKSTarget,
+				},
+				ClientEnv: []string{
+					stubTunnelListen + "=" + cfg.SOCKSListen,
+					stubTunnelForward + "=" + cfg.ClientRemote,
+				},
+			}, nil
+		},
+	}
+}
+
+const (
+	stubTunnelListen  = "QUEQIAO_STUB_TUNNEL_LISTEN"
+	stubTunnelForward = "QUEQIAO_STUB_TUNNEL_FORWARD"
+)
+
+// TestStubTunnelHelper is one end of the stub tunnel when the environment says
+// so, and nothing at all otherwise.
+func TestStubTunnelHelper(t *testing.T) {
+	listen, forward := os.Getenv(stubTunnelListen), os.Getenv(stubTunnelForward)
+	if listen == "" || forward == "" {
+		t.Skip("not running as a stub tunnel process")
+	}
+	listener, err := net.Listen("tcp", listen)
+	if err != nil {
+		t.Fatalf("stub tunnel listen %s: %v", listen, err)
+	}
+	defer func() { _ = listener.Close() }()
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer func() { _ = conn.Close() }()
+			onward, err := net.DialTimeout("tcp", forward, 5*time.Second)
+			if err != nil {
+				return
+			}
+			defer func() { _ = onward.Close() }()
+			relay(conn, onward)
+		}()
+	}
+}
+
+// startEchoOrigin is the destination a measured connection ends at.
+func startEchoOrigin(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+// reserveAddress takes a loopback port and releases it, which is what the
+// harness does before an external implementation binds it itself.
+func reserveAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	_ = listener.Close()
+	return address
+}
+
+// socksConnect performs an unauthenticated SOCKS5 CONNECT.
+func socksConnect(conn net.Conn, destination string) error {
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		return err
+	}
+	defer func() { _ = conn.SetDeadline(time.Time{}) }()
+	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
+		return err
+	}
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		return err
+	}
+	if method[0] != 5 || method[1] != 0 {
+		return errors.New("no-authentication was not selected")
+	}
+	host, portText, err := net.SplitHostPort(destination)
+	if err != nil {
+		return err
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return err
+	}
+	address := net.ParseIP(host).To4()
+	if address == nil {
+		return errors.New("the test destination is not IPv4")
+	}
+	request := []byte{5, 1, 0, 1}
+	request = append(request, address...)
+	request = binary.BigEndian.AppendUint16(request, uint16(port))
+	if _, err := conn.Write(request); err != nil {
+		return err
+	}
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		return err
+	}
+	if reply[1] != 0 {
+		return errors.New("SOCKS5 reply " + strconv.Itoa(int(reply[1])))
+	}
+	return nil
+}
+
+func argMap(t *testing.T, args []string) map[string]string {
+	t.Helper()
+	values := map[string]string{}
+	for i := 0; i < len(args); i++ {
+		if !strings.HasPrefix(args[i], "-") {
+			continue
+		}
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			values[args[i]] = args[i+1]
+			i++
+			continue
+		}
+		values[args[i]] = "true"
+	}
+	return values
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, arg := range args {
+		if arg == flag {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Adds kcptun to the benchmark matrix, answering the first half of #19. #28 defined the contract for adding an external transport; this is a stack built against it, with a live campaign behind the numbers.

## Why this comparison

kcptun is the comparator closest to what queqiao does differently. Both spend parity to avoid a round trip and choose how much in opposite ways: queqiao sizes its code from a measured erasure floor and revises it while a flow runs, while a kcptun deployment fixes a ratio in advance. TUIC and Hysteria2 do not cover that axis.

## What the stack looks like

kcptun is the first stack here that is not a proxy: it forwards a local TCP port and speaks no SOCKS5. So the harness runs a SOCKS5 server of its own beyond the emulator for the tunnel's server to forward to, and the tunnel's local port becomes the endpoint the benchmark speaks to:

```
benchmark -> [kcptun client] -> emulator -> [kcptun server] -> [harness SOCKS5 target] -> destination
```

The measured path is crossed exactly once, as for every other stack; the two extra hops are loopback. The target is in-process on purpose — an external SOCKS5 server would be a third implementation in the measurement whose version and buffering nobody recorded.

Supporting changes, all driven by this stack: a binary per side (kcptun ships two programs), `Launch` environment as well as arguments, `socksTarget` in the registry with `Kind.NeedsSOCKSTarget()`, and `Plan` refusing a tunnel that was given no target rather than letting every trial fail at SOCKS with an error that says nothing about why.

Compression is forced off (`-nocomp`): the benchmark's payload is a repeating byte ramp, and with snappy on this stack would report the compressor's rate rather than the path's while carrying no more bytes.

`github.com/xtaci/kcptun` no longer resolves — the owner's account has `kcp`, `kcp-go` and `libkcp` but no `kcptun` — so the stack takes two binary paths and asks the operator to record their build's provenance.

## Live campaign

Client in China to a maintainer-controlled US egress, both ends on `main-126eb5c` (Go 1.25.13, wire 1), `scripts/bench_live_matched.sh` alternating a 4 MiB object between the two SOCKS5 endpoints, twelve rounds each with the order swapped every round. Path during the window: 192–276 ms RTT, ~5% ICMP loss. kcptun ran `-mode fast3 -datashard 10 -parityshard 3 -nocomp`.

| kcptun send/receive window | queqiao median | kcptun median | matched rounds | sign test | ratio |
| --- | ---: | ---: | ---: | ---: | ---: |
| 128/512 (kcptun's default) | **48.60 Mbit/s** | 5.09 | queqiao 12/12 | p=0.00049 | 9.64× |
| 2048/2048 (sized to this path) | **50.23 Mbit/s** | 25.36 | queqiao 12/12 | p=0.00049 | **2.10×** |

24 trials per campaign, every one complete at the exact object length with `curl` exit 0.

**The window matters more than the parity.** kcptun's default send window of 128 packets caps a 210 ms path at about 6.6 Mbit/s whatever its code does, so the first row measures that ceiling rather than the transport. Sized to the path's delay-bandwidth product the same build is five times faster and the gap falls to 2.1×. queqiao's own median moved 3% between the two campaigns, which is the check that the difference between the rows belongs to kcptun's configuration rather than to the path moving underneath. `docs/BENCHMARKING.md` now asks for the window to be sized before anything else is swept.

Validity checks, because this path has traps the guide documents: the desktop routes the gateway's address into a TUN interface, so both legs were confirmed by packet capture to reach the server from the same uplink address — kcptun behind a loopback relay bound to the physical interface, queqiao with `--local-address`. Fetches use `--noproxy ''`, not `--noproxy '*'`, which would disable proxying entirely.

Limits, stated with the numbers: one path, one object size, one direction, one fifteen-minute window; the parity ratio was not swept live; the loopback relay costs kcptun tens of microseconds against a 210 ms path; and the queqiao client was carrying the operator's ~70 real flows throughout while the kcptun tunnel carried only the benchmark. That asymmetry works against queqiao, which still led every round.

## Emulated campaign

Twelve paired trials per cell — trial *k* is the same seeded path for every stack — run in both stack orders so host drift shows up as an order effect rather than a transport difference:

| cell | queqiao median | kcptun median | matched trials | sign test |
| --- | ---: | ---: | ---: | ---: |
| 3% loss, 100 Mbit, 4 MiB | 17.5 | 5.05 | queqiao 12/12 | p=0.0005 |
| 20% loss, 50 Mbit, 2 MiB, parity 10:1 | 6.51 | 1.55 | queqiao 12/12 | p=0.0005 |
| 20% loss, parity 10:3 | 6.51 | 2.05 | queqiao 12/12 | p=0.0005 |
| 20% loss, parity 10:10 | 6.11 / 6.75 | 4.10 / 4.01 | queqiao 11/12, both orders | p=0.0064 |

The emulator is deterministic per seed but goodput is not, so cells are compared as paired trials with a sign test rather than as medians of a handful of runs.

## Checks

New tests cover both ends' addresses, identical shared parameters, `-nocomp`, the swept parity and window values, the two refusals, `SOCKSTarget` relaying, an end-to-end three-process tunnel launch with teardown verification, and per-stack binary selection with its error text. `go test -short -timeout 20m ./...`, `go vet ./...`, `gofmt -l .`, `staticcheck -checks=all,-U1000`, `go test -race ./internal/extproxy/`, and the Python suite are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jidJ9KKtHtTbWUX2sgKf5
