### PR TITLE
fix: keep provider state owned by the account that reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable user-visible changes are recorded here. Queqiao uses semantic
 versioning for release artifacts, while the pre-1.0 wire-compatibility rules
 remain stricter than semantic versioning alone; see `docs/PROTOCOL.md`.
 
+## Unreleased
+
+### Fixed
+
+- Provider state keeps its owner when a maintenance command runs under `sudo`.
+  State files are installed by renaming a replacement over the target, and the
+  replacement belonged to whoever ran the command, so one privileged
+  `queqiaod provider add-user` transferred `authorization.json` to `root` and
+  left the gateway's own service account unable to open it. The gateway then
+  logged `authorization refresh failed; retaining last known-good state` once a
+  second, kept admitting existing devices from its cached snapshot, and refused
+  every new enrollment - which surfaced to users as an invalid invitation
+  rather than as the server-side outage it was. Replacements now adopt the
+  owner of the file they replace, or of the state directory when the file is
+  new. The authorization lock is covered too: it is taken before the store is
+  read and is never removed, so a lock left behind by a privileged run refused
+  every later write.
+
 ## v0.1.0 - 2026-08-19
 
 ### Added

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -72,6 +72,12 @@ account, remove inherited access with the directory's DACL (for example with
 `icacls`), and grant full control only to that account and `SYSTEM`. Do not keep
 provider state on a shared or synchronizing folder on either platform.
 
+Run the `provider` subcommands as the account that owns that directory, as every
+example below does. Running one under plain `sudo` is no longer destructive -
+state files keep the owner they already had rather than following the caller -
+but the account that owns the state is still the account the gateway reads it
+as, and keeping the two aligned is what makes a misconfiguration obvious.
+
 ### systemd
 
 Install [`deploy/queqiaod.service`](../deploy/queqiaod.service), then create

--- a/internal/identity/filelock_unix.go
+++ b/internal/identity/filelock_unix.go
@@ -5,6 +5,7 @@ package identity
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -13,6 +14,14 @@ func lockFile(path string) (func(), error) {
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open authorization lock: %w", err)
+	}
+	// The lock is created on first use and never removed, and beginWrite takes
+	// it before reading the store. A lock left behind by a privileged run would
+	// therefore refuse every later write by the service account, so give it the
+	// same owner as the state directory it guards.
+	if err := adoptOwnerOf(path, filepath.Dir(path)); err != nil {
+		_ = file.Close()
+		return nil, err
 	}
 	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
 		_ = file.Close()

--- a/internal/identity/owner_test.go
+++ b/internal/identity/owner_test.go
@@ -1,0 +1,166 @@
+//go:build !windows
+
+package identity
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A uid/gid pair that need not resolve to a real account: chown accepts bare
+// numeric ids, which keeps the test independent of the host's user database.
+const (
+	testStateUID = 12345
+	testStateGID = 12345
+)
+
+func requireRoot(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Skip("ownership preservation is only observable when running as root")
+	}
+}
+
+func ownerOfPath(t *testing.T, path string) (int, int) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("no POSIX ownership for %s", path)
+	}
+	return int(stat.Uid), int(stat.Gid)
+}
+
+// A privileged provider command must not move the authorization store out of
+// reach of the unprivileged gateway that reads it.
+func TestWriteFileAtomicPreservesExistingOwner(t *testing.T) {
+	requireRoot(t)
+	path := filepath.Join(t.TempDir(), authorizationFile)
+	if err := os.WriteFile(path, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(path, testStateUID, testStateGID); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeFileAtomic(path, []byte("replacement\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	uid, gid := ownerOfPath(t, path)
+	if uid != testStateUID || gid != testStateGID {
+		t.Fatalf("replace transferred the state file to uid %d gid %d", uid, gid)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode is %s; want 0600", info.Mode())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "replacement\n" {
+		t.Fatalf("contents are %q (err %v)", data, err)
+	}
+}
+
+// A file created for the first time follows the directory it lives in, so a
+// privileged init against an already-provisioned state directory stays usable.
+func TestWriteFileAtomicAdoptsDirectoryOwnerForNewFile(t *testing.T) {
+	requireRoot(t)
+	directory := filepath.Join(t.TempDir(), "provider")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(directory, testStateUID, testStateGID); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, authorizationFile)
+	if err := writeFileAtomic(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if uid, gid := ownerOfPath(t, path); uid != testStateUID || gid != testStateGID {
+		t.Fatalf("new state file is owned by uid %d gid %d", uid, gid)
+	}
+}
+
+// beginWrite takes the lock before it reads the store, and the lock is never
+// removed, so a lock left behind by a privileged run would refuse every later
+// write by the service account.
+func TestLockFilePreservesDirectoryOwner(t *testing.T) {
+	requireRoot(t)
+	directory := filepath.Join(t.TempDir(), "provider")
+	if err := os.Mkdir(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(directory, testStateUID, testStateGID); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, authorizationFile+".lock")
+	unlock, err := lockFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unlock()
+	if uid, gid := ownerOfPath(t, path); uid != testStateUID || gid != testStateGID {
+		t.Fatalf("authorization lock is owned by uid %d gid %d", uid, gid)
+	}
+}
+
+// The whole mixed-ownership sequence the gateway actually runs: an
+// unprivileged service account provisions the state, a privileged
+// administrator adds a user, and the service account must still be able to
+// read and write what it owns.
+func TestProviderMutationUnderRootKeepsStateReadableByOwner(t *testing.T) {
+	requireRoot(t)
+	now := time.Now()
+	directory := filepath.Join(t.TempDir(), "provider")
+	provider, err := InitProvider(directory, "Example Provider", "127.0.0.1:443", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(directory, testStateUID, testStateGID); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if err := os.Chown(filepath.Join(directory, entry.Name()), testStateUID, testStateGID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := provider.Store.AddAccount("alice", time.Time{}, 0, now); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if uid, gid := ownerOfPath(t, filepath.Join(directory, name)); uid != testStateUID || gid != testStateGID {
+			t.Fatalf("%s is owned by uid %d gid %d after a privileged mutation", name, uid, gid)
+		}
+	}
+}
+
+// Unprivileged runs cannot cross accounts in a 0700 directory, so the helper
+// stays out of the way rather than failing a chown it is not allowed to make.
+func TestAdoptOwnerOfIsInertWithoutPrivilege(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; the privileged paths are covered elsewhere")
+	}
+	directory := t.TempDir()
+	path := filepath.Join(directory, authorizationFile)
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := adoptOwnerOf(path, directory); err != nil {
+		t.Fatalf("unprivileged adoption returned %v", err)
+	}
+	if uid, gid := ownerOfPath(t, path); uid != os.Geteuid() || gid != os.Getegid() {
+		t.Fatalf("unprivileged adoption changed ownership to uid %d gid %d", uid, gid)
+	}
+}

--- a/internal/identity/owner_unix.go
+++ b/internal/identity/owner_unix.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package identity
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// adoptOwnerOf gives path the ownership that reference already carries, or the
+// ownership of reference's directory when reference does not exist yet.
+//
+// Private state is installed by renaming a freshly created file over the
+// target, so the installed file is always a new inode owned by whoever ran the
+// process. The gateway runs as a dedicated service account while provider
+// maintenance runs from an administrator's shell, and Refresh is documented to
+// adopt changes written by those separate CLI processes. Without this step a
+// single privileged `queqiaod provider add-user` hands authorization.json to
+// root, and the gateway - which re-reads it once a second and on every
+// enrollment - can no longer open its own state. Callers restore the mode
+// themselves; only ownership needs carrying across the replace.
+func adoptOwnerOf(path, reference string) error {
+	// Only a privileged process can write into another account's 0700 state
+	// directory, so only a privileged process can perform this transfer. An
+	// unprivileged run already creates files as the account that owns the
+	// directory, and would fail these chown calls with EPERM.
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	uid, gid, ok, err := ownerOf(reference)
+	if err != nil || !ok {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect state file ownership: %w", err)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Uid) == uid && int(stat.Gid) == gid {
+		return nil
+	}
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("preserve state ownership uid %d gid %d: %w", uid, gid, err)
+	}
+	return nil
+}
+
+// ownerOf reports the uid and gid that private state beside reference should
+// carry, falling back to the containing directory when reference is absent.
+// The final boolean is false on platforms that do not expose POSIX ownership.
+func ownerOf(reference string) (int, int, bool, error) {
+	info, err := os.Lstat(reference)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return 0, 0, false, fmt.Errorf("inspect state ownership: %w", err)
+		}
+		if info, err = os.Stat(filepath.Dir(reference)); err != nil {
+			return 0, 0, false, fmt.Errorf("inspect state directory ownership: %w", err)
+		}
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false, nil
+	}
+	return int(stat.Uid), int(stat.Gid), true, nil
+}

--- a/internal/identity/owner_windows.go
+++ b/internal/identity/owner_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package identity
+
+// Windows does not express access through POSIX ownership. A file created in
+// the state directory inherits that directory's DACL, which the installer and
+// the service account own, so there is nothing to carry across a replace.
+func adoptOwnerOf(path, reference string) error { return nil }

--- a/internal/identity/pki.go
+++ b/internal/identity/pki.go
@@ -705,6 +705,12 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return fmt.Errorf("close state file: %w", err)
 	}
+	// Carry the existing owner across the replace. The rename installs a new
+	// inode owned by the calling process, which would otherwise move the file
+	// out of reach of the service account that has to read it.
+	if err := adoptOwnerOf(tmpName, path); err != nil {
+		return err
+	}
 	if err := replaceFile(tmpName, path); err != nil {
 		return fmt.Errorf("install state file: %w", err)
 	}


### PR DESCRIPTION
## What broke

A gateway stopped accepting new enrollments. Every attempt returned `invitation is invalid` to the user, while the invitation on disk was valid, unconsumed, and hours from expiry.

The real cause was in the daemon log, once per second:

```
{"level":"ERROR","msg":"authorization refresh failed; retaining last known-good state",
 "error":"read authorization store: open /var/lib/queqiao/provider/authorization.json: permission denied"}
```

```
drwx------ 2 queqiao queqiao  /var/lib/queqiao/provider/
-rw------- 1 root    root     authorization.json   <- the only root-owned file in the store
-rw------- 1 queqiao queqiao  device-issuer-key.pem
   ... every other file: queqiao:queqiao
```

The trigger was one ordinary maintenance command run under plain `sudo`:

```sh
sudo queqiaod provider add-user --state /var/lib/queqiao/provider --name jiaying
```

## Why one `sudo` was enough

`writeFileAtomic` installs state by renaming a replacement over the target. `os.CreateTemp` gives that replacement to whoever runs the process, and nothing carried the previous owner across the rename. The mode is restored explicitly; ownership silently followed the caller.

This is not an exotic path. `Store.Refresh` is documented to *"atomically adopt authorization changes written by provider CLI processes"* — the design intends the writer and the reader to be different processes, and in every deployment they are different **accounts**: the gateway runs as `User=queqiao`, maintenance runs from an administrator's shell.

The existing permission check could not catch it. `checkPrivatePermissions` inspects `os.FileInfo` mode bits and never calls `Sys()`, so `root:root 0600` passes cleanly. The failure only reappears later as a bare `permission denied`.

## Why it surfaced as a bad invitation

The two read paths diverge, which is what made this read as user error rather than an outage:

| Path | Source | Behaviour when the store is unreadable |
|---|---|---|
| `Authorize` (session admission) | in-memory snapshot, `RLock` | keeps admitting established devices from stale state |
| `EnrollDevice` (enrollment) | fresh disk read under `flock` | fails on every single attempt |

So established sessions kept flowing — the gateway looked healthy — while every new enrollment failed. And `EnrollmentService.Serve` collapses *every* `EnrollDevice` error into one client string:

```go
if err != nil {
    return s.writeError(conn, "invitation is invalid, expired, already used, or unavailable")
}
```

`err` is never inspected, wrapped, or logged. "I cannot open my own authorization store" and "your token is expired" are indistinguishable to the user, and a rejected enrollment writes nothing server-side at any log level, including Debug.

## The fix

Replacements adopt the owner of the file they replace, or of the state directory when the file is new.

The authorization **lock** gets the same treatment, and matters more than the store: `beginWrite` takes it *before* reading, and it is never removed. A lock left behind by one privileged run refuses every later write by the service account — permanently, and after the root process is long gone. In the incident that motivated this, the lock happened to predate the root command and survived; had it not existed, the repair would have been harder to find.

Only a privileged process can write into another account's `0700` directory, so only a privileged process can cause this transfer. The helper is therefore inert below `euid 0` rather than attempting a `chown` it is not permitted to make, which keeps unprivileged runs on exactly their current behaviour. Windows has no POSIX ownership to carry and keeps a no-op.

## Verification

The new tests fail on `main` with the production symptom and pass with the fix:

```
--- FAIL: TestWriteFileAtomicPreservesExistingOwner
    replace transferred the state file to uid 0 gid 0
--- FAIL: TestLockFilePreservesDirectoryOwner
    authorization lock is owned by uid 0 gid 0
--- FAIL: TestProviderMutationUnderRootKeepsStateReadableByOwner
    authorization.json is owned by uid 0 gid 0 after a privileged mutation
```

End to end against a real state directory initialised by the service account, then mutated under `sudo`:

```
after (binary without this change):
   root:root         authorization.json
after (binary with this change):
   queqiao:queqiao   authorization.json

service account can read the store afterwards?
   without : read authorization store: open .../authorization.json: permission denied
   with    : 9044309b84a0...  jiaying  true  never  16
```

The failure string reproduced without the change is byte-identical to the one from the production journal.

`go test ./...` passes: 27 packages ok, 0 failed. The privileged tests skip below `euid 0`, so unprivileged CI keeps the coverage it has today; the unprivileged inertness test runs there instead.

## Deliberately not in this PR

Two real bugs found while tracing this, both worth their own change:

1. **Enrollment errors are collapsed and unlogged.** `enrollment.go:186` flattens ten-plus distinct causes — including total store failure — into one client string, and no enroll rejection or acceptance is logged server-side. An operator cannot tell a user typo from an outage. `refuseLaneJoin` (`server.go:843`) already solves exactly this shape in this codebase, with a metric, a rate limiter, and a level that escalates by reason; its comment reads like a description of this bug.
2. **The refresh loop cannot report its own staleness.** It logs an identical Error line every second with no first-failure or recovery transition, no consecutive-failure count, and no metric. `Store` records no timestamp of its last good load, so staleness age is not merely unexported — it is never computed.

Happy to open either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juuoq98WrCgQJ5XXF6jQS9