### PR TITLE
test: take the shared test port from the allocator that was refusing it

### DIFF
--- a/internal/pep/integration_test.go
+++ b/internal/pep/integration_test.go
@@ -334,15 +334,24 @@ func mustUDPAddr(t *testing.T, address string) *net.UDPAddr {
 	return addr
 }
 
+// The port is chosen by the UDP allocator, and TCP is bound onto it -- not the
+// other way around. Windows reserves contiguous excluded port ranges at boot,
+// Hyper-V and WinNAT among them, and a bind inside one fails with WSAEACCES
+// even though nothing holds the port. Asking TCP for an ephemeral port and then
+// forcing UDP onto that number walked into them: the ephemeral allocator hands
+// out ports close to sequentially, so all twenty retries landed in the same
+// excluded band and every one of them failed. A :0 UDP bind never returns a
+// UDP-excluded port, so the side that was failing now cannot, and a retry gets
+// a fresh kernel-chosen port rather than the next number up.
 func listenTCPAndUDPOnOnePort(t *testing.T) (net.Listener, net.PacketConn) {
 	t.Helper()
 	var lastErr error
 	for range 20 {
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		packetConn, err := net.ListenPacket("udp", "127.0.0.1:0")
 		if err != nil {
 			t.Fatal(err)
 		}
-		packetConn, err := net.ListenPacket("udp", listener.Addr().String())
+		listener, err := net.Listen("tcp", packetConn.LocalAddr().String())
 		if err == nil {
 			t.Cleanup(func() {
 				_ = packetConn.Close()
@@ -351,7 +360,7 @@ func listenTCPAndUDPOnOnePort(t *testing.T) (net.Listener, net.PacketConn) {
 			return listener, packetConn
 		}
 		lastErr = err
-		_ = listener.Close()
+		_ = packetConn.Close()
 	}
 	t.Fatalf("could not reserve one TCP/UDP test port: %v", lastErr)
 	return nil, nil


### PR DESCRIPTION
## The flake

The Windows arm64 runner failed **six** `internal/pep` tests at once on #45 — a **Markdown-only** commit:

```
--- FAIL: TestPooledFlowsRecoverThroughOneReplacementGeneration/quic
    pool_recovery_test.go:40: could not reserve one TCP/UDP test port:
      listen udp 127.0.0.1:59584: bind: An attempt was made to access a socket
      in a way forbidden by its access permissions.
```

Same `WSAEACCES` for all six, on ports **59584, 59605, 59626, 59634, 59654, 59655** — a ~70-port spread. `windows-11-arm` passed the previous 8 runs, including current `main`.

## Why the retries could not save it

Windows reserves **contiguous excluded port ranges** at boot (Hyper-V, WinNAT). A bind inside one fails with `WSAEACCES` even though nothing holds the port.

`listenTCPAndUDPOnOnePort` asked **TCP** for an ephemeral port, then forced **UDP** onto that number:

```go
listener, _ := net.Listen("tcp", "127.0.0.1:0")                        // OS picks N
packetConn, err := net.ListenPacket("udp", listener.Addr().String())   // bind UDP on N  <-- fails
```

It retried 20 times, but the ephemeral allocator hands out ports close to **sequentially**, so all 20 attempts landed in the *same* excluded band. That is exactly the narrow spread above. A runner that boots without an exclusion over the ephemeral range passes; one that boots with it fails all six. Hence 8 green, then 1 red, with no code change between.

## The fix

Take the port from the **UDP** allocator and bind TCP onto it. A `:0` UDP bind never returns a UDP-excluded port, so the side that was failing now cannot — and each retry starts from a fresh kernel-chosen port rather than the next number up.

## Why not delete the tests

They cover UDP rescue, QUIC→TCP fallback, and pooled-flow recovery on the platform where the **ICMP port-unreachable bug in v0.1.0** was found — a bug that a Windows CI runner caught and nothing else did. Nothing about what they assert was ever unreliable; only the shared port helper was.

## Checks

```
go test -short ./internal/pep/ -count=3 -run '<the six that failed>'   # ok
go test -short -timeout 20m ./internal/pep/                            # ok
go test -short -timeout 20m ./...                                      # all packages ok
go vet ./internal/pep/ ; gofmt -l internal/pep/                        # clean
```

The failure is Windows-only and cannot be reproduced on macOS or Linux, so the proof is CI on this PR.

Test-only, so no `changelog.d/` entry. Worth landing **before** the v0.2.0 candidate: `release-candidate.yml`'s `native-test` job also runs Windows, and the same flake would fail the candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2