### PR TITLE
Limit accounts by device, not by connection count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ remain stricter than semantic versioning alone; see `docs/PROTOCOL.md`.
 
 ## Unreleased
 
+### Added
+
+- A per-account concurrent-device limit, `provider add-user --max-clients`,
+  defaulting to 8. A device counts once however many flows it carries, so this
+  is the limit that expresses "this account is for eight devices" -- which is
+  what the per-account limit was widely assumed to already mean.
+- `provider set-user-limits`, which corrects an account's limits in place. The
+  only previous way to change them was to delete the account, which deletes
+  every device enrolled against it.
+- `queqiao_account_admission_refused_total` by reason, and an `account flow
+  open refused` log record at `warn` naming the reason, account, and device.
+  Account admission was previously the one admission decision the gateway made
+  silently: no record at any log level and no counter, so a gateway refusing
+  half an account's connections was indistinguishable from a healthy one.
+
+### Changed
+
+- `provider add-user --max-sessions` is renamed `--max-flows`, and now defaults
+  to 1024 instead of deferring to the gateway ceiling. It counts concurrent
+  flows -- one TCP connection or one UDP association each -- and never counted
+  devices. A browser opens roughly six connections per host across dozens of
+  hosts per page and holds them for the flow idle timeout, so a value chosen as
+  though it were a device count fails in the least legible way available: most
+  sites load and a few do not. The old flag name still works and warns.
+  Existing accounts keep the limit they were given; correct one with
+  `provider set-user-limits`.
+- A flow open refused by an account limit now says which limit refused it:
+  `account flow limit reached` or `account device limit reached`, replacing
+  `account session unavailable`. A device that lost authorization between its
+  handshake and its next flow open is answered with the AUTHENTICATION reset
+  code and `device is not authorized` rather than being reported as a limit.
+- `provider list-users` reports `MAX_FLOWS` and `MAX_CLIENTS` in place of
+  `MAX_SESSIONS`.
+- Provider authorization state writes the per-account flow limit as
+  `max_flows`. An existing state naming it `max_sessions` is read unchanged and
+  rewritten on the next save; a state naming both is refused rather than having
+  one silently win.
+
 ### Fixed
 
 - Provider state keeps its owner when a maintenance command runs under `sudo`.
@@ -37,6 +75,8 @@ remain stricter than semantic versioning alone; see `docs/PROTOCOL.md`.
   storm stays one readable line. Enrollment attempts dropped because the
   enrollment slots were full are also reported now, matching the session and
   connection ceilings beside them.
+- The deployment guide's worked example created an account with a flow ceiling
+  of 8, which is too low to load a web page.
 
 ## v0.1.0 - 2026-08-19
 

--- a/cmd/queqiaobench/main.go
+++ b/cmd/queqiaobench/main.go
@@ -653,7 +653,7 @@ func benchmarkCredentials(directory, endpoint string) (identity.ServerCredential
 	if err != nil {
 		return identity.ServerCredentials{}, identity.ClientCredentials{}, err
 	}
-	account, err := provider.Store.AddAccount("benchmark", time.Time{}, 0, now)
+	account, err := provider.Store.AddAccount("benchmark", time.Time{}, identity.AccountLimits{}, now)
 	if err != nil {
 		return identity.ServerCredentials{}, identity.ClientCredentials{}, err
 	}

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -74,6 +74,28 @@ func newFlagSet(name string) *flag.FlagSet {
 	return fs
 }
 
+// flagWasSet reports whether the operator named this flag, as opposed to it
+// holding its default. A limit the operator did not name must keep its current
+// value rather than being reset to a default.
+func flagWasSet(fs *flag.FlagSet, name string) bool {
+	set := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			set = true
+		}
+	})
+	return set
+}
+
+// describeLimit renders a limit for an operator, spelling out what zero means
+// instead of printing a zero that reads like "none allowed".
+func describeLimit(value int, unlimited string) string {
+	if value == 0 {
+		return fmt.Sprintf("0 (%s)", unlimited)
+	}
+	return fmt.Sprintf("%d", value)
+}
+
 func requireNoArguments(fs *flag.FlagSet) error {
 	if fs.NArg() != 0 {
 		return fmt.Errorf("unexpected arguments: %s", strings.Join(fs.Args(), " "))
@@ -83,7 +105,7 @@ func requireNoArguments(fs *flag.FlagSet) error {
 
 func runProvider(args []string) error {
 	if len(args) == 0 {
-		return errors.New("provider command is required: init, add-user, list-users, invite, list-invites, revoke-invite, list-devices, revoke-device, enable-user, or disable-user")
+		return errors.New("provider command is required: init, add-user, list-users, set-user-limits, invite, list-invites, revoke-invite, list-devices, revoke-device, enable-user, or disable-user")
 	}
 	switch args[0] {
 	case "init":
@@ -111,7 +133,9 @@ func runProvider(args []string) error {
 		state := fs.String("state", "", "provider state directory")
 		name := fs.String("name", "", "unique user name")
 		expiresIn := fs.Duration("expires-in", 0, "optional account lifetime (0 never expires)")
-		maxSessions := fs.Int("max-sessions", 0, "concurrent flows for this user (0 uses provider limit)")
+		maxFlows := fs.Int("max-flows", identity.DefaultAccountMaxFlows, "concurrent proxied flows for this user (0 uses the gateway limit)")
+		maxClients := fs.Int("max-clients", identity.DefaultAccountMaxClients, "concurrent devices for this user (0 allows every enrolled device)")
+		maxSessions := fs.Int("max-sessions", 0, "deprecated name for --max-flows")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -129,11 +153,20 @@ func runProvider(args []string) error {
 		if *expiresIn > 0 {
 			expires = time.Now().Add(*expiresIn)
 		}
-		account, err := provider.Store.AddAccount(*name, expires, *maxSessions, time.Now())
+		limits := identity.AccountLimits{MaxFlows: *maxFlows, MaxClients: *maxClients}
+		if flagWasSet(fs, "max-sessions") {
+			if flagWasSet(fs, "max-flows") {
+				return errors.New("--max-sessions is the former name of --max-flows; set only one")
+			}
+			fmt.Fprintln(os.Stderr, "queqiaod: --max-sessions is deprecated and renamed --max-flows. It counts concurrent flows, not devices: one flow is one TCP connection or one UDP association, and a browser needs hundreds. Use --max-clients to limit devices.")
+			limits.MaxFlows = *maxSessions
+		}
+		account, err := provider.Store.AddAccount(*name, expires, limits, time.Now())
 		if err != nil {
 			return err
 		}
-		fmt.Printf("User %q created.\nID: %s\n", account.Name, account.ID)
+		fmt.Printf("User %q created.\nID: %s\nFlows: %s\nClients: %s\n",
+			account.Name, account.ID, describeLimit(account.MaxFlows, "gateway limit"), describeLimit(account.MaxClients, "every enrolled device"))
 		return nil
 	case "list-users":
 		fs := newFlagSet("provider list-users")
@@ -148,14 +181,53 @@ func runProvider(args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println("ID\tNAME\tENABLED\tEXPIRES\tMAX_SESSIONS")
+		fmt.Println("ID\tNAME\tENABLED\tEXPIRES\tMAX_FLOWS\tMAX_CLIENTS")
 		for _, account := range provider.Store.Accounts() {
 			expires := account.ExpiresAt
 			if expires == "" {
 				expires = "never"
 			}
-			fmt.Printf("%s\t%s\t%t\t%s\t%d\n", account.ID, account.Name, account.Enabled, expires, account.MaxSessions)
+			fmt.Printf("%s\t%s\t%t\t%s\t%d\t%d\n", account.ID, account.Name, account.Enabled, expires, account.MaxFlows, account.MaxClients)
 		}
+		return nil
+	case "set-user-limits":
+		fs := newFlagSet("provider set-user-limits")
+		state := fs.String("state", "", "provider state directory")
+		user := fs.String("user", "", "user name or ID")
+		maxFlows := fs.Int("max-flows", 0, "concurrent proxied flows for this user, unchanged if not given (0 uses the gateway limit)")
+		maxClients := fs.Int("max-clients", 0, "concurrent devices for this user, unchanged if not given (0 allows every enrolled device)")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if err := requireNoArguments(fs); err != nil {
+			return err
+		}
+		if !flagWasSet(fs, "max-flows") && !flagWasSet(fs, "max-clients") {
+			return errors.New("set at least one of --max-flows or --max-clients")
+		}
+		provider, err := loadProviderRequired(*state)
+		if err != nil {
+			return err
+		}
+		account, ok := provider.Store.FindAccount(*user)
+		if !ok {
+			return errors.New("unknown user")
+		}
+		// An unnamed limit keeps its current value. Correcting one limit is
+		// the common case, and defaulting the other to this build's default
+		// would silently rewrite a policy the operator did not mention.
+		limits := account.Limits()
+		if flagWasSet(fs, "max-flows") {
+			limits.MaxFlows = *maxFlows
+		}
+		if flagWasSet(fs, "max-clients") {
+			limits.MaxClients = *maxClients
+		}
+		if err := provider.Store.SetAccountLimits(account.ID, limits); err != nil {
+			return err
+		}
+		fmt.Printf("User %q limits updated.\nFlows: %s\nClients: %s\n",
+			account.Name, describeLimit(limits.MaxFlows, "gateway limit"), describeLimit(limits.MaxClients, "every enrolled device"))
 		return nil
 	case "invite":
 		fs := newFlagSet("provider invite")

--- a/cmd/queqiaod/provider_cli_test.go
+++ b/cmd/queqiaod/provider_cli_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bojieli/queqiao/internal/identity"
+)
+
+func providerStateForTest(t *testing.T) string {
+	t.Helper()
+	state := filepath.Join(t.TempDir(), "provider")
+	if err := runProvider([]string{"init", "--state", state, "--name", "test", "--endpoint", "127.0.0.1:443"}); err != nil {
+		t.Fatalf("provider init: %v", err)
+	}
+	return state
+}
+
+func accountForTest(t *testing.T, state, name string) identity.Account {
+	t.Helper()
+	provider, err := loadProviderRequired(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	account, ok := provider.Store.FindAccount(name)
+	if !ok {
+		t.Fatalf("account %q is missing", name)
+	}
+	return account
+}
+
+// A new account must be able to browse. The flow default is high because one
+// flow is one connection, and the limit an operator reaches for when they mean
+// "this account is for a few devices" is the device count beside it.
+func TestAddUserDefaultsAdmitOrdinaryBrowsing(t *testing.T) {
+	state := providerStateForTest(t)
+	if err := runProvider([]string{"add-user", "--state", state, "--name", "alice"}); err != nil {
+		t.Fatal(err)
+	}
+	account := accountForTest(t, state, "alice")
+	if account.MaxFlows != identity.DefaultAccountMaxFlows || account.MaxClients != identity.DefaultAccountMaxClients {
+		t.Fatalf("defaults = %+v, want flows %d and clients %d",
+			account.Limits(), identity.DefaultAccountMaxFlows, identity.DefaultAccountMaxClients)
+	}
+	if account.MaxFlows < 1024 {
+		t.Fatalf("default flow ceiling %d is too low for a browser", account.MaxFlows)
+	}
+}
+
+// The old name kept working, but it must not be settable alongside the new one:
+// the two would name one limit twice, and picking a winner picks a policy.
+func TestAddUserAcceptsTheFormerFlagNameButNotBoth(t *testing.T) {
+	state := providerStateForTest(t)
+	if err := runProvider([]string{"add-user", "--state", state, "--name", "alice", "--max-sessions", "64"}); err != nil {
+		t.Fatal(err)
+	}
+	if account := accountForTest(t, state, "alice"); account.MaxFlows != 64 {
+		t.Fatalf("max flows = %d, want the value given as --max-sessions", account.MaxFlows)
+	}
+	err := runProvider([]string{"add-user", "--state", state, "--name", "bob", "--max-sessions", "64", "--max-flows", "64"})
+	if err == nil {
+		t.Fatal("both spellings of the flow limit were accepted at once")
+	}
+}
+
+// Correcting one limit must not silently rewrite the other, and an account
+// whose limit was set too low must be correctable without being deleted.
+func TestSetUserLimitsChangesOnlyWhatIsNamed(t *testing.T) {
+	state := providerStateForTest(t)
+	if err := runProvider([]string{"add-user", "--state", state, "--name", "alice", "--max-flows", "16", "--max-clients", "2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runProvider([]string{"set-user-limits", "--state", state, "--user", "alice", "--max-flows", "0"}); err != nil {
+		t.Fatal(err)
+	}
+	account := accountForTest(t, state, "alice")
+	if account.MaxFlows != 0 {
+		t.Fatalf("max flows = %d, want the gateway limit", account.MaxFlows)
+	}
+	if account.MaxClients != 2 {
+		t.Fatalf("max clients = %d, want the unnamed limit left alone", account.MaxClients)
+	}
+	if err := runProvider([]string{"set-user-limits", "--state", state, "--user", "alice"}); err == nil {
+		t.Fatal("set-user-limits with no limit named was accepted")
+	}
+	if err := runProvider([]string{"set-user-limits", "--state", state, "--user", "nobody", "--max-clients", "4"}); err == nil {
+		t.Fatal("limits were set on an unknown user")
+	}
+}

--- a/cmd/queqiaod/providers_test.go
+++ b/cmd/queqiaod/providers_test.go
@@ -227,7 +227,7 @@ func providerTestProfile(t *testing.T, directory string, index int, endpoint str
 	if err != nil {
 		t.Fatal(err)
 	}
-	account, err := provider.Store.AddAccount("user", time.Time{}, 0, now)
+	account, err := provider.Store.AddAccount("user", time.Time{}, identity.AccountLimits{}, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/deploy/install-server.sh
+++ b/deploy/install-server.sh
@@ -27,7 +27,8 @@ provider_name=
 endpoint=
 listen=
 user_name=
-user_max_sessions=0
+user_max_flows=1024
+user_max_clients=8
 invite_expires_in=24h
 transport=auto
 max_sessions=4096
@@ -56,7 +57,11 @@ Required for a first install:
 
 Provider options:
   --state DIR              provider state directory (default /var/lib/queqiao/provider)
-  --user-max-sessions N    per-user concurrent flow limit (default 0, provider-wide)
+  --user-max-clients N     per-user concurrent device limit (default 8, 0 for every device)
+  --user-max-flows N       per-user concurrent flow limit (default 1024, 0 for the
+                           gateway-wide limit). One flow is one TCP connection or
+                           one UDP association, so a browser needs hundreds: this
+                           is not a device count.
   --invite-expires-in DUR  invitation lifetime, maximum 7d (default 24h)
   --no-provider-init       upgrade an existing deployment; skip init/add-user/invite
 
@@ -131,9 +136,20 @@ while [ "$#" -gt 0 ]; do
 		state=$2
 		shift
 		;;
+	--user-max-clients)
+		next_value "$#" "$1"
+		user_max_clients=$2
+		shift
+		;;
+	--user-max-flows)
+		next_value "$#" "$1"
+		user_max_flows=$2
+		shift
+		;;
 	--user-max-sessions)
 		next_value "$#" "$1"
-		user_max_sessions=$2
+		printf '%s\n' "install-server.sh: --user-max-sessions is the former name of --user-max-flows; use --user-max-clients to limit devices." >&2
+		user_max_flows=$2
 		shift
 		;;
 	--invite-expires-in)
@@ -294,8 +310,8 @@ EOF
 		cat <<EOF
 
 Would initialize provider "$provider_name" at $endpoint, create user
-"$user_name" with --max-sessions $user_max_sessions, and print one invitation
-valid for $invite_expires_in.
+"$user_name" with --max-clients $user_max_clients and --max-flows
+$user_max_flows, and print one invitation valid for $invite_expires_in.
 EOF
 	else
 		echo
@@ -423,7 +439,8 @@ if [ "$bootstrap" = true ]; then
 	provider_run "$binary_path" provider init \
 		--state "$state" --name "$provider_name" --endpoint "$endpoint"
 	provider_run "$binary_path" provider add-user \
-		--state "$state" --name "$user_name" --max-sessions "$user_max_sessions"
+		--state "$state" --name "$user_name" \
+		--max-flows "$user_max_flows" --max-clients "$user_max_clients"
 	echo "Created user $user_name."
 fi
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,7 +226,8 @@ atomic rename, and directory sync. The server reloads only complete snapshots
 and retains the last known-good state if a replacement is malformed.
 
 The implementation explicitly bounds unauthenticated connections, per-user
-sessions, streams, frames, payloads, acknowledgement ranges, send replay,
+flows and concurrently active devices, streams, frames, payloads,
+acknowledgement ranges, send replay,
 reassembly, writer queues, probes, lane recovery, retained UDP relays, idle
 periods, and total flow lifetime. Exact wire fields and validation rules are in
 the [protocol specification](PROTOCOL.md); operational residual risks are in

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -208,11 +208,50 @@ Create a separate account for every customer or administrative boundary:
 sudo -u queqiao /usr/local/bin/queqiaod provider add-user \
   --state /var/lib/queqiao/provider \
   --name alice \
-  --max-sessions 8
+  --max-clients 8
 ```
 
-`--max-sessions 0` uses the gateway-wide limit. The limit spans all devices
-owned by that user.
+An account carries two limits, and they count different things:
+
+- `--max-clients` is how many of the account's devices may be carrying traffic
+  at once. A device counts once however much it carries, so this is the limit
+  that expresses "this account is for eight devices". It defaults to 8, and
+  zero admits every enrolled device.
+- `--max-flows` is how many proxied flows the account may hold at once. One
+  flow is one TCP connection or one UDP association — not one device, and not
+  one page. It defaults to 1024, and zero defers to the gateway-wide
+  `--max-sessions` ceiling.
+
+Set the device limit and leave the flow limit alone unless you are deliberately
+capping one account's footprint on the gateway. A flow ceiling low enough to be
+interesting as a quota is low enough to break ordinary browsing: one page opens
+roughly six connections per host across dozens of hosts, and with the default
+`--flow-idle-timeout` those keep-alive connections keep holding their slots for
+half an hour after the page finished loading. The failure that produces is hard
+to recognize — most sites load, a few do not, and the only symptom is the
+client reporting `peer reset flow: account flow limit reached`.
+
+`--max-sessions` is the former name of `--max-flows` and still works. It is
+deprecated because it reads like a device count and has never been one.
+
+Both limits can be corrected in place, without deleting the account and every
+device enrolled against it:
+
+```sh
+sudo -u queqiao /usr/local/bin/queqiaod provider set-user-limits \
+  --state /var/lib/queqiao/provider \
+  --user alice \
+  --max-flows 0
+```
+
+A limit you do not name keeps its current value. The gateway re-reads
+authorization state every second, so a corrected limit admits new flows within
+a second, without a restart and without disturbing open connections.
+
+Refusals are counted at `queqiao_account_admission_refused_total` by reason —
+`flow_limit`, `client_limit`, `unauthorized` — and logged as `msg="account flow
+open refused"` naming the account and device. Check those first when a user
+reports that some sites work and others do not.
 
 Create a one-time invitation and deliver the single printed URI through an
 authenticated private channel:

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -110,7 +110,7 @@ Prometheus `/metrics` names. They cover:
 - transient local UDP send errors absorbed into QUIC loss recovery;
 - flow telemetry entries expired because nothing refreshed them, which is how
   a round-trip aggregate frozen at a stale constant announces itself;
-- lane joins refused, split by reason; and
+- lane joins refused and account flow opens refused, each split by reason; and
 - the controller's measured erasure floor, sampler diagnostics, and class
   transitions.
 
@@ -127,6 +127,15 @@ are the peer's to choose, so a map keyed by them is memory a peer sizes -- and
 each record carries how many refusals of that reason it stands for in
 `suppressed`. The matching counters are `queqiao_lane_join_refused_total` by
 reason.
+
+A gateway that refuses a flow open because of the opening account's own limits
+writes `msg="account flow open refused"` at `warn`, naming the `reason` --
+`flow_limit`, `client_limit`, or `unauthorized` -- with the account and device.
+It is rate limited and counted the same way, with `suppressed` and `total` in
+each record and `queqiao_account_admission_refused_total` by reason. This is
+the record to look for when a user reports that most sites load and a few do
+not: an account whose flow limit is too low for a browser fails exactly that
+way, and the flow limit counts connections rather than devices.
 
 Flow-completion records add an opaque session/flow correlation ID, transport,
 duration, directional bytes, class, lane byte

--- a/internal/conformance/generate_test.go
+++ b/internal/conformance/generate_test.go
@@ -336,7 +336,8 @@ func resetVectors() []ResetVector {
 		{"protocol", session.ResetProtocol, "invalid flow open"},
 		{"authentication", session.ResetAuthentication, "device is not authorized"},
 		{"destination", session.ResetDestination, "destination unavailable"},
-		{"flow limit", session.ResetFlowLimit, "account session unavailable"},
+		{"flow limit", session.ResetFlowLimit, "account flow limit reached"},
+		{"client limit", session.ResetFlowLimit, "account device limit reached"},
 		{"transport", session.ResetTransport, "lane transport failed"},
 		{"no message", session.ResetProtocol, ""},
 	}

--- a/internal/identity/enrollment_outcome_test.go
+++ b/internal/identity/enrollment_outcome_test.go
@@ -14,7 +14,7 @@ import (
 
 // attemptEnrollment runs one enrollment over an in-memory pipe and returns
 // what the gateway recorded alongside what the client was told.
-func attemptEnrollment(t *testing.T, provider *Provider, token string) (EnrollmentResult, error, enrollmentResponse) {
+func attemptEnrollment(t *testing.T, provider *Provider, token string) (EnrollmentResult, enrollmentResponse, error) {
 	t.Helper()
 	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -47,12 +47,12 @@ func attemptEnrollment(t *testing.T, provider *Provider, token string) (Enrollme
 		}
 	}
 	outcome := <-done
-	return outcome.result, outcome.err, response
+	return outcome.result, response, outcome.err
 }
 
 func mintInvitation(t *testing.T, provider *Provider) string {
 	t.Helper()
-	account, err := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestEnrollmentSeparatesStoreOutageFromRejection(t *testing.T) {
 	if err := os.Remove(filepath.Join(provider.Directory, authorizationFile)); err != nil {
 		t.Fatal(err)
 	}
-	result, err, response := attemptEnrollment(t, provider, token)
+	result, response, err := attemptEnrollment(t, provider, token)
 	if result.Outcome != EnrollmentUnavailable {
 		t.Fatalf("outcome is %q; want %q", result.Outcome, EnrollmentUnavailable)
 	}
@@ -99,7 +99,7 @@ func TestEnrollmentRejectionIsNotBlamedOnTheStore(t *testing.T) {
 	if _, err := rand.Read(bogus[:]); err != nil {
 		t.Fatal(err)
 	}
-	result, err, response := attemptEnrollment(t, provider, base64.RawURLEncoding.EncodeToString(bogus[:]))
+	result, response, err := attemptEnrollment(t, provider, base64.RawURLEncoding.EncodeToString(bogus[:]))
 	if result.Outcome != EnrollmentRejected {
 		t.Fatalf("outcome is %q; want %q", result.Outcome, EnrollmentRejected)
 	}
@@ -127,7 +127,7 @@ func TestEnrollmentMalformedTokenIsNotAnInvitationVerdict(t *testing.T) {
 func TestEnrollmentAcceptanceCarriesIdentifiers(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
 	token := mintInvitation(t, provider)
-	result, err, response := attemptEnrollment(t, provider, token)
+	result, response, err := attemptEnrollment(t, provider, token)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -120,7 +120,7 @@ func TestProviderRejectsMismatchedIssuerPrivateKey(t *testing.T) {
 func TestInvitationIsCompactStrictExpiringAndOneTime(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, err := provider.Store.AddAccount("alice", time.Time{}, 2, now)
+	account, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{MaxFlows: 2}, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestInvitationIsCompactStrictExpiringAndOneTime(t *testing.T) {
 func TestIssuerFailureDoesNotConsumeInvitation(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	_, invitation, _ := provider.CreateInvitation(account.ID, time.Hour, now)
 	publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
 	if _, _, _, err := provider.Store.EnrollDevice(invitation.Token, "laptop", publicKey, now, func(Account, Device) ([]byte, error) {
@@ -181,7 +181,7 @@ func TestIssuerFailureDoesNotConsumeInvitation(t *testing.T) {
 func TestInterruptedEnrollmentIsIdempotentOnlyForTheSameClientKey(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	_, invitation, _ := provider.CreateInvitation(account.ID, time.Hour, now)
 	publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
 	issue := func(account Account, device Device) ([]byte, error) {
@@ -204,7 +204,7 @@ func TestInterruptedEnrollmentIsIdempotentOnlyForTheSameClientKey(t *testing.T) 
 func TestConsumedInvitationRecoversAfterItsOriginalExpiry(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	_, invitation, _ := provider.CreateInvitation(account.ID, time.Minute, now)
 	publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
 	issue := func(account Account, device Device) ([]byte, error) {
@@ -236,7 +236,7 @@ func TestConsumedInvitationRecoversAfterItsOriginalExpiry(t *testing.T) {
 func TestProviderCanListAndRevokeOutstandingInvitations(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	record, token, err := provider.Store.CreateInvite(account.ID, time.Hour, now)
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func TestProviderCanListAndRevokeOutstandingInvitations(t *testing.T) {
 
 func TestEnrollmentDraftPreservesKeyAcrossRestart(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	_, invitation, _ := provider.CreateInvitation(account.ID, time.Hour, time.Now())
 	draft, err := NewEnrollmentDraft(invitation, "laptop")
 	if err != nil {
@@ -280,7 +280,7 @@ func TestEnrollmentDraftPreservesKeyAcrossRestart(t *testing.T) {
 func TestProfilesAreSelfContainedStrictAndPrivate(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	profile := localProfile(t, provider, account, "laptop", now)
 	path := filepath.Join(t.TempDir(), "profile.json")
 	if err := profile.Save(path); err != nil {
@@ -344,7 +344,7 @@ func tlsHandshake(t *testing.T, serverConfig, clientConfig *tls.Config) error {
 func TestMutualTLSRequiresAnAuthorizedDeviceAndPinnedGateway(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	profile := localProfile(t, provider, account, "laptop", now)
 	clientCredentials, _ := profile.Credentials()
 	serverConfig, err := ServerTLSConfig(provider.ServerCredentials(), "queqiao/1", false)
@@ -391,7 +391,7 @@ func TestEnrollmentEndToEndAndReplayFails(t *testing.T) {
 	}
 	defer listener.Close()
 	provider := testProvider(t, listener.Addr().String(), time.Now())
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	uri, invitation, err := provider.CreateInvitation(account.ID, time.Hour, time.Now())
 	if err != nil {
 		t.Fatal(err)
@@ -429,7 +429,7 @@ func TestEnrollmentEndToEndAndReplayFails(t *testing.T) {
 
 func TestEnrollmentRejectsInvalidLocalAddressBeforeDial(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	_, invitation, err := provider.CreateInvitation(account.ID, time.Hour, time.Now())
 	if err != nil {
 		t.Fatal(err)
@@ -451,7 +451,7 @@ func TestEnrollmentExplainsProtocolALPNMismatch(t *testing.T) {
 	}
 	defer listener.Close()
 	provider := testProvider(t, listener.Addr().String(), time.Now())
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	_, invitation, err := provider.CreateInvitation(account.ID, time.Hour, time.Now())
 	if err != nil {
 		t.Fatal(err)
@@ -483,7 +483,7 @@ func TestRenewalPreservesDeviceAndRejectsRevocation(t *testing.T) {
 	}
 	defer listener.Close()
 	provider := testProvider(t, listener.Addr().String(), time.Now().Add(-24*24*time.Hour))
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	profile := localProfile(t, provider, account, "laptop", time.Now().Add(-24*24*time.Hour))
 	needs, err := profile.NeedsRenewal(time.Now(), 7*24*time.Hour)
 	if err != nil || !needs {
@@ -526,7 +526,7 @@ func TestRenewalPreservesDeviceAndRejectsRevocation(t *testing.T) {
 func TestAuthorizationRefreshKeepsLastKnownGoodState(t *testing.T) {
 	now := time.Now()
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	reader, err := NewStore(filepath.Join(provider.Directory, authorizationFile))
 	if err != nil || reader.Load() != nil {
 		t.Fatal(err)
@@ -572,6 +572,111 @@ func TestAuthorizationStoreRejectsUnknownAndInconsistentFields(t *testing.T) {
 	}
 }
 
+// A provider state written before the flow limit was renamed still calls it
+// max_sessions. The store rejects unknown fields and keeps the last known-good
+// state when a replacement will not decode, so failing to read the old name
+// would not degrade gracefully: it would leave a running gateway pinned to
+// stale authorization and a provider CLI unable to load the state at all.
+func TestLegacyMaxSessionsIsReadAsTheFlowLimit(t *testing.T) {
+	provider := testProvider(t, "127.0.0.1:443", time.Now())
+	path := filepath.Join(provider.Directory, authorizationFile)
+	if _, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{MaxFlows: 16}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := bytes.Replace(data, []byte(`"max_flows"`), []byte(`"max_sessions"`), 1)
+	if bytes.Equal(legacy, data) {
+		t.Fatal("test did not rewrite the flow limit to its old name")
+	}
+	if err := os.WriteFile(path, legacy, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := NewStore(path)
+	if err := store.Load(); err != nil {
+		t.Fatalf("state naming the flow limit max_sessions did not load: %v", err)
+	}
+	account, ok := store.FindAccount("alice")
+	if !ok || account.MaxFlows != 16 {
+		t.Fatalf("legacy limit read as %d, want 16", account.MaxFlows)
+	}
+	// The old name is compatibility on read only. Saving must write the
+	// current one so the store has a single spelling of the limit.
+	if err := store.SetAccountEnabled(account.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(saved, []byte(`"max_sessions"`)) {
+		t.Fatal("saving rewrote the flow limit under its old name")
+	}
+	if !bytes.Contains(saved, []byte(`"max_flows"`)) {
+		t.Fatal("saving dropped the flow limit")
+	}
+}
+
+// Both spellings at once is a state nobody can have written on purpose, and
+// guessing which one the operator meant is guessing at a security policy.
+func TestConflictingFlowLimitSpellingsAreRejected(t *testing.T) {
+	provider := testProvider(t, "127.0.0.1:443", time.Now())
+	path := filepath.Join(provider.Directory, authorizationFile)
+	if _, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{MaxFlows: 16}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	both := bytes.Replace(data, []byte(`"max_flows": 16`), []byte(`"max_flows": 16, "max_sessions": 8`), 1)
+	if bytes.Equal(both, data) {
+		t.Fatal("test did not add the conflicting field")
+	}
+	if err := os.WriteFile(path, both, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := NewStore(path)
+	if err := store.Load(); err == nil {
+		t.Fatal("a store naming two different flow limits was accepted")
+	}
+}
+
+// An operator who set a limit too low must be able to correct it in place. The
+// alternative is deleting the account, which deletes every device enrolled
+// against it.
+func TestSetAccountLimitsIsAdoptedByAReader(t *testing.T) {
+	now := time.Now()
+	provider := testProvider(t, "127.0.0.1:443", now)
+	account, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{MaxFlows: 16, MaxClients: 2}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewStore(filepath.Join(provider.Directory, authorizationFile))
+	if err != nil || reader.Load() != nil {
+		t.Fatal(err)
+	}
+	if err := provider.Store.SetAccountLimits(account.ID, AccountLimits{MaxFlows: 0, MaxClients: 8}); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := reader.Refresh()
+	if err != nil || !changed {
+		t.Fatalf("refresh changed=%t err=%v", changed, err)
+	}
+	updated, _ := reader.FindAccount(account.ID)
+	if updated.MaxFlows != 0 || updated.MaxClients != 8 {
+		t.Fatalf("limits after refresh = %+v, want flows 0 and clients 8", updated.Limits())
+	}
+	if err := provider.Store.SetAccountLimits(account.ID, AccountLimits{MaxFlows: -1}); err == nil {
+		t.Fatal("a negative flow limit was accepted")
+	}
+	if err := provider.Store.SetAccountLimits("unknown", AccountLimits{}); err == nil {
+		t.Fatal("limits were set on an unknown account")
+	}
+}
+
 func TestIndependentProviderProcessesDoNotLoseConcurrentUpdates(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "authorization.json")
 	first, _ := NewStore(path)
@@ -588,7 +693,7 @@ func TestIndependentProviderProcessesDoNotLoseConcurrentUpdates(t *testing.T) {
 		index, store := index, store
 		go func() {
 			<-start
-			_, err := store.AddAccount([]string{"alice", "bob"}[index], time.Time{}, 0, time.Now())
+			_, err := store.AddAccount([]string{"alice", "bob"}[index], time.Time{}, AccountLimits{}, time.Now())
 			results <- err
 		}()
 	}
@@ -627,7 +732,7 @@ func TestCertificateRolesCannotBeSwapped(t *testing.T) {
 func TestGatewayRenewalIsVisibleToExistingTLSConfiguration(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	provider := testProvider(t, "127.0.0.1:443", now)
-	account, _ := provider.Store.AddAccount("alice", time.Time{}, 0, now)
+	account, _ := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now)
 	profile := localProfile(t, provider, account, "laptop", now)
 	clientCredentials, err := profile.Credentials()
 	if err != nil {

--- a/internal/identity/owner_test.go
+++ b/internal/identity/owner_test.go
@@ -135,7 +135,7 @@ func TestProviderMutationUnderRootKeepsStateReadableByOwner(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := provider.Store.AddAccount("alice", time.Time{}, 0, now); err != nil {
+	if _, err := provider.Store.AddAccount("alice", time.Time{}, AccountLimits{}, now); err != nil {
 		t.Fatal(err)
 	}
 	for _, entry := range entries {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -19,13 +19,101 @@ import (
 	"time"
 )
 
+// DefaultAccountMaxFlows and DefaultAccountMaxClients are the policy a new
+// account is created with.
+//
+// The flow ceiling is deliberately generous. One flow is one TCP connection or
+// one UDP association, and a browser opens roughly six per host across dozens
+// of hosts to load a single page; with the default flow idle timeout, its
+// keep-alive connections keep holding those slots long after the page
+// finished. A flow ceiling low enough to be interesting as a quota is
+// therefore low enough to break ordinary browsing, and it breaks it in the
+// least legible way available: most sites load and a few do not. The quota an
+// operator actually wants is a device count, which is what MaxClients is.
+const (
+	DefaultAccountMaxFlows   = 1024
+	DefaultAccountMaxClients = 8
+)
+
+// maxAccountLimit bounds both per-account limits. A hand-edited store cannot
+// name a policy larger than the gateway could ever admit.
+const maxAccountLimit = 1 << 16
+
+// AccountLimits is one account's admission policy.
+type AccountLimits struct {
+	// MaxFlows is how many proxied flows the account may hold at once. Zero
+	// defers to the gateway-wide session ceiling.
+	MaxFlows int
+	// MaxClients is how many of the account's enrolled devices may be
+	// carrying flows at once. A device counts once however many flows it
+	// holds, so this is the limit that expresses "this account is for eight
+	// devices". Zero admits every enrolled device.
+	MaxClients int
+}
+
+func (l AccountLimits) validate() error {
+	if l.MaxFlows < 0 || l.MaxFlows > maxAccountLimit {
+		return fmt.Errorf("account max flows must be between 0 and %d", maxAccountLimit)
+	}
+	if l.MaxClients < 0 || l.MaxClients > maxAccountLimit {
+		return fmt.Errorf("account max clients must be between 0 and %d", maxAccountLimit)
+	}
+	return nil
+}
+
 type Account struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Enabled     bool   `json:"enabled"`
-	ExpiresAt   string `json:"expires_at,omitempty"`
-	MaxSessions int    `json:"max_sessions,omitempty"`
-	CreatedAt   string `json:"created_at"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Enabled    bool   `json:"enabled"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
+	MaxFlows   int    `json:"max_flows,omitempty"`
+	MaxClients int    `json:"max_clients,omitempty"`
+	CreatedAt  string `json:"created_at"`
+}
+
+// Limits is this account's admission policy.
+func (a Account) Limits() AccountLimits {
+	return AccountLimits{MaxFlows: a.MaxFlows, MaxClients: a.MaxClients}
+}
+
+// accountJSON is the on-disk shape of an account. max_sessions is the name
+// MaxFlows was written under before there was a device limit beside it; it is
+// still read so an existing provider state survives this upgrade in place, and
+// it is never written back. Unknown fields stay rejected here exactly as the
+// store's own decoder rejects them: Refresh keeps the last known-good state
+// when a replacement will not decode, so a field this build does not
+// understand must fail loudly rather than be silently dropped on the next
+// save.
+type accountJSON struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Enabled    bool   `json:"enabled"`
+	ExpiresAt  string `json:"expires_at,omitempty"`
+	MaxFlows   int    `json:"max_flows,omitempty"`
+	MaxClients int    `json:"max_clients,omitempty"`
+	// LegacyMaxSessions is read-only compatibility; see the type comment.
+	LegacyMaxSessions int    `json:"max_sessions,omitempty"`
+	CreatedAt         string `json:"created_at"`
+}
+
+func (a *Account) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var raw accountJSON
+	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+	if raw.LegacyMaxSessions != 0 {
+		if raw.MaxFlows != 0 && raw.MaxFlows != raw.LegacyMaxSessions {
+			return errors.New("account carries conflicting max_flows and legacy max_sessions")
+		}
+		raw.MaxFlows = raw.LegacyMaxSessions
+	}
+	*a = Account{
+		ID: raw.ID, Name: raw.Name, Enabled: raw.Enabled, ExpiresAt: raw.ExpiresAt,
+		MaxFlows: raw.MaxFlows, MaxClients: raw.MaxClients, CreatedAt: raw.CreatedAt,
+	}
+	return nil
 }
 
 type Device struct {
@@ -209,13 +297,13 @@ func (s *Store) beginWrite(initialize bool) (func(), error) {
 	return release, nil
 }
 
-func (s *Store) AddAccount(name string, expiresAt time.Time, maxSessions int, now time.Time) (Account, error) {
+func (s *Store) AddAccount(name string, expiresAt time.Time, limits AccountLimits, now time.Time) (Account, error) {
 	name = strings.TrimSpace(name)
 	if name == "" || len(name) > 128 {
 		return Account{}, errors.New("account name must contain 1-128 characters")
 	}
-	if maxSessions < 0 || maxSessions > 1<<16 {
-		return Account{}, errors.New("account max sessions must be between 0 and 65536")
+	if err := limits.validate(); err != nil {
+		return Account{}, err
 	}
 	if now.IsZero() {
 		now = time.Now()
@@ -234,7 +322,11 @@ func (s *Store) AddAccount(name string, expiresAt time.Time, maxSessions int, no
 			return Account{}, fmt.Errorf("account name already exists: %s", name)
 		}
 	}
-	account := Account{ID: id, Name: name, Enabled: true, MaxSessions: maxSessions, CreatedAt: now.UTC().Format(time.RFC3339)}
+	account := Account{
+		ID: id, Name: name, Enabled: true,
+		MaxFlows: limits.MaxFlows, MaxClients: limits.MaxClients,
+		CreatedAt: now.UTC().Format(time.RFC3339),
+	}
 	if !expiresAt.IsZero() {
 		if !expiresAt.After(now) {
 			return Account{}, errors.New("account expiration must be in the future")
@@ -264,6 +356,33 @@ func (s *Store) SetAccountEnabled(accountID string, enabled bool) error {
 	}
 	old := account
 	account.Enabled = enabled
+	s.data.Accounts[accountID] = account
+	if err := s.saveLocked(); err != nil {
+		s.data.Accounts[accountID] = old
+		return err
+	}
+	return nil
+}
+
+// SetAccountLimits replaces one account's admission policy. The gateway adopts
+// it from disk within a second, so an operator who set a limit too low to
+// browse through can correct it without deleting the account and losing every
+// device enrolled against it.
+func (s *Store) SetAccountLimits(accountID string, limits AccountLimits) error {
+	if err := limits.validate(); err != nil {
+		return err
+	}
+	release, err := s.beginWrite(false)
+	if err != nil {
+		return err
+	}
+	defer release()
+	account, ok := s.data.Accounts[accountID]
+	if !ok {
+		return errors.New("unknown account")
+	}
+	old := account
+	account.MaxFlows, account.MaxClients = limits.MaxFlows, limits.MaxClients
 	s.data.Accounts[accountID] = account
 	if err := s.saveLocked(); err != nil {
 		s.data.Accounts[accountID] = old
@@ -609,7 +728,7 @@ func validateStoreData(data storeData) error {
 		}
 		accountNames[folded] = struct{}{}
 		created, err := parseStateTime(account.CreatedAt)
-		if err != nil || account.MaxSessions < 0 || account.MaxSessions > 1<<16 {
+		if err != nil || account.Limits().validate() != nil {
 			return fmt.Errorf("account %s has invalid policy or timestamps", id)
 		}
 		if account.ExpiresAt != "" {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -66,6 +66,14 @@ type Registry struct {
 	// here is the other half of a peer's stalling and failing flows -- the
 	// half the endpoint doing the refusing can see.
 	laneJoinRefusals [LaneJoinReasons]atomic.Uint64
+	// accountAdmissionRefusals counts flow opens this gateway answered with a
+	// reset because of the opening account's own policy, by reason. It exists
+	// because these refusals used to be the one admission decision the
+	// gateway made silently: an account whose limit was set too low to browse
+	// through produced a client reporting resets and a server reporting
+	// nothing at all, at any log level, with no counter to check. The reason
+	// an operator needs is which limit was hit.
+	accountAdmissionRefusals [AccountRefusalReasons]atomic.Uint64
 	// quicObservationsExpired counts per-flow QUIC telemetry entries dropped
 	// because nothing refreshed them within quicObservationTTL. The aggregate
 	// below reports round-trip time as a maximum, so an entry that is never
@@ -130,6 +138,47 @@ func (r LaneJoinRefusal) String() string {
 	return laneJoinRefusalNames[r]
 }
 
+// AccountRefusal is why a flow open was refused by the opening account's
+// admission policy.
+//
+// The set is closed at compile time for the same reason LaneJoinRefusal's is:
+// these are exported label values, and a label whose values come off the wire
+// is a label a peer can make unbounded.
+type AccountRefusal int
+
+const (
+	// AccountRefusalFlowLimit is an account already holding as many
+	// concurrent flows as its policy allows. One flow is one TCP connection
+	// or one UDP association, so this is reached by ordinary browsing on any
+	// account whose flow ceiling was set as though it counted devices.
+	AccountRefusalFlowLimit AccountRefusal = iota
+	// AccountRefusalClientLimit is a device that would be one more
+	// simultaneously active device than the account's policy allows. Unlike
+	// the flow limit it does not move with how hard one device is being used,
+	// so it is the refusal an operator should expect to see when a
+	// subscription is genuinely oversubscribed.
+	AccountRefusalClientLimit
+	// AccountRefusalUnauthorized is an account or device that stopped being
+	// authorized between the TLS handshake and this flow open.
+	AccountRefusalUnauthorized
+	// AccountRefusalReasons is how many reasons there are.
+	AccountRefusalReasons
+)
+
+var accountRefusalNames = [AccountRefusalReasons]string{
+	AccountRefusalFlowLimit:    "flow_limit",
+	AccountRefusalClientLimit:  "client_limit",
+	AccountRefusalUnauthorized: "unauthorized",
+}
+
+// String is the stable label and log value for a refusal reason.
+func (r AccountRefusal) String() string {
+	if r < 0 || r >= AccountRefusalReasons {
+		return "unknown"
+	}
+	return accountRefusalNames[r]
+}
+
 // quicObservationTTL is how long one flow's QUIC telemetry keeps contributing
 // to the process aggregate without being refreshed. A live flow republishes
 // every second, so this is generous by an order of magnitude; its purpose is
@@ -177,6 +226,8 @@ type Snapshot struct {
 	QUICObservationsExpired uint64
 	// LaneJoinRefusals is indexed by LaneJoinRefusal.
 	LaneJoinRefusals [LaneJoinReasons]uint64
+	// AccountAdmissionRefusals is indexed by AccountRefusal.
+	AccountAdmissionRefusals [AccountRefusalReasons]uint64
 }
 
 // QUICObservation is a point-in-time aggregate over the lanes of one logical
@@ -301,6 +352,15 @@ func (r *Registry) LaneJoinRefused(reason LaneJoinRefusal) {
 	r.laneJoinRefusals[reason].Add(1)
 }
 
+// AccountAdmissionRefused records a flow open answered with a reset because of
+// the opening account's admission policy.
+func (r *Registry) AccountAdmissionRefused(reason AccountRefusal) {
+	if r == nil || reason < 0 || reason >= AccountRefusalReasons {
+		return
+	}
+	r.accountAdmissionRefusals[reason].Add(1)
+}
+
 // PeerProtocolViolation records a peer that authenticated as a protocol-1
 // endpoint and then did something protocol 1 forbids.
 func (r *Registry) PeerProtocolViolation() { r.peerProtocolViolations.Add(1) }
@@ -367,6 +427,9 @@ func (r *Registry) Snapshot() Snapshot {
 	}
 	for i := range s.LaneJoinRefusals {
 		s.LaneJoinRefusals[i] = r.laneJoinRefusals[i].Load()
+	}
+	for i := range s.AccountAdmissionRefusals {
+		s.AccountAdmissionRefusals[i] = r.accountAdmissionRefusals[i].Load()
 	}
 	now := r.now()
 	var expired uint64
@@ -575,5 +638,8 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// and an unavailable lane is this endpoint's own ceiling.
 	for i, value := range s.LaneJoinRefusals {
 		fmt.Fprintf(w, "queqiao_lane_join_refused_total{reason=\"%s\"} %d\n", LaneJoinRefusal(i), value)
+	}
+	for i, value := range s.AccountAdmissionRefusals {
+		fmt.Fprintf(w, "queqiao_account_admission_refused_total{reason=\"%s\"} %d\n", AccountRefusal(i), value)
 	}
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -201,6 +201,41 @@ func TestSnapshotKeepsRefreshedQUICObservations(t *testing.T) {
 	}
 }
 
+// Account admission had no counter at all, so a gateway refusing every second
+// flow an account opened was indistinguishable from a healthy one. The reasons
+// are counted apart because they need different fixes: a flow ceiling too low
+// for a browser is a misconfiguration, and a device limit reached is the
+// policy working.
+func TestAccountAdmissionRefusalsAreCountedByReason(t *testing.T) {
+	registry := New()
+	registry.AccountAdmissionRefused(AccountRefusalFlowLimit)
+	registry.AccountAdmissionRefused(AccountRefusalFlowLimit)
+	registry.AccountAdmissionRefused(AccountRefusalClientLimit)
+	registry.AccountAdmissionRefused(AccountRefusalReasons) // out of range: ignored
+	registry.AccountAdmissionRefused(AccountRefusal(-1))
+
+	got := registry.Snapshot()
+	if got.AccountAdmissionRefusals[AccountRefusalFlowLimit] != 2 || got.AccountAdmissionRefusals[AccountRefusalClientLimit] != 1 {
+		t.Fatalf("refusals = %v", got.AccountAdmissionRefusals)
+	}
+	if got.AccountAdmissionRefusals[AccountRefusalUnauthorized] != 0 {
+		t.Fatalf("unauthorized counted %d refusals it never saw", got.AccountAdmissionRefusals[AccountRefusalUnauthorized])
+	}
+
+	recorder := httptest.NewRecorder()
+	registry.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := recorder.Body.String()
+	for _, want := range []string{
+		"queqiao_account_admission_refused_total{reason=\"flow_limit\"} 2",
+		"queqiao_account_admission_refused_total{reason=\"client_limit\"} 1",
+		"queqiao_account_admission_refused_total{reason=\"unauthorized\"} 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics output is missing %q:\n%s", want, body)
+		}
+	}
+}
+
 // The refusal reasons are counted apart because they send an operator to
 // different places: a forgotten session is a peer whose flows are failing, a
 // principal mismatch is a peer reaching for a session that is not its own.

--- a/internal/pep/accountrefusal_test.go
+++ b/internal/pep/accountrefusal_test.go
@@ -1,0 +1,143 @@
+package pep
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/protocol"
+	"github.com/bojieli/queqiao/internal/session"
+)
+
+// An account whose limit was set too low produced a client reporting resets
+// and a gateway reporting nothing: no record at any level, and no counter to
+// check. The refusal had to be diagnosed from the peer, which is the one place
+// that cannot see which limit was hit or whose account hit it.
+//
+// Every refusal must now reach an operator reading at the default level, be
+// counted by reason, and name in the RESET which of the two limits refused.
+func TestAccountRefusalsAreVisibleCountedAndNamed(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		limits  identity.AccountLimits
+		devices int
+		// prime is how many flows to admit before the one that is refused.
+		prime   int
+		refuser int
+		reason  metrics.AccountRefusal
+		code    session.ResetCode
+		message string
+	}{
+		{
+			name: "flow limit", limits: identity.AccountLimits{MaxFlows: 1}, devices: 1,
+			prime: 1, refuser: 0, reason: metrics.AccountRefusalFlowLimit,
+			code: session.ResetFlowLimit, message: "account flow limit reached",
+		},
+		{
+			name: "client limit", limits: identity.AccountLimits{MaxClients: 1}, devices: 2,
+			prime: 1, refuser: 1, reason: metrics.AccountRefusalClientLimit,
+			code: session.ResetFlowLimit, message: "account device limit reached",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, principals := admissionFixture(t, test.limits, test.devices)
+			var records bytes.Buffer
+			registry := metrics.New()
+			server.cfg.Logger = slog.New(slog.NewJSONHandler(&records, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			server.metrics = registry
+
+			for i := 0; i < test.prime; i++ {
+				if refusal := server.admitAccountFlow(principals[0]); refusal != nil {
+					t.Fatalf("priming flow %d refused: %v", i, refusal)
+				}
+			}
+			principal := principals[test.refuser]
+			refusal := server.admitAccountFlow(principal)
+			if refusal == nil {
+				t.Fatal("the flow that should have been refused was admitted")
+			}
+			if refusal.reason != test.reason {
+				t.Fatalf("reason = %s, want %s", refusal.reason, test.reason)
+			}
+
+			local, remote := net.Pipe()
+			t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+			var sessionID [16]byte
+			go server.refuseAccountFlow(newFrameConn(local), sessionID, 1, principal, refusal)
+
+			response, err := newFrameConn(remote).Read()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Header.Type != protocol.TypeReset {
+				t.Fatalf("response = %d, want RESET", response.Header.Type)
+			}
+			if len(response.Payload) == 0 || session.ResetCode(response.Payload[0]) != test.code {
+				t.Fatalf("reset payload = %q, want code %d", response.Payload, test.code)
+			}
+			if got := string(response.Payload[1:]); got != test.message {
+				t.Fatalf("reset message = %q, want %q", got, test.message)
+			}
+			if got := registry.Snapshot().AccountAdmissionRefusals[test.reason]; got != 1 {
+				t.Fatalf("%s counter = %d, want 1", test.reason, got)
+			}
+			var record map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(records.Bytes()), &record); err != nil {
+				t.Fatalf("no record at info level: %v (%q)", err, records.String())
+			}
+			if record["msg"] != "account flow open refused" || record["reason"] != test.reason.String() || record["level"] != "WARN" {
+				t.Fatalf("record = %#v", record)
+			}
+			// The account is the only thing an operator can act on, and one
+			// record has to be readable on its own.
+			if record["account"] != principal.AccountID || record["total"] != float64(1) {
+				t.Fatalf("record = %#v", record)
+			}
+		})
+	}
+}
+
+// A revoked device used to be answered with the flow-limit message, which
+// sends whoever reads it looking for a quota that is not the problem.
+func TestUnauthorizedDeviceIsNotReportedAsALimit(t *testing.T) {
+	server, principals := admissionFixture(t, identity.AccountLimits{}, 1)
+	principal := principals[0]
+	account, ok := server.cfg.Credentials.Store.FindAccount(principal.AccountID)
+	if !ok {
+		t.Fatal("fixture account is missing")
+	}
+	if err := server.cfg.Credentials.Store.SetAccountEnabled(account.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	refusal := server.admitAccountFlow(principal)
+	if refusal == nil {
+		t.Fatal("a disabled account was admitted")
+	}
+	if refusal.reason != metrics.AccountRefusalUnauthorized || refusal.code != session.ResetAuthentication {
+		t.Fatalf("refusal = %+v, want an authentication refusal", refusal)
+	}
+}
+
+// A storm of refusals from one account must not suppress the record of a
+// different reason, and must not suppress lane-join records either.
+func TestAccountAndLaneJoinRefusalsDoNotSuppressEachOther(t *testing.T) {
+	var accountLog, laneLog refusalLog
+	now := time.Now()
+	if write, _, _ := accountLog.due(metrics.AccountRefusalFlowLimit, now); !write {
+		t.Fatal("the first account refusal was not written")
+	}
+	if write, _, _ := accountLog.due(metrics.AccountRefusalFlowLimit, now); write {
+		t.Fatal("a repeated account refusal was written inside the interval")
+	}
+	if write, _, _ := accountLog.due(metrics.AccountRefusalClientLimit, now); !write {
+		t.Fatal("a client-limit refusal was hidden by a flow-limit storm")
+	}
+	if write, _, _ := laneLog.due(metrics.LaneJoinUnknownSession, now); !write {
+		t.Fatal("a lane-join refusal was hidden by an account refusal storm")
+	}
+}

--- a/internal/pep/config_test.go
+++ b/internal/pep/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -234,35 +235,115 @@ func TestCodedDataGetsOneReliableSafetyCopyBeforeOpenConfirmation(t *testing.T) 
 	}
 }
 
-func TestPerUserSessionLimitSpansDevicesAndReleases(t *testing.T) {
+// admissionFixture is an account with limits and the given number of enrolled
+// devices, plus a server holding only the admission state under test.
+func admissionFixture(t *testing.T, limits identity.AccountLimits, devices int) (*Server, []identity.Principal) {
+	t.Helper()
 	store, err := identity.NewStore(filepath.Join(t.TempDir(), "authorization.json"))
 	if err != nil || store.Initialize() != nil {
 		t.Fatal(err)
 	}
 	now := time.Now()
-	account, err := store.AddAccount("alice", time.Time{}, 1, now)
+	account, err := store.AddAccount("alice", time.Time{}, limits, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
-	_, token, _ := store.CreateInvite(account.ID, time.Hour, now)
-	_, device, err := store.ConsumeInvite(token, "laptop", publicKey, now)
-	if err != nil {
-		t.Fatal(err)
+	principals := make([]identity.Principal, 0, devices)
+	for i := 0; i < devices; i++ {
+		publicKey, _, _ := ed25519.GenerateKey(rand.Reader)
+		_, token, _ := store.CreateInvite(account.ID, time.Hour, now)
+		_, device, err := store.ConsumeInvite(token, fmt.Sprintf("device-%d", i), publicKey, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		principals = append(principals, identity.Principal{AccountID: account.ID, DeviceID: device.ID, PublicKey: publicKey})
 	}
-	principal := identity.Principal{AccountID: account.ID, DeviceID: device.ID, PublicKey: publicKey}
-	server := &Server{cfg: ServerConfig{Credentials: identity.ServerCredentials{Store: store}}, accountSessions: make(map[string]int)}
-	if err := server.acquireAccountSession(principal); err != nil {
-		t.Fatal(err)
+	server := &Server{
+		cfg:          ServerConfig{Credentials: identity.ServerCredentials{Store: store}},
+		accountUsage: make(map[string]*accountUsage),
 	}
-	if err := server.acquireAccountSession(principal); err == nil {
-		t.Fatal("per-user session limit was exceeded")
+	return server, principals
+}
+
+func TestPerUserFlowLimitSpansDevicesAndReleases(t *testing.T) {
+	server, principals := admissionFixture(t, identity.AccountLimits{MaxFlows: 1}, 2)
+	laptop, phone := principals[0], principals[1]
+	if refusal := server.admitAccountFlow(laptop); refusal != nil {
+		t.Fatalf("first flow refused: %v", refusal)
 	}
-	server.releaseAccountSession(account.ID)
-	if err := server.acquireAccountSession(principal); err != nil {
-		t.Fatalf("released per-user session slot was not reusable: %v", err)
+	if refusal := server.admitAccountFlow(laptop); refusal != errAccountFlowLimit {
+		t.Fatalf("second flow refusal = %v, want the flow limit", refusal)
 	}
-	server.releaseAccountSession(account.ID)
+	// The limit is the account's, not the device's: a second device does not
+	// get its own allowance.
+	if refusal := server.admitAccountFlow(phone); refusal != errAccountFlowLimit {
+		t.Fatalf("another device's flow refusal = %v, want the flow limit", refusal)
+	}
+	server.releaseAccountFlow(laptop)
+	if refusal := server.admitAccountFlow(phone); refusal != nil {
+		t.Fatalf("released flow slot was not reusable: %v", refusal)
+	}
+	server.releaseAccountFlow(phone)
+	if len(server.accountUsage) != 0 {
+		t.Fatalf("account usage retained after every flow was released: %#v", server.accountUsage)
+	}
+}
+
+// The limit an operator reaches for when they mean "this account is for N
+// devices" must count devices. A device that opens a page's worth of
+// connections is still one device, and this is the property that makes the
+// client limit usable where a flow limit is not.
+func TestPerUserClientLimitCountsDevicesNotFlows(t *testing.T) {
+	server, principals := admissionFixture(t, identity.AccountLimits{MaxClients: 1}, 2)
+	laptop, phone := principals[0], principals[1]
+	for i := 0; i < 200; i++ {
+		if refusal := server.admitAccountFlow(laptop); refusal != nil {
+			t.Fatalf("flow %d from the only admitted device refused: %v", i, refusal)
+		}
+	}
+	if refusal := server.admitAccountFlow(phone); refusal != errAccountClientLimit {
+		t.Fatalf("second device refusal = %v, want the client limit", refusal)
+	}
+	// The slot frees only when the device stops holding flows entirely.
+	for i := 0; i < 199; i++ {
+		server.releaseAccountFlow(laptop)
+	}
+	if refusal := server.admitAccountFlow(phone); refusal != errAccountClientLimit {
+		t.Fatalf("second device admitted while the first still held a flow: %v", refusal)
+	}
+	server.releaseAccountFlow(laptop)
+	if refusal := server.admitAccountFlow(phone); refusal != nil {
+		t.Fatalf("device slot was not reusable once released: %v", refusal)
+	}
+}
+
+// A refused open must leave nothing behind. Otherwise an account that is
+// refused repeatedly accumulates state for flows it never got.
+func TestRefusedFlowLeavesNoAccountState(t *testing.T) {
+	server, principals := admissionFixture(t, identity.AccountLimits{MaxClients: 1}, 2)
+	if refusal := server.admitAccountFlow(principals[0]); refusal != nil {
+		t.Fatalf("first flow refused: %v", refusal)
+	}
+	server.releaseAccountFlow(principals[0])
+	if refusal := server.admitAccountFlow(principals[1]); refusal != nil {
+		t.Fatalf("device slot was not free after release: %v", refusal)
+	}
+	server.releaseAccountFlow(principals[1])
+	if len(server.accountUsage) != 0 {
+		t.Fatalf("account usage retained: %#v", server.accountUsage)
+	}
+}
+
+// Zero means "no per-account limit", not "no flows".
+func TestZeroAccountLimitsAdmitEverything(t *testing.T) {
+	server, principals := admissionFixture(t, identity.AccountLimits{}, 3)
+	for i := 0; i < 50; i++ {
+		for _, principal := range principals {
+			if refusal := server.admitAccountFlow(principal); refusal != nil {
+				t.Fatalf("unlimited account refused a flow: %v", refusal)
+			}
+		}
+	}
 }
 
 func TestTUICAlignedCongestionConfigurationIsAccepted(t *testing.T) {

--- a/internal/pep/integration_test.go
+++ b/internal/pep/integration_test.go
@@ -31,7 +31,7 @@ func testCertificate(t *testing.T) (identity.ServerCredentials, identity.ClientC
 	if err != nil {
 		t.Fatal(err)
 	}
-	account, err := provider.Store.AddAccount("test account", time.Time{}, 0, now)
+	account, err := provider.Store.AddAccount("test account", time.Time{}, identity.AccountLimits{}, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pep/lanejoinrefusal_test.go
+++ b/internal/pep/lanejoinrefusal_test.go
@@ -102,12 +102,12 @@ func TestLaneJoinRefusalLogSurvivesAStorm(t *testing.T) {
 	if write, _, _ := log.due(metrics.LaneJoinPrincipalMismatch, start.Add(time.Second)); !write {
 		t.Fatal("a principal mismatch was hidden by an unknown-session storm")
 	}
-	write, suppressed, total = log.due(metrics.LaneJoinUnknownSession, start.Add(laneJoinRefusalLogInterval))
+	write, suppressed, total = log.due(metrics.LaneJoinUnknownSession, start.Add(refusalLogInterval))
 	if !write || suppressed != storm || total != storm+2 {
 		t.Fatalf("after the interval write=%t suppressed=%d total=%d, want true, %d and %d",
 			write, suppressed, total, storm, storm+2)
 	}
-	if write, suppressed, _ = log.due(metrics.LaneJoinUnknownSession, start.Add(2*laneJoinRefusalLogInterval)); !write || suppressed != 0 {
+	if write, suppressed, _ = log.due(metrics.LaneJoinUnknownSession, start.Add(2*refusalLogInterval)); !write || suppressed != 0 {
 		t.Fatalf("suppressed count survived being reported: write=%t suppressed=%d", write, suppressed)
 	}
 }
@@ -128,7 +128,7 @@ func TestARefusalRecordSaysHowManyThereHaveBeen(t *testing.T) {
 	// Nothing more arrives, so no further record is written and the suppressed
 	// count is never reported. The record that was written must already carry
 	// the count, which the next one confirms.
-	_, _, total := log.due(metrics.LaneJoinUnknownSession, start.Add(laneJoinRefusalLogInterval))
+	_, _, total := log.due(metrics.LaneJoinUnknownSession, start.Add(refusalLogInterval))
 	if total != 95 {
 		t.Fatalf("total = %d, want every refusal counted", total)
 	}

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -77,10 +77,15 @@ type Server struct {
 	sessionsMu       sync.RWMutex
 	sessions         map[[16]byte]*serverFlow
 	accountMu        sync.Mutex
-	accountSessions  map[string]int
+	accountUsage     map[string]*accountUsage
 	maxObservedLanes atomic.Int64
-	// refusals keeps the lane-join refusal record readable during a storm.
-	refusals refusalLog
+	// refusals keeps the lane-join refusal record readable during a storm,
+	// and accountRefusals does the same for account admission. They are
+	// separate logs so a lane-join storm cannot suppress the record of an
+	// account hitting its limit, which is the record an operator is looking
+	// for when a user reports that some sites load and others do not.
+	refusals        refusalLog
+	accountRefusals refusalLog
 	// enrollLog does the same for enrollment and renewal attempts, which are
 	// likewise a stranger's to generate.
 	enrollLog enrollmentLog
@@ -257,15 +262,15 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	budget := limiter.New(limiter.Config{TotalBytesPerSec: cfg.AggregateBytesPerSec, ReserveBytesPerSec: cfg.InteractiveReserveBytesPerSec})
 	cfg.ChunkSize = chunkSizeForBudget(cfg.ChunkSize, budget)
 	server := &Server{
-		cfg:             cfg,
-		semaphore:       make(chan struct{}, cfg.MaxSessions),
-		connections:     make(chan struct{}, cfg.MaxSessions),
-		enrollments:     make(chan struct{}, min(cfg.MaxSessions, 64)),
-		sessions:        make(map[[16]byte]*serverFlow),
-		accountSessions: make(map[string]int),
-		budget:          budget,
-		metrics:         cfg.Metrics,
-		udpRelays:       newUDPRelayStore(),
+		cfg:          cfg,
+		semaphore:    make(chan struct{}, cfg.MaxSessions),
+		connections:  make(chan struct{}, cfg.MaxSessions),
+		enrollments:  make(chan struct{}, min(cfg.MaxSessions, 64)),
+		sessions:     make(map[[16]byte]*serverFlow),
+		accountUsage: make(map[string]*accountUsage),
+		budget:       budget,
+		metrics:      cfg.Metrics,
+		udpRelays:    newUDPRelayStore(),
 	}
 	return server, nil
 }
@@ -635,11 +640,11 @@ func (s *Server) handleSession(ctx context.Context, conn streamConn, principal i
 		_ = fc.Write(protocol.Frame{Header: protocol.Header{Version: protocol.Version, Type: protocol.TypeReset, SessionID: sessionID, FlowID: open.Header.FlowID, Class: protocol.ClassNew}, Payload: session.ResetPayload(session.ResetProtocol, "invalid flow open")})
 		return
 	}
-	if err := s.acquireAccountSession(principal); err != nil {
-		_ = fc.Write(protocol.Frame{Header: protocol.Header{Version: protocol.Version, Type: protocol.TypeReset, SessionID: sessionID, FlowID: open.Header.FlowID, Class: protocol.ClassNew}, Payload: session.ResetPayload(session.ResetFlowLimit, "account session unavailable")})
+	if refusal := s.admitAccountFlow(principal); refusal != nil {
+		s.refuseAccountFlow(fc, sessionID, open.Header.FlowID, principal, refusal)
 		return
 	}
-	defer s.releaseAccountSession(principal.AccountID)
+	defer s.releaseAccountFlow(principal)
 	if session.IsUDPAssociation(open.Payload) {
 		s.handleUDPAssociation(ctx, conn, fc, principal, sessionID, open.Header.FlowID, nil, false)
 		return
@@ -817,10 +822,10 @@ func (s *Server) retainCompletedSession(sessionID [16]byte, serverSession *serve
 	})
 }
 
-// laneJoinRefusalLogInterval is how often one refusal reason is written to the
-// log while a storm is running. The first refusal of a reason is always
-// written; the ones a storm suppresses are counted and reported with the next.
-const laneJoinRefusalLogInterval = 10 * time.Second
+// refusalLogInterval is how often one refusal reason is written to the log
+// while a storm is running. The first refusal of a reason is always written;
+// the ones a storm suppresses are counted and reported with the next.
+const refusalLogInterval = 10 * time.Second
 
 // refusalLog rate-limits the refusal record without keeping per-session state.
 //
@@ -829,11 +834,14 @@ const laneJoinRefusalLogInterval = 10 * time.Second
 // a peer decides, and a storm of refusals is exactly when a peer is producing
 // identifiers this endpoint has never seen. Per reason is bounded by the
 // reasons, and the suppressed count keeps the storm's size in the record.
+// The reason is carried as its own label rather than as an enum value so one
+// implementation serves both refusal paths. Both enums are closed at compile
+// time, so the keys stay bounded by the reasons that exist.
 type refusalLog struct {
 	mu         sync.Mutex
-	last       [metrics.LaneJoinReasons]time.Time
-	suppressed [metrics.LaneJoinReasons]uint64
-	total      [metrics.LaneJoinReasons]uint64
+	last       map[string]time.Time
+	suppressed map[string]uint64
+	total      map[string]uint64
 }
 
 // due reports whether this reason should be written now, how many of its
@@ -846,20 +854,23 @@ type refusalLog struct {
 // record saying it stood for none of them, which is the same silence this
 // logging exists to end. Every record now carries the count for its reason, so
 // one record is the whole story.
-func (l *refusalLog) due(reason metrics.LaneJoinRefusal, now time.Time) (write bool, suppressed, total uint64) {
-	if reason < 0 || reason >= metrics.LaneJoinReasons {
-		return false, 0, 0
-	}
+func (l *refusalLog) due(reason fmt.Stringer, now time.Time) (write bool, suppressed, total uint64) {
+	label := reason.String()
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.total[reason]++
-	total = l.total[reason]
-	if last := l.last[reason]; !last.IsZero() && now.Sub(last) < laneJoinRefusalLogInterval {
-		l.suppressed[reason]++
+	if l.total == nil {
+		l.last = make(map[string]time.Time)
+		l.suppressed = make(map[string]uint64)
+		l.total = make(map[string]uint64)
+	}
+	l.total[label]++
+	total = l.total[label]
+	if last := l.last[label]; !last.IsZero() && now.Sub(last) < refusalLogInterval {
+		l.suppressed[label]++
 		return false, 0, total
 	}
-	suppressed = l.suppressed[reason]
-	l.last[reason], l.suppressed[reason] = now, 0
+	suppressed = l.suppressed[label]
+	l.last[label], l.suppressed[label] = now, 0
 	return true, suppressed, total
 }
 
@@ -1013,29 +1024,123 @@ func samePrincipal(a, b identity.Principal) bool {
 	return a.ProviderID == b.ProviderID && a.AccountID == b.AccountID && a.DeviceID == b.DeviceID
 }
 
-func (s *Server) acquireAccountSession(principal identity.Principal) error {
+// accountUsage is one account's live admission state: how many flows it holds
+// and which of its devices are holding them. The device counts are what make
+// a client limit a limit on devices rather than on flows -- a device that
+// holds two hundred flows is still one client.
+type accountUsage struct {
+	flows   int
+	devices map[string]int
+}
+
+// accountRefusal is a flow open refused by the opening account's own policy
+// rather than by the gateway's capacity. It carries the reason for the counter
+// and the log, and the code and message for the RESET.
+//
+// The message names the limit that was hit. That matters more than it looks:
+// the peer is where this refusal is first seen, frequently by someone who
+// cannot read the gateway's logs, and a message that does not distinguish
+// "this account is out of flows" from "this account is out of device slots"
+// sends them looking in the wrong place.
+type accountRefusal struct {
+	reason  metrics.AccountRefusal
+	code    session.ResetCode
+	message string
+}
+
+func (r *accountRefusal) Error() string { return r.message }
+
+var (
+	errAccountFlowLimit = &accountRefusal{
+		reason: metrics.AccountRefusalFlowLimit, code: session.ResetFlowLimit,
+		message: "account flow limit reached",
+	}
+	errAccountClientLimit = &accountRefusal{
+		reason: metrics.AccountRefusalClientLimit, code: session.ResetFlowLimit,
+		message: "account device limit reached",
+	}
+	errAccountUnauthorized = &accountRefusal{
+		reason: metrics.AccountRefusalUnauthorized, code: session.ResetAuthentication,
+		message: "device is not authorized",
+	}
+)
+
+// admitAccountFlow reserves one flow against the opening account's policy, and
+// counts the opening device against the account's client limit. A device
+// already holding a flow is already counted, so an existing client is never
+// refused by the client limit however many flows it opens.
+func (s *Server) admitAccountFlow(principal identity.Principal) *accountRefusal {
 	authorization, err := s.cfg.Credentials.Store.Authorize(principal, time.Now())
 	if err != nil {
-		return err
+		return errAccountUnauthorized
 	}
+	limits := authorization.Account.Limits()
 	s.accountMu.Lock()
 	defer s.accountMu.Unlock()
-	active := s.accountSessions[principal.AccountID]
-	if authorization.Account.MaxSessions > 0 && active >= authorization.Account.MaxSessions {
-		return errors.New("account session limit reached")
+	usage := s.accountUsage[principal.AccountID]
+	flows, clients, known := 0, 0, false
+	if usage != nil {
+		flows, clients = usage.flows, len(usage.devices)
+		_, known = usage.devices[principal.DeviceID]
 	}
-	s.accountSessions[principal.AccountID] = active + 1
+	if limits.MaxFlows > 0 && flows >= limits.MaxFlows {
+		return errAccountFlowLimit
+	}
+	if limits.MaxClients > 0 && !known && clients >= limits.MaxClients {
+		return errAccountClientLimit
+	}
+	// Nothing is recorded until the open is admitted, so a refused open
+	// leaves no entry behind for an account that holds no flows.
+	if usage == nil {
+		usage = &accountUsage{devices: make(map[string]int)}
+		s.accountUsage[principal.AccountID] = usage
+	}
+	usage.flows++
+	usage.devices[principal.DeviceID]++
 	return nil
 }
 
-func (s *Server) releaseAccountSession(accountID string) {
+func (s *Server) releaseAccountFlow(principal identity.Principal) {
 	s.accountMu.Lock()
 	defer s.accountMu.Unlock()
-	if active := s.accountSessions[accountID]; active <= 1 {
-		delete(s.accountSessions, accountID)
-	} else {
-		s.accountSessions[accountID] = active - 1
+	usage := s.accountUsage[principal.AccountID]
+	if usage == nil {
+		return
 	}
+	if usage.flows <= 1 {
+		delete(s.accountUsage, principal.AccountID)
+		return
+	}
+	usage.flows--
+	if usage.devices[principal.DeviceID] <= 1 {
+		delete(usage.devices, principal.DeviceID)
+		return
+	}
+	usage.devices[principal.DeviceID]--
+}
+
+// refuseAccountFlow answers a flow open with a reset, and says so where an
+// operator will see it.
+//
+// This path used to be silent at every log level and carried no counter, so a
+// gateway refusing every second open an account made looked completely
+// healthy. The account whose limit was hit is named because that is the only
+// thing an operator can act on, and it is not a secret from the operator who
+// set the limit.
+func (s *Server) refuseAccountFlow(fc *frameConn, sessionID [16]byte, flowID uint64, principal identity.Principal, refusal *accountRefusal) {
+	s.metrics.AccountAdmissionRefused(refusal.reason)
+	if write, suppressed, total := s.accountRefusals.due(refusal.reason, time.Now()); write {
+		s.cfg.Logger.LogAttrs(context.Background(), slog.LevelWarn, "account flow open refused",
+			slog.String("reason", refusal.reason.String()),
+			slog.String("account", principal.AccountID),
+			slog.String("device", principal.DeviceID),
+			slog.Uint64("suppressed", suppressed),
+			slog.Uint64("total", total))
+	}
+	_ = fc.Write(protocol.Frame{Header: protocol.Header{
+		Version: protocol.Version, Type: protocol.TypeReset, SessionID: sessionID,
+		FlowID: flowID, Class: protocol.ClassNew,
+	}, Payload: session.ResetPayload(refusal.code, refusal.message)})
 }
 
 // watchAuthorization applies revocation and account expiry to already-open

--- a/mobile/core/export_test.go
+++ b/mobile/core/export_test.go
@@ -137,7 +137,7 @@ func startTestGateway(t *testing.T) *testGateway {
 	if err != nil {
 		t.Fatal(err)
 	}
-	account, err := provider.Store.AddAccount("test account", time.Time{}, 0, now)
+	account, err := provider.Store.AddAccount("test account", time.Time{}, identity.AccountLimits{}, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testdata/protocol1/vectors.json
+++ b/testdata/protocol1/vectors.json
@@ -648,8 +648,14 @@
     {
       "name": "flow limit",
       "code": 4,
-      "message": "account session unavailable",
-      "hex": "046163636f756e742073657373696f6e20756e617661696c61626c65"
+      "message": "account flow limit reached",
+      "hex": "046163636f756e7420666c6f77206c696d69742072656163686564"
+    },
+    {
+      "name": "client limit",
+      "code": 4,
+      "message": "account device limit reached",
+      "hex": "046163636f756e7420646576696365206c696d69742072656163686564"
     },
     {
       "name": "transport",


### PR DESCRIPTION
## What went wrong

An account created with `provider add-user --max-sessions 16` could load most
websites and not others. The flag counts **concurrent flows** — one TCP
connection or one UDP association each — not devices, not sessions in any sense
an operator means by the word. A browser opens roughly six connections per host
across dozens of hosts to load one page, and the default 30-minute
`--flow-idle-timeout` keeps those slots held long after the page finished, so a
value chosen as though it counted devices runs out during ordinary browsing.

`docs/DEPLOYING.md` used `--max-sessions 8` as its worked example. That value
cannot load a web page.

The failure was also invisible from the gateway. Account admission was the one
admission decision made silently: no log record at any level, no counter, and a
RESET message — `account session unavailable` — naming neither the limit nor
the fact that a limit was involved. The only place it could be diagnosed was
the peer, which is the one place that cannot see which limit was hit or who set
it. On a live gateway, `journalctl` showed zero matching records while the
account was hitting the limit repeatedly.

## What this changes

**A device limit, which is what the flag was assumed to be.** `--max-clients`
counts devices carrying flows, once each however much they carry, defaulting to
8. A device that opens two hundred connections is still one client, so this
limit does not move with how hard a device is being used.

**The flow limit under an honest name.** `--max-flows`, defaulting to 1024
rather than deferring to the gateway ceiling. `--max-sessions` still works and
warns; existing accounts keep the value they were given.

**Refusals that can be diagnosed from the gateway.** Each refusal names which
limit refused it (`account flow limit reached` / `account device limit
reached`), increments `queqiao_account_admission_refused_total{reason=...}`, and
writes `msg="account flow open refused"` at `warn` with the account and device.
Rate limited per reason with `suppressed`/`total` in each record, matching the
existing lane-join refusal log; the two logs are separate so neither storm can
hide the other.

**`provider set-user-limits`.** There was previously no way to change an
account's limits at all — the only recourse for a limit set too low was
deleting the account, which deletes every device enrolled against it. A limit
not named on the command line keeps its current value. The gateway re-reads
authorization state every second, so a correction applies without a restart.

**The gateway installer moves to the new flags.** `deploy/install-server.sh`
(added in #32, merged while this was in review) creates its first account
through `provider add-user --max-sessions`. Left alone it would warn on every
install and hand that account no device limit, so it gets `--user-max-clients`
and `--user-max-flows`; its own `--user-max-sessions` is still accepted and
warns. This has to ride along with the rename rather than go in its own PR —
the flags it now calls do not exist until this lands.

**One incidental correctness fix.** A device that lost authorization between its
TLS handshake and its next flow open was answered with the flow-limit message.
It now gets the `AUTHENTICATION` reset code and `device is not authorized`.

## Second commit: an unrelated break on main

`main` is currently failing the Staticcheck job — `attemptEnrollment` in
`internal/identity/enrollment_outcome_test.go` (from #34) returns its error in
the middle of the tuple, which trips ST1008. Verified against a clean checkout
of `main`, so it is not from this branch, but it turns CI red here too. Fixed
as a separate commit, easy to drop if you would rather it went in on its own.

## Compatibility

- Provider state writes `max_flows` and still reads `max_sessions`, so an
  existing deployment upgrades in place; the first save rewrites the field. A
  state naming both is refused rather than having one silently win. Note this
  is one-way: state saved by this build will not load on an older binary,
  because the store rejects unknown fields.
- No wire change. `FLOW_LIMIT` still covers both limits; only the diagnostic
  text differs, and `testdata/protocol1/vectors.json` is regenerated to match.
- The client never branched on reset codes, so the changed code on the
  unauthorized path affects no client behaviour.

## Judgement calls worth a look

- **"Concurrent clients" is read as devices currently carrying flows**, not
  enrolled devices and not transport connections. It is transport-neutral (TCP
  gets no persistent connection to count) and matches what an operator means by
  "this account is for eight devices". A device's slot frees when it stops
  holding flows entirely.
- **1024 / 8 as defaults.** New accounts are now *more* bounded than before on
  devices and effectively unbounded on flows for any realistic browser. Existing
  accounts are untouched.
- **`refusalLog` was generalized** from a `LaneJoinRefusal`-indexed array to a
  label-keyed map taking a `fmt.Stringer`, so one implementation serves both
  refusal paths. Zero value stays usable; both enums remain closed at compile
  time, so keys stay bounded. Worth noting for later: #34's new `enrollmentLog`
  is now the same algorithm again with a `string` key, so the three rate
  limiters could collapse into one. Left alone here to keep this diff off
  freshly merged code.

## Verification

`go build`, `go vet`, `gofmt -l`, `staticcheck -checks=all,-U1000`, `shellcheck`
on the installers, the full suite, and `go test -race` on the changed packages
all pass, rebased on `main` at 95fad3a.

New tests cover: the client limit counting devices rather than flows (200 flows
from one device admitted, a second device refused); the flow limit spanning
devices and releasing; refused opens leaving no state behind; zero meaning
unlimited; each refusal's reason, RESET code, message, counter, and log record;
legacy `max_sessions` read and migrated on save; conflicting spellings refused;
`set-user-limits` changing only what is named and being adopted by a reader;
and the CLI defaults being high enough to browse through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ko2HaWwHbWR3XybTk5YPk
