### PR TITLE
fix: restore the analysis job on main

### DIFF
--- a/internal/identity/store_staleness_test.go
+++ b/internal/identity/store_staleness_test.go
@@ -37,7 +37,7 @@ func TestLastGoodAtAdvancesOnAnUnchangedRefresh(t *testing.T) {
 func TestLastGoodAtHoldsWhileRefreshFails(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
 	store := provider.Store
-	account, err := store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, err := store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -334,7 +334,7 @@ func (s *Server) watchAuthorizationStore(ctx context.Context) {
 				if !write {
 					continue
 				}
-				s.cfg.Logger.LogAttrs(context.Background(), slog.LevelError,
+				s.cfg.Logger.LogAttrs(ctx, slog.LevelError,
 					"authorization refresh failed; retaining last known-good state",
 					slog.String("error", err.Error()),
 					slog.Uint64("consecutive", consecutive),
@@ -344,7 +344,7 @@ func (s *Server) watchAuthorizationStore(ctx context.Context) {
 				continue
 			}
 			if recovered, attempts, unreadableFor := watch.succeeded(now); recovered {
-				s.cfg.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+				s.cfg.Logger.LogAttrs(ctx, slog.LevelWarn,
 					"authorization refresh recovered",
 					slog.Uint64("failed_attempts", attempts),
 					slog.Int64("unreadable_for_seconds", int64(unreadableFor/time.Second)))


### PR DESCRIPTION
`main` is red and its test binary does not compile. Two independent breakages, neither of which is wrong in the change that introduced it — both are merge ordering.

## 1. `internal/identity` no longer compiles

```
internal/identity/store_staleness_test.go:40:57: cannot use 0 (untyped int constant)
    as AccountLimits value in argument to store.AddAccount (compile)
```

#35 changed `AddAccount` to take `AccountLimits` and updated every call site that existed at the time — including the one #34 had added. #36 merged afterwards and brought one more. Neither PR could have seen the other's call site.

This is what staticcheck actually reported on `main`; it never got as far as running its own checks.

## 2. gosec G118

```
G118 internal/pep/server.go: found 1, reviewed maximum 0
    Goroutine uses context.Background/TODO while request-scoped context is available
```

`watchAuthorizationStore` takes a `ctx` and then logged with `context.Background()`, which is precisely what the rule looks for. The loop already has the right context, so it now uses it — which is also the better record, since these lines describe the serve context they are reporting on. My local run of #36 covered staticcheck but not the gosec baseline step in the same job, which is how this reached `main`.

## Verification

Against this branch:

- `staticcheck -checks=all,-U1000 ./...` — clean
- `gosec` + `scripts/check_gosec.py` — `baseline accepted 134 reviewed findings in 46 buckets`
- `go test ./...` — 27 packages ok, 0 failed

Both changes are two lines each and touch no behaviour: one test argument, and a context that was already in scope.

#37 is now redundant — the ST1008 fix it carried reached `main` independently as 9bf1967 — and I am closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juuoq98WrCgQJ5XXF6jQS9