### PR TITLE
fix: build the staleness test against the account limits it merged into

### DIFF
--- a/internal/identity/store_staleness_test.go
+++ b/internal/identity/store_staleness_test.go
@@ -37,7 +37,7 @@ func TestLastGoodAtAdvancesOnAnUnchangedRefresh(t *testing.T) {
 func TestLastGoodAtHoldsWhileRefreshFails(t *testing.T) {
 	provider := testProvider(t, "127.0.0.1:443", time.Now())
 	store := provider.Store
-	account, err := store.AddAccount("alice", time.Time{}, 0, time.Now())
+	account, err := store.AddAccount("alice", time.Time{}, AccountLimits{}, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## main is red

`go vet ./...` fails on `main` as of 745d31f:

```
internal/identity/store_staleness_test.go:40:57: cannot use 0 (untyped int constant)
  as AccountLimits value in argument to store.AddAccount
```

#36 was written when `AddAccount` took a session ceiling as an `int`. #35 replaced that parameter with `AccountLimits` and merged first. Neither branch touched the other's lines, so git merged them cleanly and the result does not compile — a semantic conflict, which is the kind git cannot see.

## The fix

`AccountLimits{}` carries exactly what the `0` meant: `MaxFlows: 0` defers to the gateway-wide session ceiling. It is what every other `AddAccount` call in the package passes.

Test-only, so no `changelog.d/` entry.

## Checks

```
go vet ./...                              # clean
gofmt -l internal/identity/               # empty
go test -short ./internal/identity/       # ok, 11.0s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2