### PR TITLE
fix: read the changelog label when the job runs, not when the PR opened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
   # them describe a user-visible change.
   changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -71,19 +74,29 @@ jobs:
       - name: pending entries are well formed
         run: ./scripts/changelog.py check
       - name: CHANGELOG.md is assembled, not edited
-        if: >-
-          github.event_name == 'pull_request' &&
-          !contains(github.event.pull_request.labels.*.name, 'changelog')
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: ${{ github.base_ref }}
+          NUMBER: ${{ github.event.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet "origin/${BASE_REF}...HEAD" -- CHANGELOG.md; then
+            exit 0
+          fi
+          # Read the label from the API rather than from the event payload,
+          # which is a snapshot taken when the pull request was opened. Adding
+          # the label to an open pull request and re-running this job has to be
+          # enough; with the payload it never is.
+          if gh api "repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/labels" \
+              --jq '.[].name' | grep -qx changelog; then
+            echo "The 'changelog' label permits this pull request to edit it."
             exit 0
           fi
           echo "CHANGELOG.md is assembled from changelog.d/ at release time."
           echo "Describe this change in its own file instead:"
           echo "  ./scripts/changelog.py new <category> <slug>"
-          echo "A pull request that means to edit it carries the 'changelog' label."
+          echo "A pull request that means to edit it carries the 'changelog'"
+          echo "label; add it and re-run this job."
           exit 1
 
   analysis:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ same file, so there is nothing to resolve when both merge. A change with no
 user-visible effect — a refactor, a test, internal documentation — needs no
 file. CI checks the pending files and rejects a branch that edits
 `CHANGELOG.md`. Cutting a release, or deliberately correcting text that already
-shipped, is what the `changelog` label on a pull request is for.
+shipped, is what the `changelog` label on a pull request is for; add the label
+and re-run the `changelog` job, which reads it at the moment it runs.
 
 This applies to generated and agent-authored branches too. Nothing in this
 repository writes `CHANGELOG.md` except `./scripts/changelog.py release`, and a


### PR DESCRIPTION
## The escape hatch failed the first time it was needed

#38 edited `CHANGELOG.md` legitimately — it added the header note saying not to edit it — and carried the `changelog` label before the `changelog` job started. The job failed anyway:

```
CHANGELOG.md is assembled from changelog.d/ at release time.
A pull request that means to edit it carries the 'changelog' label.
Error: Process completed with exit code 1
```

`github.event.pull_request.labels` is a snapshot of the payload from when the PR was **opened**. A label added afterwards is invisible to every run of that workflow, and `pull_request` does not fire on `labeled` here — so no re-run would ever pick it up. There was nothing a contributor could do to clear the check.

## The fix

Ask the API for the labels at the moment the step runs. Labeling an open PR and re-running the job is now enough, which is what the failure message tells you to do. That needs `pull-requests: read`, granted to this one job rather than the workflow.

Adding `labeled` to the workflow's event types would also work, but re-runs the whole CI matrix on every label change on every PR.

## Checks

```
actionlint .github/workflows/ci.yml   # no findings beyond the pre-existing runner labels
```

Best verified by merging and watching the next PR that legitimately edits `CHANGELOG.md` — a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2