### PR TITLE
One rate limiter behind all three storm-suppressed records

### DIFF
--- a/internal/pep/accountrefusal_test.go
+++ b/internal/pep/accountrefusal_test.go
@@ -126,7 +126,7 @@ func TestUnauthorizedDeviceIsNotReportedAsALimit(t *testing.T) {
 // A storm of refusals from one account must not suppress the record of a
 // different reason, and must not suppress lane-join records either.
 func TestAccountAndLaneJoinRefusalsDoNotSuppressEachOther(t *testing.T) {
-	var accountLog, laneLog refusalLog
+	var accountLog, laneLog recordLimiter
 	now := time.Now()
 	if write, _, _ := accountLog.due(metrics.AccountRefusalFlowLimit, now); !write {
 		t.Fatal("the first account refusal was not written")

--- a/internal/pep/enrollmentlog.go
+++ b/internal/pep/enrollmentlog.go
@@ -3,65 +3,31 @@ package pep
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/bojieli/queqiao/internal/identity"
 )
 
-const enrollmentRecordInterval = 10 * time.Second
+// enrollmentOutcome is the label an enrollment record is rate limited under:
+// an identity.EnrollmentOutcome for anything the store answered, plus this
+// gateway's own admissionRefused for an attempt dropped before the store was
+// reached. The set is closed, which is what keeps recordLimiter's map bounded.
+//
+// Acceptances are deliberately never rate-limited - a device joining a
+// provider is a rare, durable change to who can use this gateway, and it
+// should never be summarized away. recordEnrollment returns before consulting
+// the limiter for those.
+type enrollmentOutcome string
+
+// String makes an outcome a recordLimiter label.
+func (o enrollmentOutcome) String() string { return string(o) }
 
 // admissionRefused is recorded like an outcome but is this gateway's own
 // answer: the enrollment slots were full, so the attempt was dropped before
 // any invitation was read. It is the one enrollment ceiling that used to close
 // a connection without saying anything, while the session and QUIC ceilings
 // beside it both warn.
-const admissionRefused = "admission_refused"
-
-// enrollmentLog rate-limits the enrollment record, the way refusalLog does for
-// lane joins and for the same reason: the attempts are a stranger's to
-// generate, and a storm of them is exactly when the record matters most.
-//
-// The key space is this gateway's own outcome set rather than anything a peer
-// chooses, so a map is bounded by construction. Acceptances are deliberately
-// not rate-limited - a device joining a provider is a rare, durable change to
-// who can use this gateway, and it should never be summarized away.
-type enrollmentLog struct {
-	mu    sync.Mutex
-	state map[string]*enrollmentCounter
-}
-
-type enrollmentCounter struct {
-	last       time.Time
-	suppressed uint64
-	total      uint64
-}
-
-// due reports whether this outcome should be written now, how many of its
-// attempts went unwritten since the last time it was, and how many there have
-// been in total. The total is carried for the same reason refusalLog carries
-// it: a storm that stops otherwise leaves its tail in a record nobody writes.
-func (l *enrollmentLog) due(outcome string, now time.Time) (write bool, suppressed, total uint64) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.state == nil {
-		l.state = make(map[string]*enrollmentCounter)
-	}
-	counter, ok := l.state[outcome]
-	if !ok {
-		counter = &enrollmentCounter{}
-		l.state[outcome] = counter
-	}
-	counter.total++
-	total = counter.total
-	if !counter.last.IsZero() && now.Sub(counter.last) < enrollmentRecordInterval {
-		counter.suppressed++
-		return false, 0, total
-	}
-	suppressed = counter.suppressed
-	counter.last, counter.suppressed = now, 0
-	return true, suppressed, total
-}
+const admissionRefused enrollmentOutcome = "admission_refused"
 
 // recordEnrollment says what an enrollment or renewal attempt did, where an
 // operator will see it.
@@ -93,7 +59,7 @@ func (s *Server) recordEnrollment(kind string, result identity.EnrollmentResult,
 		level = slog.LevelError
 	}
 	outcome := string(result.Outcome)
-	write, suppressed, total := s.enrollLog.due(outcome, time.Now())
+	write, suppressed, total := s.enrollLog.due(enrollmentOutcome(result.Outcome), time.Now())
 	if !write {
 		return
 	}
@@ -120,7 +86,7 @@ func (s *Server) recordEnrollment(kind string, result identity.EnrollmentResult,
 func (s *Server) recordEnrollmentAdmission(kind string) {
 	if write, suppressed, total := s.enrollLog.due(admissionRefused, time.Now()); write {
 		s.cfg.Logger.LogAttrs(context.Background(), slog.LevelWarn, kind+" refused",
-			slog.String("outcome", admissionRefused),
+			slog.String("outcome", admissionRefused.String()),
 			slog.Uint64("suppressed", suppressed),
 			slog.Uint64("total", total))
 	}

--- a/internal/pep/enrollmentlog_test.go
+++ b/internal/pep/enrollmentlog_test.go
@@ -1,51 +1,131 @@
 package pep
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
 	"testing"
-	"time"
+
+	"github.com/bojieli/queqiao/internal/identity"
 )
 
-// A storm of attempts must leave one readable record rather than one line per
-// attempt, and that record has to carry the size of the storm it stands for.
-func TestEnrollmentLogSuppressesStormAndKeepsTotals(t *testing.T) {
-	var log enrollmentLog
-	start := time.Unix(1700000000, 0)
-	write, suppressed, total := log.due("rejected", start)
-	if !write || suppressed != 0 || total != 1 {
-		t.Fatalf("first record write=%t suppressed=%d total=%d", write, suppressed, total)
-	}
-	for i := 1; i < 50; i++ {
-		if write, _, _ := log.due("rejected", start.Add(time.Duration(i)*time.Millisecond)); write {
-			t.Fatalf("attempt %d wrote inside the interval", i)
+func enrollmentRecorder(t *testing.T) (*Server, *bytes.Buffer) {
+	t.Helper()
+	var records bytes.Buffer
+	server := &Server{cfg: ServerConfig{
+		Logger: slog.New(slog.NewJSONHandler(&records, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}}
+	return server, &records
+}
+
+func decodeRecords(t *testing.T, raw *bytes.Buffer) []map[string]any {
+	t.Helper()
+	out := []map[string]any{}
+	for _, line := range bytes.Split(bytes.TrimSpace(raw.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
 		}
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			t.Fatalf("undecodable record %q: %v", line, err)
+		}
+		out = append(out, record)
 	}
-	write, suppressed, total = log.due("rejected", start.Add(enrollmentRecordInterval))
-	if !write {
-		t.Fatal("no record written after the interval elapsed")
-	}
-	if suppressed != 49 {
-		t.Fatalf("suppressed=%d; want 49", suppressed)
-	}
-	if total != 51 {
-		t.Fatalf("total=%d; want 51", total)
+	return out
+}
+
+// An outcome's level is the whole point of recording it separately: a store
+// this gateway cannot open is an outage its operator must act on, while a
+// spent invitation is the enrolling user's problem. Reporting both the same
+// way is what the record was added to stop.
+func TestEnrollmentOutcomesAreRecordedAtTheirOwnLevel(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		outcome identity.EnrollmentOutcome
+		level   string
+	}{
+		{"rejected", identity.EnrollmentRejected, "WARN"},
+		{"store unavailable", identity.EnrollmentUnavailable, "ERROR"},
+		{"malformed", identity.EnrollmentMalformed, "INFO"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, records := enrollmentRecorder(t)
+			server.recordEnrollment("enrollment", identity.EnrollmentResult{Outcome: test.outcome}, errors.New("cause"))
+			written := decodeRecords(t, records)
+			if len(written) != 1 {
+				t.Fatalf("wrote %d records, want 1", len(written))
+			}
+			record := written[0]
+			if record["msg"] != "enrollment refused" || record["level"] != test.level {
+				t.Fatalf("record = %#v", record)
+			}
+			if record["outcome"] != string(test.outcome) || record["total"] != float64(1) {
+				t.Fatalf("record = %#v", record)
+			}
+			if record["error"] != "cause" {
+				t.Fatalf("the underlying cause was dropped: %#v", record)
+			}
+		})
 	}
 }
 
-// Outcomes are rate-limited apart, so an outage that repeats every second
-// cannot bury the single rejection an operator is looking for.
-func TestEnrollmentLogSeparatesOutcomes(t *testing.T) {
-	var log enrollmentLog
-	now := time.Unix(1700000000, 0)
-	if write, _, _ := log.due("store_unavailable", now); !write {
-		t.Fatal("first outage record was suppressed")
+// A device joining a provider is a rare, durable change to who can use this
+// gateway. It must never be summarized away by the rate limiter, however many
+// arrive together.
+func TestAcceptedEnrollmentsAreNeverSuppressed(t *testing.T) {
+	server, records := enrollmentRecorder(t)
+	const accepted = 20
+	for i := 0; i < accepted; i++ {
+		server.recordEnrollment("enrollment", identity.EnrollmentResult{
+			Outcome: identity.EnrollmentAccepted, AccountID: "account", DeviceID: "device", DeviceName: "laptop",
+		}, nil)
 	}
-	if write, _, _ := log.due("store_unavailable", now.Add(time.Second)); write {
-		t.Fatal("second outage record inside the interval was written")
+	written := decodeRecords(t, records)
+	if len(written) != accepted {
+		t.Fatalf("wrote %d records for %d acceptances", len(written), accepted)
 	}
-	if write, _, total := log.due("rejected", now.Add(time.Second)); !write || total != 1 {
-		t.Fatalf("a different outcome was suppressed by the outage: write=%t total=%d", write, total)
+	first := written[0]
+	if first["msg"] != "enrollment accepted" || first["level"] != "INFO" {
+		t.Fatalf("record = %#v", first)
 	}
-	if write, _, _ := log.due(admissionRefused, now.Add(time.Second)); !write {
-		t.Fatal("admission refusals share a budget with enrollment outcomes")
+	if first["account_id"] != "account" || first["device_id"] != "device" || first["device_name"] != "laptop" {
+		t.Fatalf("acceptance did not name what it created: %#v", first)
+	}
+}
+
+// A refusal storm must collapse to one readable record carrying its own size,
+// and must not take the record of a different outcome down with it.
+func TestRefusedEnrollmentStormStaysOneReadableRecord(t *testing.T) {
+	server, records := enrollmentRecorder(t)
+	const storm = 50
+	for i := 0; i < storm; i++ {
+		server.recordEnrollment("enrollment", identity.EnrollmentResult{Outcome: identity.EnrollmentRejected}, nil)
+	}
+	server.recordEnrollmentAdmission("enrollment")
+	written := decodeRecords(t, records)
+	if len(written) != 2 {
+		t.Fatalf("wrote %d records for a storm plus one admission refusal, want 2", len(written))
+	}
+	if written[0]["outcome"] != string(identity.EnrollmentRejected) || written[0]["total"] != float64(1) {
+		t.Fatalf("record = %#v", written[0])
+	}
+	// The admission refusal is this gateway's own answer and is rate limited
+	// apart from anything the store said.
+	if written[1]["outcome"] != admissionRefused.String() || written[1]["level"] != "WARN" {
+		t.Fatalf("record = %#v", written[1])
+	}
+	if written[1]["total"] != float64(1) {
+		t.Fatalf("admission refusals share a budget with enrollment outcomes: %#v", written[1])
+	}
+}
+
+// A stranger's attempt must not be able to write a name of their choosing into
+// this gateway's log.
+func TestRefusedEnrollmentRecordsNothingTheClientChose(t *testing.T) {
+	server, records := enrollmentRecorder(t)
+	server.recordEnrollment("enrollment", identity.EnrollmentResult{Outcome: identity.EnrollmentRejected}, nil)
+	if bytes.Contains(records.Bytes(), []byte("device_name")) {
+		t.Fatalf("a refused enrollment carried a client-chosen name: %s", records.String())
 	}
 }

--- a/internal/pep/lanejoinrefusal_test.go
+++ b/internal/pep/lanejoinrefusal_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/bojieli/queqiao/internal/identity"
 	"github.com/bojieli/queqiao/internal/metrics"
@@ -80,59 +79,5 @@ func TestLaneJoinRefusalsAreVisibleAndCountedByReason(t *testing.T) {
 				t.Fatalf("record total = %#v, want 1", record["total"])
 			}
 		})
-	}
-}
-
-// A storm must stay legible: the reason is written, the ones it stood in for
-// are counted, and the count is reported rather than lost.
-func TestLaneJoinRefusalLogSurvivesAStorm(t *testing.T) {
-	var log refusalLog
-	start := time.Now()
-	write, suppressed, total := log.due(metrics.LaneJoinUnknownSession, start)
-	if !write || suppressed != 0 || total != 1 {
-		t.Fatalf("first refusal write=%t suppressed=%d total=%d, want true, 0 and 1", write, suppressed, total)
-	}
-	const storm = 500
-	for i := 0; i < storm; i++ {
-		if write, _, _ := log.due(metrics.LaneJoinUnknownSession, start.Add(time.Duration(i)*time.Millisecond)); write {
-			t.Fatalf("refusal %d was written inside the interval", i)
-		}
-	}
-	// A different reason is never suppressed by another one's storm.
-	if write, _, _ := log.due(metrics.LaneJoinPrincipalMismatch, start.Add(time.Second)); !write {
-		t.Fatal("a principal mismatch was hidden by an unknown-session storm")
-	}
-	write, suppressed, total = log.due(metrics.LaneJoinUnknownSession, start.Add(refusalLogInterval))
-	if !write || suppressed != storm || total != storm+2 {
-		t.Fatalf("after the interval write=%t suppressed=%d total=%d, want true, %d and %d",
-			write, suppressed, total, storm, storm+2)
-	}
-	if write, suppressed, _ = log.due(metrics.LaneJoinUnknownSession, start.Add(2*refusalLogInterval)); !write || suppressed != 0 {
-		t.Fatalf("suppressed count survived being reported: write=%t suppressed=%d", write, suppressed)
-	}
-}
-
-// A storm that stops must still say how big it was. The suppressed count is
-// reported one record late, so on a gateway restart ninety-four refusals
-// produced a single record claiming to stand for none of them; the total is
-// what makes one record the whole story.
-func TestARefusalRecordSaysHowManyThereHaveBeen(t *testing.T) {
-	var log refusalLog
-	start := time.Now()
-	if _, _, total := log.due(metrics.LaneJoinUnknownSession, start); total != 1 {
-		t.Fatalf("total = %d on the first refusal, want 1", total)
-	}
-	for i := 0; i < 93; i++ {
-		log.due(metrics.LaneJoinUnknownSession, start.Add(time.Duration(i)*time.Millisecond))
-	}
-	// Nothing more arrives, so no further record is written and the suppressed
-	// count is never reported. The record that was written must already carry
-	// the count, which the next one confirms.
-	_, _, total := log.due(metrics.LaneJoinUnknownSession, start.Add(refusalLogInterval))
-	if total != 95 {
-		t.Fatalf("total = %d, want every refusal counted", total)
-	}
-	if _, _, other := log.due(metrics.LaneJoinFlowMismatch, start); other != 1 {
-		t.Fatalf("reasons share a total: flow mismatch = %d, want 1", other)
 	}
 }

--- a/internal/pep/recordlimiter.go
+++ b/internal/pep/recordlimiter.go
@@ -1,0 +1,75 @@
+package pep
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// recordLogInterval is how often one label is written to the log while a storm
+// is running. The first record of a label is always written; the ones a storm
+// suppresses are counted and reported with the next.
+//
+// Every caller has wanted the same ten seconds so far. If one ever needs a
+// different cadence, this becomes a field on recordLimiter -- which costs the
+// zero value its usability, so it is not worth doing before there is a second
+// answer.
+const recordLogInterval = 10 * time.Second
+
+// recordLimiter keeps a storm of repeated operational records legible. It
+// writes one record per label per interval and counts the ones that record
+// stands in for, so a gateway under a storm produces a readable log rather
+// than either a flood or a silence.
+//
+// Grouping is by label rather than by the identifiers in the event. Per
+// session or per invitation would read better, but those identifiers are the
+// peer's to choose: a map keyed by them is memory whose size a peer decides,
+// and a storm is exactly when a peer is producing identifiers this endpoint
+// has never seen. Every label space here is closed at compile time -- lane
+// join refusals, account admission refusals, enrollment outcomes -- so the map
+// stays bounded by construction.
+//
+// The zero value is ready to use.
+type recordLimiter struct {
+	mu     sync.Mutex
+	labels map[string]*recordCounter
+}
+
+type recordCounter struct {
+	last       time.Time
+	suppressed uint64
+	total      uint64
+}
+
+// due reports whether this label should be written now, how many of its events
+// went unwritten since the last time it was, and how many there have been in
+// total.
+//
+// The total is there because the suppressed count alone is reported one record
+// late: a storm that stops leaves its tail in a record that never gets
+// written. Measured on a gateway restart, ninety-four refusals produced one
+// record saying it stood for none of them, which is the same silence this
+// logging exists to end. Every record carries the count for its label, so one
+// record is the whole story.
+func (l *recordLimiter) due(label fmt.Stringer, now time.Time) (write bool, suppressed, total uint64) {
+	key := label.String()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.labels == nil {
+		l.labels = make(map[string]*recordCounter)
+	}
+	counter, ok := l.labels[key]
+	if !ok {
+		counter = &recordCounter{}
+		l.labels[key] = counter
+	}
+	counter.total++
+	total = counter.total
+	if !counter.last.IsZero() && now.Sub(counter.last) < recordLogInterval {
+		counter.suppressed++
+		return false, 0, total
+	}
+	suppressed = counter.suppressed
+	counter.last, counter.suppressed = now, 0
+	return true, suppressed, total
+}

--- a/internal/pep/recordlimiter_test.go
+++ b/internal/pep/recordlimiter_test.go
@@ -1,0 +1,88 @@
+package pep
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/metrics"
+)
+
+// A storm must stay legible: the label is written, the events it stood in for
+// are counted, and the count is reported rather than lost.
+func TestRecordLimiterSurvivesAStorm(t *testing.T) {
+	var limiter recordLimiter
+	start := time.Unix(1700000000, 0)
+	write, suppressed, total := limiter.due(metrics.LaneJoinUnknownSession, start)
+	if !write || suppressed != 0 || total != 1 {
+		t.Fatalf("first record write=%t suppressed=%d total=%d, want true, 0 and 1", write, suppressed, total)
+	}
+	const storm = 500
+	for i := 0; i < storm; i++ {
+		if write, _, _ := limiter.due(metrics.LaneJoinUnknownSession, start.Add(time.Duration(i)*time.Millisecond)); write {
+			t.Fatalf("event %d was written inside the interval", i)
+		}
+	}
+	write, suppressed, total = limiter.due(metrics.LaneJoinUnknownSession, start.Add(recordLogInterval))
+	if !write || suppressed != storm || total != storm+2 {
+		t.Fatalf("after the interval write=%t suppressed=%d total=%d, want true, %d and %d",
+			write, suppressed, total, storm, storm+2)
+	}
+	if write, suppressed, _ = limiter.due(metrics.LaneJoinUnknownSession, start.Add(2*recordLogInterval)); !write || suppressed != 0 {
+		t.Fatalf("suppressed count survived being reported: write=%t suppressed=%d", write, suppressed)
+	}
+}
+
+// A storm that stops must still say how big it was. The suppressed count is
+// reported one record late, so on a gateway restart ninety-four refusals
+// produced a single record claiming to stand for none of them; the total is
+// what makes one record the whole story.
+func TestARecordSaysHowManyThereHaveBeen(t *testing.T) {
+	var limiter recordLimiter
+	start := time.Unix(1700000000, 0)
+	if _, _, total := limiter.due(metrics.LaneJoinUnknownSession, start); total != 1 {
+		t.Fatalf("total = %d on the first event, want 1", total)
+	}
+	for i := 0; i < 93; i++ {
+		limiter.due(metrics.LaneJoinUnknownSession, start.Add(time.Duration(i)*time.Millisecond))
+	}
+	// Nothing more arrives, so no further record is written and the suppressed
+	// count is never reported. The record that was written must already carry
+	// the count, which the next one confirms.
+	if _, _, total := limiter.due(metrics.LaneJoinUnknownSession, start.Add(recordLogInterval)); total != 95 {
+		t.Fatalf("total = %d, want every event counted", total)
+	}
+}
+
+// Labels are rate-limited apart, so a storm of one cannot bury the single
+// event an operator is looking for -- across all three label spaces sharing
+// this implementation, and whether or not they share a limiter.
+func TestRecordLimiterSeparatesLabels(t *testing.T) {
+	var limiter recordLimiter
+	now := time.Unix(1700000000, 0)
+	if write, _, _ := limiter.due(metrics.LaneJoinUnknownSession, now); !write {
+		t.Fatal("the first record was suppressed")
+	}
+	if write, _, _ := limiter.due(metrics.LaneJoinUnknownSession, now.Add(time.Second)); write {
+		t.Fatal("a repeated label was written inside the interval")
+	}
+	for _, label := range []interface {
+		String() string
+	}{
+		metrics.LaneJoinPrincipalMismatch,
+		metrics.AccountRefusalFlowLimit,
+		metrics.AccountRefusalClientLimit,
+		enrollmentOutcome("rejected"),
+		enrollmentOutcome("store_unavailable"),
+		admissionRefused,
+	} {
+		if write, _, total := limiter.due(label, now.Add(time.Second)); !write || total != 1 {
+			t.Fatalf("%s shared a budget with another label: write=%t total=%d", label, write, total)
+		}
+	}
+	// Separate limiters are separate: an enrollment storm cannot suppress a
+	// refusal record, and neither can suppress the other's totals.
+	var other recordLimiter
+	if write, _, total := other.due(metrics.LaneJoinUnknownSession, now.Add(time.Second)); !write || total != 1 {
+		t.Fatalf("a second limiter shared the first's state: write=%t total=%d", write, total)
+	}
+}

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -79,18 +79,19 @@ type Server struct {
 	accountMu        sync.Mutex
 	accountUsage     map[string]*accountUsage
 	maxObservedLanes atomic.Int64
-	// refusals keeps the lane-join refusal record readable during a storm,
-	// and accountRefusals does the same for account admission. They are
-	// separate logs so a lane-join storm cannot suppress the record of an
-	// account hitting its limit, which is the record an operator is looking
-	// for when a user reports that some sites load and others do not.
-	refusals        refusalLog
-	accountRefusals refusalLog
-	// enrollLog does the same for enrollment and renewal attempts, which are
-	// likewise a stranger's to generate.
-	enrollLog enrollmentLog
-	budget    *limiter.Budget
-	metrics   *metrics.Registry
+	// These keep three kinds of record readable during a storm: lane-join
+	// refusals, account admission refusals, and enrollment or renewal
+	// attempts. All three are a stranger's to generate.
+	//
+	// They are three limiters rather than one because a storm in any of them
+	// must not suppress the others. The record an operator wants when a user
+	// says some sites load and others do not is the account one, and a peer
+	// hammering lane joins would otherwise bury it.
+	refusals        recordLimiter
+	accountRefusals recordLimiter
+	enrollLog       recordLimiter
+	budget          *limiter.Budget
+	metrics         *metrics.Registry
 	// udpRelays holds the relay sockets of UDP associations whose lane died,
 	// so the replacement association keeps the source address the destination
 	// has been talking to.
@@ -820,58 +821,6 @@ func (s *Server) retainCompletedSession(sessionID [16]byte, serverSession *serve
 			s.unregisterSession(sessionID, serverSession)
 		})
 	})
-}
-
-// refusalLogInterval is how often one refusal reason is written to the log
-// while a storm is running. The first refusal of a reason is always written;
-// the ones a storm suppresses are counted and reported with the next.
-const refusalLogInterval = 10 * time.Second
-
-// refusalLog rate-limits the refusal record without keeping per-session state.
-//
-// Per session would read better in a log, but the session identifier in a
-// refused join is the peer's to choose: a map keyed by it is memory whose size
-// a peer decides, and a storm of refusals is exactly when a peer is producing
-// identifiers this endpoint has never seen. Per reason is bounded by the
-// reasons, and the suppressed count keeps the storm's size in the record.
-// The reason is carried as its own label rather than as an enum value so one
-// implementation serves both refusal paths. Both enums are closed at compile
-// time, so the keys stay bounded by the reasons that exist.
-type refusalLog struct {
-	mu         sync.Mutex
-	last       map[string]time.Time
-	suppressed map[string]uint64
-	total      map[string]uint64
-}
-
-// due reports whether this reason should be written now, how many of its
-// refusals went unwritten since the last time it was, and how many there have
-// been in total.
-//
-// The total is there because the suppressed count alone is reported one record
-// late: a storm that stops leaves its tail in a record that never gets
-// written. Measured on a gateway restart, ninety-four refusals produced one
-// record saying it stood for none of them, which is the same silence this
-// logging exists to end. Every record now carries the count for its reason, so
-// one record is the whole story.
-func (l *refusalLog) due(reason fmt.Stringer, now time.Time) (write bool, suppressed, total uint64) {
-	label := reason.String()
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	if l.total == nil {
-		l.last = make(map[string]time.Time)
-		l.suppressed = make(map[string]uint64)
-		l.total = make(map[string]uint64)
-	}
-	l.total[label]++
-	total = l.total[label]
-	if last := l.last[label]; !last.IsZero() && now.Sub(last) < refusalLogInterval {
-		l.suppressed[label]++
-		return false, 0, total
-	}
-	suppressed = l.suppressed[label]
-	l.last[label], l.suppressed[label] = now, 0
-	return true, suppressed, total
 }
 
 // refuseLaneJoin answers a lane join with a reset, and says so where an


### PR DESCRIPTION
## Why

The gateway grew three storm-suppressing log limiters independently:
`refusalLog` for lane-join refusals, then account admission refusals (#35), then
`enrollmentLog` for enrollment and renewal outcomes (#34). After the last two
landed they were the same algorithm written three times — write one record per
label per ten seconds, count the ones that record stood in for, carry a running
total so a storm that *stops* still says how big it was.

Their doc comments were separately arguing for the same property, too: group by
a label from a closed set rather than by identifiers the peer chooses, because a
map keyed by peer-chosen identifiers is memory whose size the peer decides, and a
storm is exactly when a peer is producing identifiers this endpoint has never
seen.

## What this does

Collapses them into one `recordLimiter` in `internal/pep/recordlimiter.go`. The
label is a `fmt.Stringer`, so each caller keeps its own compile-time-closed enum
at the call site and the map stays bounded by construction. Enrollment outcomes
get a small named type to supply that, covering both the store's answers and the
gateway's own `admissionRefused` — which is deliberately not an
`identity.EnrollmentOutcome`, since it is this gateway's answer rather than
anything the store said.

The three `Server` fields stay three separate limiters. That is the point of the
comment now on them: a storm in any one must not suppress the others, and the
record an operator wants when a user reports that some sites load and others do
not is the account one, which a peer hammering lane joins would otherwise bury.

## Behaviour is unchanged

- All three intervals were already ten seconds, so they share one constant. If a
  caller ever needs a different cadence it becomes a field — noted in the
  comment, not done speculatively, since a field costs the zero value its
  usability.
- Acceptances are still never rate limited: `recordEnrollment` returns before
  consulting the limiter for those.
- No label value, log message, or level moves. Internal only, so no changelog
  entry.
- The internal representation is #34's (one map of counters) rather than #35's
  (three parallel maps) — one lookup and one allocation per label instead of
  three.

## Tests

The two storm tests that shipped with the enrollment log tested only the shared
algorithm, and so did two of the three in `lanejoinrefusal_test.go`. Those four
become three in `recordlimiter_test.go`, exercised against labels drawn from all
three spaces at once, which also pins that the spaces do not share budgets.

In their place the enrollment log gets the tests it never actually had — nothing
covered `recordEnrollment` itself before:

- each outcome is recorded at its own level (`rejected` → warn, `store_unavailable`
  → error, `malformed_request` → info), carrying the underlying cause;
- an acceptance is never suppressed, and names the account, device, and device
  name it created;
- a refusal storm collapses to one record, and an admission refusal is limited
  apart from anything the store said;
- a refused attempt writes nothing the client chose — no `device_name` — so a
  stranger cannot write a name of their choosing into this gateway's log.

`TestLaneJoinRefusalsAreVisibleAndCountedByReason` stays where it is; it asserts
what a refused join actually logs rather than the limiter.

## Verification

`go build`, `go vet`, `gofmt -l`, `staticcheck -checks=all,-U1000`, the full
`-short` suite, and `go test -race ./internal/pep` all pass on `main` at d9161df.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ko2HaWwHbWR3XybTk5YPk
