### PR TITLE
fix: return the error last from the enrollment test helper

### DIFF
--- a/internal/identity/enrollment_outcome_test.go
+++ b/internal/identity/enrollment_outcome_test.go
@@ -14,7 +14,7 @@ import (
 
 // attemptEnrollment runs one enrollment over an in-memory pipe and returns
 // what the gateway recorded alongside what the client was told.
-func attemptEnrollment(t *testing.T, provider *Provider, token string) (EnrollmentResult, error, enrollmentResponse) {
+func attemptEnrollment(t *testing.T, provider *Provider, token string) (EnrollmentResult, enrollmentResponse, error) {
 	t.Helper()
 	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -47,7 +47,7 @@ func attemptEnrollment(t *testing.T, provider *Provider, token string) (Enrollme
 		}
 	}
 	outcome := <-done
-	return outcome.result, outcome.err, response
+	return outcome.result, response, outcome.err
 }
 
 func mintInvitation(t *testing.T, provider *Provider) string {
@@ -74,7 +74,7 @@ func TestEnrollmentSeparatesStoreOutageFromRejection(t *testing.T) {
 	if err := os.Remove(filepath.Join(provider.Directory, authorizationFile)); err != nil {
 		t.Fatal(err)
 	}
-	result, err, response := attemptEnrollment(t, provider, token)
+	result, response, err := attemptEnrollment(t, provider, token)
 	if result.Outcome != EnrollmentUnavailable {
 		t.Fatalf("outcome is %q; want %q", result.Outcome, EnrollmentUnavailable)
 	}
@@ -99,7 +99,7 @@ func TestEnrollmentRejectionIsNotBlamedOnTheStore(t *testing.T) {
 	if _, err := rand.Read(bogus[:]); err != nil {
 		t.Fatal(err)
 	}
-	result, err, response := attemptEnrollment(t, provider, base64.RawURLEncoding.EncodeToString(bogus[:]))
+	result, response, err := attemptEnrollment(t, provider, base64.RawURLEncoding.EncodeToString(bogus[:]))
 	if result.Outcome != EnrollmentRejected {
 		t.Fatalf("outcome is %q; want %q", result.Outcome, EnrollmentRejected)
 	}
@@ -127,7 +127,7 @@ func TestEnrollmentMalformedTokenIsNotAnInvitationVerdict(t *testing.T) {
 func TestEnrollmentAcceptanceCarriesIdentifiers(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
 	token := mintInvitation(t, provider)
-	result, err, response := attemptEnrollment(t, provider, token)
+	result, response, err := attemptEnrollment(t, provider, token)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`main` is red. The `analysis` job fails on `95fad3a`:

```
internal/identity/enrollment_outcome_test.go:17:91: error should be returned as the last argument (ST1008)
```

The test helper added in #34 returned `(EnrollmentResult, error, enrollmentResponse)`. Staticcheck runs with `-checks=all`, and ST1008 requires `error` last. I caught this and pushed the fix to the branch, but #34 merged the commit before it, so the fix never landed.

This is that fix alone, on top of `main`: the helper now returns `(EnrollmentResult, enrollmentResponse, error)`, with its four call sites reordered. Test-only, no production code.

Verified on this branch:

- `staticcheck -checks=all,-U1000 ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — 27 packages ok

Unrelated, so it does not belong in this PR but is worth recording: the `test (macos-15, darwin, arm64)` failure on #34 was `TestLostFinalFINUsesOneTombstoneRescueWithoutStorm`, in the final-FIN tombstone-rescue path that #34 does not touch. It passed on the other six platforms there and passed on `main` in the very run whose `analysis` job failed above, so it looks like a flake in that test rather than a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juuoq98WrCgQJ5XXF6jQS9