### PR TITLE
docs: start from a published binary, not from a build

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,85 +119,90 @@ workload; see the full [comparison and methodology](docs/COMPARISON.md).
 - Bounded JSON logs, metrics, a local visualizer, deterministic benchmarks,
   release packaging, SBOMs, and rollback procedures.
 
+All of it ships as a prebuilt binary. Download it below, or from the
+[latest release](https://github.com/bojieli/queqiao/releases/latest); there is no build step for normal use.
+
 ## Platform availability
 
-- **macOS and Linux:** desktop and provider-gateway builds are available to use
-  from source today.
-- **Windows:** native release targets are built, but the Windows client is
-  currently under testing and is not presented as production-ready.
-- **Android and iOS:** clients use the same protocol-1 core and are currently
-  under testing. They are not yet presented as production-ready mobile apps.
+Every release publishes reproducible, signed binaries for six native targets.
+The links below are v0.1.1, the current release; the
+[releases page](https://github.com/bojieli/queqiao/releases/latest) always has the newest.
+
+| Platform | Status | Download |
+| --- | --- | --- |
+| macOS, Apple silicon | Desktop and gateway, ready to use | [`darwin_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_darwin_arm64_signed.zip), notarized |
+| macOS, Intel | Desktop and gateway, ready to use | [`darwin_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_darwin_amd64_signed.zip), notarized |
+| Linux, x86-64 | Desktop and gateway, ready to use | [`linux_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_linux_amd64.tar.gz) |
+| Linux, arm64 | Desktop and gateway, ready to use | [`linux_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_linux_arm64.tar.gz) |
+| Windows, x86-64 | Native target built; under testing, not production-ready | [`windows_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_windows_amd64.zip) |
+| Windows, arm64 | Native target built; under testing, not production-ready | [`windows_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/queqiaod_v0.1.1_windows_arm64.zip) |
+| Android and iOS | Same protocol-1 core, under testing; not yet production-ready mobile apps | -- |
+
+Check a download against its release's
+[`SHA256SUMS`](https://github.com/bojieli/queqiao/releases/download/v0.1.1/SHA256SUMS)
+before running it. Each archive carries its own CycloneDX SBOM and the complete
+license text for every module linked into the binary.
 
 ## Quick start
 
-Build from source with the Go version declared in [`go.mod`](go.mod):
+Two scripts perform a whole deployment and verify the result, one per side.
+Neither needs a Go toolchain: point them at the binary you downloaded above.
+
+On the Linux gateway, as root:
+
+```sh
+sudo ./deploy/install-server.sh \
+  --binary ./queqiaod \
+  --name "Example Network" \
+  --endpoint gateway.example.net:443 \
+  --user alice \
+  --tune
+```
+
+That installs the binary, service account, directories, hardened unit, and
+environment file, initializes the provider, creates the first user, starts and
+verifies the gateway, and only then prints one single-use invitation URI.
+Deliver that URI over an authenticated private channel: it is a bearer
+credential.
+
+On the client, as the account that will use the tunnel -- not with `sudo`:
+
+```sh
+./deploy/install-client.sh --binary ./queqiaod --invite 'queqiao://enroll/...'
+```
+
+That enrolls the invitation, writes the profile and manifest, installs a
+per-user service that starts at login -- a LaunchAgent on macOS, a systemd
+`--user` unit on Linux -- and checks end to end that traffic reaches the
+gateway. Repeat `--invite` to add providers, each on its own loopback port.
+
+The client listens on `127.0.0.1:12080`, the port
+[`deploy/clash-queqiao.yaml`](deploy/clash-queqiao.yaml) already points at.
+Point an application or Clash/mihomo at that SOCKS5 endpoint.
+
+The scripts live in this repository: clone it, or copy `deploy/` beside the
+downloaded binary. From the next release they also ship inside the archives.
+
+The [deployment guide](docs/DEPLOYING.md) is the reference for everything past
+this point -- what the scripts do, the hosts they do not cover, the manual
+gateway and enrollment steps for a host they do not fit, firewall and socket
+tuning, multiple users, source-interface selection, verification, upgrades, and
+rollback. To serve several providers from one client process, see
+[multi-provider](docs/DEPLOYING.md#connect-to-multiple-providers).
+
+## Build from source
+
+Normal use needs no build. Build to develop, or to run on a platform with no
+published archive, using the Go version declared in [`go.mod`](go.mod):
 
 ```sh
 go test ./...
 go build -o ./queqiaod ./cmd/queqiaod
 ```
 
-On the provider gateway, initialize a provider, add a user, and create a
-single-use invitation:
-
-```sh
-sudo ./queqiaod provider init \
-  --state /var/lib/queqiao/provider \
-  --name "Example Network" \
-  --endpoint gateway.example.net:443
-
-sudo ./queqiaod provider add-user \
-  --state /var/lib/queqiao/provider \
-  --name alice \
-  --max-sessions 8
-
-sudo ./queqiaod provider invite \
-  --state /var/lib/queqiao/provider \
-  --user alice
-
-sudo ./queqiaod server \
-  --state /var/lib/queqiao/provider \
-  --listen :443
-```
-
-Send the printed `queqiao://` URI to the user over a private channel. On the
-client:
-
-```sh
-./queqiaod enroll 'queqiao://enroll/…'
-./queqiaod service install --profile "$PROFILE"
-```
-
-`enroll` prints the profile path it wrote and the exact `service install` line
-to run next. That second command installs a per-user service — a LaunchAgent on
-macOS, a systemd `--user` unit on Linux — so the client starts on its own
-instead of living in a terminal. `./queqiaod client --profile "$PROFILE"` runs
-it in the foreground when you only want to try it.
-
-The client listens on `127.0.0.1:12080`, the port
-[`deploy/clash-queqiao.yaml`](deploy/clash-queqiao.yaml) already points at.
-Point an application or Clash/mihomo at that SOCKS5 endpoint.
-
-Two scripts collapse the whole of the above into one command per side and
-verify the result:
-
-```sh
-# Linux gateway, as root: binary, service account, unit, provider, first user,
-# and one invitation printed once the running gateway has been verified.
-sudo ./deploy/install-server.sh --name "Example Network" \
-  --endpoint gateway.example.net:443 --user alice --tune
-
-# Client, as the account that will use the tunnel: enrollment, manifest,
-# service, and an end-to-end check that traffic reaches the gateway.
-./deploy/install-client.sh --invite 'queqiao://enroll/…'
-```
-
-The [deployment guide](docs/DEPLOYING.md) covers what those scripts do, the
-hosts they do not cover, firewall and socket tuning, multiple users,
-source-interface selection, verification, upgrades, and rollback.
-
-To use several providers from one desktop client process, follow the
-[multi-provider deployment guide](docs/DEPLOYING.md#connect-to-multiple-providers).
+Both installer scripts pick up `./queqiaod` from the repository root on their
+own, so the commands above work unchanged without `--binary`.
+[`CONTRIBUTING.md`](CONTRIBUTING.md) lists the full development checks.
 
 ## Who is it for?
 
@@ -216,8 +221,8 @@ a full mesh control plane belong to a larger overlay product built around it.
 
 ## Project status
 
-Queqiao is ready to build and use from source for the supported paired-gateway
-topology. It is a public preview, not a production-ready claim for every
+Queqiao is ready to use for the supported paired-gateway topology, from the
+published binaries or from source. It is a public preview, not a production-ready claim for every
 network. Protocol 1 is the only supported wire version; broader independent
 field qualification, transport and security review, and mobile review remain
 open. See [current status](docs/STATUS.md) for the evidence boundary and

--- a/changelog.d/prebuilt-binary-install.changed.md
+++ b/changelog.d/prebuilt-binary-install.changed.md
@@ -1,0 +1,9 @@
+Installation now starts from a published binary rather than a build. The
+README carries per-platform download links, states which platforms are ready
+to use, and gives the deployment scripts as the quick start; the manual
+gateway and enrollment sequence it used to inline is the deployment guide's
+job, and building from source is now a section for developing rather than the
+first thing a reader is asked to do. The deployment guide opens with the
+download link. Every release has published reproducible archives for Linux,
+macOS, and Windows on amd64 and arm64 since v0.1.0; the documentation had
+continued to describe macOS and Linux as available from source.

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -10,6 +10,15 @@ Clash/mihomo integration. It also covers multi-provider clients, service
 operation, upgrades, and rollback. Protocol 1 is the only supported wire
 protocol, so client and server must be upgraded together.
 
+**Download the binary first:** [latest release](https://github.com/bojieli/queqiao/releases/latest), or the
+per-platform links in the
+[README](../README.md#platform-availability). Every release publishes
+reproducible archives for Linux, macOS, and Windows on amd64 and arm64, so a
+normal deployment has no build step; check what you downloaded against the
+release's `SHA256SUMS` before running it. [Build from
+source](../README.md#build-from-source) only to develop or to run somewhere no
+archive covers.
+
 For a quick overview, start with the [repository README](../README.md). Use
 [known limitations](KNOWN-LIMITATIONS.md) to check whether the paired-gateway
 assumption fits your network before exposing a service.

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -43,6 +43,10 @@ exact commit. Production-ready language has additional gates below.
   section has been read as prose, and `changelog.d/` is empty on the candidate
   commit. A shipped release with no section of its own is a release whose
   changes are recorded nowhere.
+- [ ] The download links in `README.md` name the version being released.
+  `python3 -m unittest scripts.test_download_links` fails until they do: it
+  compares them against the newest section in `CHANGELOG.md`, which the step
+  above has just added.
 - [ ] `CHANGELOG.md` and the exact candidate release notes describe v0.1 as a
   paired fixed-egress public preview.
 - [ ] The maintainer has reviewed the candidate artifacts and explicitly

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,8 +6,8 @@
 > **Wire protocol:** Version 1 only; incompatible versions fail closed
 > **Last reviewed:** 2026-08-20
 
-Queqiao is ready to build and use from source for its supported paired-gateway
-topology. It is not a universal acceleration layer and it does not promise the
+Queqiao is ready to use for its supported paired-gateway topology, from the
+binaries published with every release or from source. It is not a universal acceleration layer and it does not promise the
 same result on every route. The current work is broadening independent field
 evidence and review while keeping the usable protocol moving forward.
 
@@ -41,7 +41,7 @@ limitations](KNOWN-LIMITATIONS.md) before deploying it.
 | Contention | behavioral flow state, priority queues, reactive bulk isolation, and bounded opt-in TCP fallback striping |
 | Identity | one-time invitations, provider-pinned gateway identity, per-device mutual TLS, renewal, revocation, and per-user limits |
 | Operations | bounded JSON logs, metrics, local visualizer, service examples, release packaging, SBOMs, and rollback procedure |
-| Clients | one process per provider or one process serving several providers on separate loopback SOCKS5 listeners; macOS/Linux desktop and gateway builds available from source; Windows targets built but under testing; Android SOCKS export and iOS packet-tunnel clients under testing, all using the protocol-1 core |
+| Clients | one process per provider or one process serving several providers on separate loopback SOCKS5 listeners; macOS/Linux desktop and gateway binaries published with every release; Windows targets built but under testing; Android SOCKS export and iOS packet-tunnel clients under testing, all using the protocol-1 core |
 | Conformance | committed protocol-1 vectors for framing, acknowledgement, destinations, UDP, coding, and enrollment, replayed by the test suite |
 
 ## Evidence and open work
@@ -69,6 +69,7 @@ than a single benchmark number.
 
 | Claim | Status |
 | --- | --- |
+| Prebuilt binaries for macOS, Linux, and Windows | Published with every release: six reproducible archives with SBOMs and license texts |
 | Builds and runs from source | Supported by the current repository and CI design |
 | Usable public preview | Supported for the paired-gateway topology; final publication gates remain explicit |
 | Works on every high-loss path | Not claimed |

--- a/scripts/test_download_links.py
+++ b/scripts/test_download_links.py
@@ -1,0 +1,68 @@
+"""The published download links must name the newest release, not a stale one."""
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+# Scanned for pinned download links wherever they appear. docs/DEPLOYING.md
+# links the releases page instead, which cannot go stale and needs no entry
+# here; it is scanned anyway in case a pinned link is added to it later.
+DOCUMENTS = ("README.md", "docs/DEPLOYING.md")
+# The document that must actually offer per-platform downloads.
+CATALOG = "README.md"
+DOWNLOAD = re.compile(
+    r"https://github\.com/bojieli/queqiao/releases/download/(?P<version>v\S+?)/"
+    r"(?P<asset>[A-Za-z0-9._-]+)"
+)
+SECTION = re.compile(r"^## (?P<version>v\S+) - \d{4}-\d{2}-\d{2}\s*$", re.M)
+
+
+class DownloadLinkTests(unittest.TestCase):
+    def links(self):
+        found = []
+        for name in DOCUMENTS:
+            text = (ROOT / name).read_text(encoding="utf-8")
+            for match in DOWNLOAD.finditer(text):
+                found.append((name, match.group("version"), match.group("asset")))
+        return found
+
+    def newest_release(self):
+        text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        versions = SECTION.findall(text)
+        self.assertTrue(versions, "CHANGELOG.md records no release")
+        return versions[0]
+
+    def test_the_catalog_offers_downloads(self):
+        assets = {asset for name, _, asset in self.links() if name == CATALOG}
+        for target in ("darwin_arm64", "darwin_amd64", "linux_amd64", "linux_arm64"):
+            self.assertTrue(
+                any(target in asset for asset in assets),
+                f"{CATALOG} offers no {target} download",
+            )
+
+    def test_links_name_one_version(self):
+        versions = {version for _, version, _ in self.links()}
+        self.assertEqual(len(versions), 1, f"mixed download versions: {versions}")
+
+    def test_links_name_the_newest_released_version(self):
+        newest = self.newest_release()
+        for name, version, asset in self.links():
+            self.assertEqual(
+                version,
+                newest,
+                f"{name} links {version}; CHANGELOG.md's newest release is "
+                f"{newest}. Cutting a release means updating these links.",
+            )
+
+    def test_asset_names_carry_that_version(self):
+        # SHA256SUMS is the one published asset with no version in its name.
+        for name, version, asset in self.links():
+            if asset.startswith("SHA256SUMS"):
+                continue
+            self.assertIn(version, asset, f"{name}: {asset} is not a {version} asset")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacked on #43 — the download-link check compares the links against the newest section in `CHANGELOG.md`, which #43 adds. GitHub will retarget this to `main` when #43 merges.

## The gap

Every release since v0.1.0 has published reproducible archives for **all six targets** — Linux, macOS, Windows × amd64, arm64 — with SBOMs, license texts, and **notarized** macOS zips. The docs never said so:

- README: "macOS and Linux: desktop and provider-gateway builds are available to use **from source** today."
- README Quick start opened with `go test ./... && go build`, then inlined the manual `provider init` → `add-user` → `invite` sequence, and only at the very end mentioned that two scripts collapse all of it into one command per side.
- `STATUS.md`: "ready to **build and use from source**", "builds available from source".

A reader was walked through the long path first and the supported one last.

## What changes

**README**
- "What you can use today" now ends by pointing at the downloads.
- "Platform availability" is a table with **direct per-platform download links** and honest per-platform status (macOS/Linux ready; Windows built but under testing; mobile under testing).
- **Quick start is the two installer scripts**, `--binary` pointed at what you downloaded. No build, no manual provider sequence — that is handed to the deployment guide, which is where it belongs.
- **"Build from source" is now its own section**, for developing or a platform no archive covers.

**docs/DEPLOYING.md** opens with the download link.

**docs/STATUS.md** — the three from-source claims corrected; a published-binaries row added.

## Keeping the links from rotting

`scripts/test_download_links.py`: all pinned links must name one version, that version must be the **newest section in `CHANGELOG.md`**, and each asset name must carry it. So cutting a release fails the suite until the links are bumped. `docs/RELEASE-CHECKLIST.md` says so too.

All eight published URLs were confirmed to resolve (HTTP 200).

## One thing to know

**The installer scripts are not in the v0.1.1 archives** — they were added after it, and are only on `main`. So the quick start says to take them from the repository, and notes they ship inside the archives from the next release. `validate_release.py` already requires them, so v0.1.2 archives will be self-contained.

This is a good argument for cutting v0.1.2 soon: there are 16 pending `changelog.d/` entries, and the installers are the release's headline.

## Checks

```
python3 -m unittest discover -s scripts -p 'test_*.py'   # 80 passed (4 new)
./scripts/changelog.py check                             # 16 pending, well formed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2