### PR TITLE
fix: let the installed client read its own interfaces

### DIFF
--- a/changelog.d/client-unit-interface-enumeration.fixed.md
+++ b/changelog.d/client-unit-interface-enumeration.fixed.md
@@ -1,0 +1,9 @@
+The installed Linux client service can resolve `--local-address` again. The
+generated systemd user unit allowed only `AF_INET`, `AF_INET6`, and
+`AF_UNIX`, but reading this machine's interfaces needs `AF_NETLINK`:
+`if:NAME` looks up the named interface's address, and `auto` has to know
+whether the choice is ambiguous. Without it the unit installed, the SOCKS5
+listener bound, systemd reported the service active, and every flow then
+failed with `enumerate local interfaces: netlinkrib: address family not
+supported by protocol`. The option this broke is the one the installer
+recommends when `auto` cannot decide between two uplinks.

--- a/changelog.d/install-server-listener-wait.fixed.md
+++ b/changelog.d/install-server-listener-wait.fixed.md
@@ -1,0 +1,5 @@
+`deploy/install-server.sh` waits for the gateway's listener instead of
+looking for it once. `Type=simple` reports a service active as soon as its
+process is forked, so the check ran before the socket was bound and a
+successful upgrade of a live gateway exited non-zero claiming nothing was
+listening on a port that was serving traffic seconds later.

--- a/cmd/queqiaod/service.go
+++ b/cmd/queqiaod/service.go
@@ -125,7 +125,14 @@ func renderSystemdUnit(c serviceConfig) string {
 	b.WriteString("PrivateTmp=true\n")
 	b.WriteString("LockPersonality=true\n")
 	b.WriteString("RestrictRealtime=true\n")
-	b.WriteString("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX\n")
+	// AF_NETLINK is how the client reads this machine's interfaces, which it
+	// does to resolve --local-address: `if:NAME` needs the named interface's
+	// address, and `auto` needs to know whether the choice is ambiguous.
+	// Without it the unit installs, binds its listener, and looks healthy,
+	// then fails every flow with "enumerate local interfaces: netlinkrib:
+	// address family not supported by protocol" - and the option this breaks
+	// is the one the installer recommends when `auto` cannot decide.
+	b.WriteString("RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK\n")
 	b.WriteString("SystemCallArchitectures=native\n")
 	b.WriteString("LimitNOFILE=65536\n\n")
 	b.WriteString("[Install]\n")

--- a/cmd/queqiaod/service_test.go
+++ b/cmd/queqiaod/service_test.go
@@ -108,6 +108,35 @@ func TestRenderSystemdUnitQuotesEveryArgument(t *testing.T) {
 	}
 }
 
+// The client resolves --local-address by reading this machine's interfaces,
+// which needs AF_NETLINK. Without it the unit installs cleanly, binds its
+// listener, and then fails every flow at run time - the worst shape a sandbox
+// mistake can take, because nothing looks wrong until traffic is attempted.
+func TestRenderSystemdUnitAllowsInterfaceEnumeration(t *testing.T) {
+	config := testServiceConfig()
+	config.localAddress = "if:enp6s0"
+	rendered := renderSystemdUnit(config)
+
+	families := ""
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.HasPrefix(line, "RestrictAddressFamilies=") {
+			families = line
+		}
+	}
+	if families == "" {
+		t.Fatalf("unit does not restrict address families at all:\n%s", rendered)
+	}
+	if !strings.Contains(families, "AF_NETLINK") {
+		t.Fatalf("--local-address cannot resolve without AF_NETLINK: %s", families)
+	}
+	// The restriction must still be a restriction.
+	for _, refused := range []string{"AF_PACKET", "AF_RAW"} {
+		if strings.Contains(families, refused) {
+			t.Fatalf("%s must not be permitted: %s", refused, families)
+		}
+	}
+}
+
 func TestSystemdQuoteEscapesMetacharacters(t *testing.T) {
 	got := systemdQuote(`a"b\c`)
 	want := `"a\"b\\c"`

--- a/deploy/install-server.sh
+++ b/deploy/install-server.sh
@@ -489,10 +489,16 @@ if [ "$verify" = true ]; then
 	}
 
 	if command -v ss >/dev/null 2>&1; then
-		listeners=$(ss -lntup 2>/dev/null | grep ":$listen_port " || true)
-		if [ -z "$listeners" ]; then
+		# Type=simple reports active as soon as the process is forked, so the
+		# socket is not bound yet on the first look. Checking once turned a
+		# successful upgrade into a failed install with a message saying the
+		# gateway was not listening while it was already serving traffic.
+		port_listening() {
+			ss -lntup 2>/dev/null | grep -q ":$listen_port "
+		}
+		wait_for port_listening ||
 			die "nothing is listening on port $listen_port after start-up"
-		fi
+		listeners=$(ss -lntup 2>/dev/null | grep ":$listen_port " || true)
 		echo "$listeners"
 		if [ "$transport" = auto ]; then
 			echo "$listeners" | grep -q '^udp' ||


### PR DESCRIPTION
Found by running the installers from #32 against a real gateway. Both faults share a shape: the install reports success, the service looks healthy, and the failure appears later — or never, if you only check `systemctl is-active`.

## 1. The client unit cannot resolve `--local-address`

`renderSystemdUnit` allowed `AF_INET`, `AF_INET6`, and `AF_UNIX`. Reading this machine's interfaces needs `AF_NETLINK` — `if:NAME` looks up the named interface's address, and `auto` has to know whether the choice is ambiguous.

So the unit installed, the SOCKS5 listener bound, systemd reported `active`, the installer's own listener check passed, and every flow failed:

```
level=WARN msg="configured endpoint failed on both transports" endpoint=...:12540
level=WARN msg="remote flow open failed"
  error="tcp lane: enumerate local interfaces: route ip+net: netlinkrib: address family not supported by protocol"
```

The part that makes this more than a missing entry: **the option it breaks is the one the installer recommends.** On a host with more than one physical IPv4 address, enrollment stops with

```
select --local-address "auto" for enrollment: more than one physical IPv4
address is active (172.18.0.1 on br-…, 172.19.0.1 on br-…); choose one with
--local-address if:NAME
```

and `install-client.sh` repeats that advice in its own failure text. Take it, and you get a client that installs cleanly and cannot carry traffic. Any host running Docker or podman has extra bridge addresses, so `auto` is ambiguous there by default and this is the path such a host is pushed down.

`AF_NETLINK` is a local kernel interface, and the restriction stays a restriction — the test asserts both that `AF_NETLINK` is present and that `AF_PACKET`/`AF_RAW` are not.

## 2. `install-server.sh` checks its listener once

```sh
listeners=$(ss -lntup 2>/dev/null | grep ":$listen_port " || true)
if [ -z "$listeners" ]; then
    die "nothing is listening on port $listen_port after start-up"
fi
```

The `systemctl is-active` check immediately above it already uses `wait_for`; this one does not. `Type=simple` reports a service active as soon as its process is forked, so the socket is not bound yet on the first look.

Upgrading a live gateway therefore exited non-zero with `nothing is listening on port 12540 after start-up` while the gateway was serving traffic on that port seconds later. The binary, unit, and environment file had all been installed and the service restarted, so the failure was purely cosmetic — but it is indistinguishable from a real failed install, which is the worst thing a deploy script can be ambiguous about. Now wrapped in the same `wait_for` as the check above it.

## Verification

Both fixes were confirmed on a live gateway, not just in tests:

- Server upgraded from `126eb5c` to current `main` with the existing trust root and a byte-identical `QUEQIAOD_ARGS`; the listener check passes once it waits.
- Client installed, enrolled, and reaching egress through the tunnel — `curl --socks5-hostname 127.0.0.1:12080 https://api.ipify.org` returns the gateway's address, exit 0 — after the unit could enumerate interfaces. Before the fix, the same command failed with `curl: (97) Can't complete SOCKS5 connection`.

`TestRenderSystemdUnitAllowsInterfaceEnumeration` fails on `main` with the exact production symptom:

```
--- FAIL: TestRenderSystemdUnitAllowsInterfaceEnumeration
    --local-address cannot resolve without AF_NETLINK:
    RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
```

`go test ./...` 27 packages ok, `go vet` clean, `staticcheck -checks=all,-U1000` clean, gosec baseline `accepted 134 reviewed findings in 46 buckets`, `sh -n deploy/install-server.sh` clean.

Changelog entries go in `changelog.d/` per CONTRIBUTING; `CHANGELOG.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Juuoq98WrCgQJ5XXF6jQS9