### PR TITLE
release: record the two fixes that landed after v0.2.0 was cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,20 @@ to `changelog.d/` instead, as [`CONTRIBUTING.md`](CONTRIBUTING.md) describes.
   :443` the guide recommends could not bind: the capability has to be granted
   at exec because nothing may acquire it afterwards. The capability bounding
   set is now that one capability rather than the full set.
+- The installed Linux client service can resolve `--local-address` again. The
+  generated systemd user unit allowed only `AF_INET`, `AF_INET6`, and
+  `AF_UNIX`, but reading this machine's interfaces needs `AF_NETLINK`:
+  `if:NAME` looks up the named interface's address, and `auto` has to know
+  whether the choice is ambiguous. Without it the unit installed, the SOCKS5
+  listener bound, systemd reported the service active, and every flow then
+  failed with `enumerate local interfaces: netlinkrib: address family not
+  supported by protocol`. The option this broke is the one the installer
+  recommends when `auto` cannot decide between two uplinks.
+- `deploy/install-server.sh` waits for the gateway's listener instead of
+  looking for it once. `Type=simple` reports a service active as soon as its
+  process is forked, so the check ran before the socket was bound and a
+  successful upgrade of a live gateway exited non-zero claiming nothing was
+  listening on a port that was serving traffic seconds later.
 
 ## v0.1.1 - 2026-08-21
 

--- a/changelog.d/client-unit-interface-enumeration.fixed.md
+++ b/changelog.d/client-unit-interface-enumeration.fixed.md
@@ -1,9 +1,0 @@
-The installed Linux client service can resolve `--local-address` again. The
-generated systemd user unit allowed only `AF_INET`, `AF_INET6`, and
-`AF_UNIX`, but reading this machine's interfaces needs `AF_NETLINK`:
-`if:NAME` looks up the named interface's address, and `auto` has to know
-whether the choice is ambiguous. Without it the unit installed, the SOCKS5
-listener bound, systemd reported the service active, and every flow then
-failed with `enumerate local interfaces: netlinkrib: address family not
-supported by protocol`. The option this broke is the one the installer
-recommends when `auto` cannot decide between two uplinks.

--- a/changelog.d/install-server-listener-wait.fixed.md
+++ b/changelog.d/install-server-listener-wait.fixed.md
@@ -1,5 +1,0 @@
-`deploy/install-server.sh` waits for the gateway's listener instead of
-looking for it once. `Type=simple` reports a service active as soon as its
-process is forked, so the check ran before the socket was bound and a
-successful upgrade of a live gateway exited non-zero claiming nothing was
-listening on a port that was serving traffic seconds later.

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -172,6 +172,70 @@ def render_section(heading: str, fragments: list[Fragment]) -> list[str]:
     return lines
 
 
+def amend_section(text: str, version: str, fragments: list[Fragment]) -> str | None:
+    """Fold late entries into a section that is cut but not yet tagged.
+
+    Entries keep landing between the release commit and the tag. Without this
+    they stay pending and the release ships changes it does not record, which is
+    how v0.1.1 shipped with no notes at all.
+    """
+    lines = text.split("\n")
+    start = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if (m := VERSION_HEADING.match(line)) and m.group("version") == version
+        ),
+        None,
+    )
+    if start is None:
+        return None
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+    section = lines[start:end]
+    for category in CATEGORIES:
+        chosen = sorted(
+            (f for f in fragments if f.category == category), key=lambda f: f.slug
+        )
+        if not chosen:
+            continue
+        bullets: list[str] = []
+        for fragment in chosen:
+            bullets.extend(fragment.bullet())
+        heading = f"### {HEADINGS[category]}"
+        if heading in section:
+            # Append to the list that is already there; the entries above it
+            # were released together and are not re-sorted around.
+            at = section.index(heading) + 1
+            at = next(
+                (i for i in range(at, len(section)) if section[i].startswith("### ")),
+                len(section),
+            )
+            while at > 0 and section[at - 1] == "":
+                at -= 1
+            section[at:at] = bullets
+            continue
+        later = {HEADINGS[c] for c in CATEGORIES[CATEGORIES.index(category) + 1 :]}
+        at = next(
+            (
+                i
+                for i, line in enumerate(section)
+                if line.startswith("### ") and line[4:] in later
+            ),
+            None,
+        )
+        if at is None:
+            at = len(section)
+            while at > 0 and section[at - 1] == "":
+                at -= 1
+            section[at:at] = [""] + [heading, ""] + bullets
+        else:
+            section[at:at] = [heading, ""] + bullets + [""]
+    return "\n".join(lines[:start] + section + lines[end:])
+
+
 def insert_section(text: str, section: list[str]) -> str:
     """Insert above the newest released section, leaving released bytes alone."""
     lines = text.split("\n")
@@ -235,12 +299,25 @@ def command_release(args: argparse.Namespace) -> int:
     if report(problems):
         return 1
     text = changelog.read_text(encoding="utf-8")
-    for line in text.split("\n"):
-        match = VERSION_HEADING.match(line)
-        if match and match.group("version") == args.version:
-            return report([f"{changelog}: {args.version} is already released"])
-    section = render_section(f"## {args.version} - {date}", fragments)
-    changelog.write_text(insert_section(text, section), encoding="utf-8")
+    present = any(
+        (match := VERSION_HEADING.match(line)) and match.group("version") == args.version
+        for line in text.split("\n")
+    )
+    if present and not args.amend:
+        return report(
+            [
+                f"{changelog}: {args.version} is already released; --amend folds "
+                "these entries into it"
+            ]
+        )
+    if args.amend:
+        amended = amend_section(text, args.version, fragments)
+        if amended is None:
+            return report([f"{changelog}: {args.version} has no section to amend"])
+        changelog.write_text(amended, encoding="utf-8")
+    else:
+        section = render_section(f"## {args.version} - {date}", fragments)
+        changelog.write_text(insert_section(text, section), encoding="utf-8")
     for fragment in fragments:
         fragment.path.unlink()
     print(f"{changelog}: added {args.version} - {date}")
@@ -314,6 +391,11 @@ def main(argv: list[str] | None = None) -> int:
     release.add_argument("--date", help="release date, default today in UTC")
     release.add_argument(
         "--allow-empty", action="store_true", help="release with no pending changes"
+    )
+    release.add_argument(
+        "--amend",
+        action="store_true",
+        help="fold entries into an existing section not yet tagged",
     )
     release.set_defaults(handler=command_release)
 

--- a/scripts/test_changelog.py
+++ b/scripts/test_changelog.py
@@ -138,11 +138,60 @@ class ChangelogTests(unittest.TestCase):
             sorted(p.name for p in (self.root / "changelog.d").iterdir()), []
         )
 
+    def test_amend_appends_to_an_existing_category(self):
+        self.fragment("late.added.md", "Landed after the cut.\n")
+        result = self.run_tool("release", "--version", "v0.1.0", "--amend")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            "### Added\n\n- Something that already shipped.\n- Landed after the cut.\n",
+            self.changelog.read_text(encoding="utf-8"),
+        )
+        self.assertEqual(
+            sorted(p.name for p in (self.root / "changelog.d").iterdir()), []
+        )
+
+    def test_amend_creates_a_category_in_order(self):
+        self.fragment("late.fixed.md", "A late fix.\n")
+        result = self.run_tool("release", "--version", "v0.1.0", "--amend")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        text = self.changelog.read_text(encoding="utf-8")
+        self.assertIn(
+            "- Something that already shipped.\n\n### Fixed\n\n- A late fix.\n", text
+        )
+        self.assertLess(text.index("### Added"), text.index("### Fixed"))
+
+    def test_amend_puts_a_new_category_before_a_later_one(self):
+        self.changelog.write_text(
+            HEADER + "## v0.1.0 - 2026-08-19\n\n### Fixed\n\n- Shipped fix.\n\n",
+            encoding="utf-8",
+        )
+        self.fragment("late.added.md", "A late addition.\n")
+        result = self.run_tool("release", "--version", "v0.1.0", "--amend")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        text = self.changelog.read_text(encoding="utf-8")
+        self.assertLess(text.index("### Added"), text.index("### Fixed"))
+        self.assertIn("### Added\n\n- A late addition.\n\n### Fixed", text)
+
+    def test_amend_leaves_other_sections_alone(self):
+        older = "## v0.0.9 - 2026-08-01\n\n### Fixed\n\n- Older.\n\n"
+        self.changelog.write_text(HEADER + RELEASED + older, encoding="utf-8")
+        self.fragment("late.added.md", "Landed after the cut.\n")
+        result = self.run_tool("release", "--version", "v0.1.0", "--amend")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(older, self.changelog.read_text(encoding="utf-8"))
+
+    def test_amend_refuses_an_absent_version(self):
+        self.fragment("late.added.md", "Body.\n")
+        result = self.run_tool("release", "--version", "v0.9.9", "--amend")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("no section to amend", result.stderr)
+        self.assertTrue((self.root / "changelog.d" / "late.added.md").exists())
+
     def test_release_refuses_a_released_version(self):
         self.fragment("a-fix.fixed.md", "Body.\n")
         result = self.run_tool("release", "--version", "v0.1.0")
         self.assertEqual(result.returncode, 1)
-        self.assertIn("already released", result.stderr)
+        self.assertIn("--amend", result.stderr)
         self.assertTrue((self.root / "changelog.d" / "a-fix.fixed.md").exists())
 
     def test_release_refuses_an_empty_pending_set(self):


### PR DESCRIPTION
## Blocks the v0.2.0 tag

#42, #46, and 522caa3 merged **between** the release commit and the tag. Two carried `changelog.d/` entries, which stayed pending — so `main` right now contains both fixes and records neither.

That is the v0.1.1 failure arriving through a different door: a release that ships changes its notes do not mention.

Both belong in v0.2.0, not after it — they fix the installer scripts and the generated client unit, which is the feature this release exists to ship:

- **`client-unit-interface-enumeration`** — the generated systemd user unit allowed only `AF_INET`/`AF_INET6`/`AF_UNIX`, but enumerating interfaces needs `AF_NETLINK`. The unit installed, the listener bound, systemd reported *active*, and every flow then failed with `netlinkrib: address family not supported by protocol` — on `--local-address`, the option the installer itself recommends when `auto` can't pick between two uplinks.
- **`install-server-listener-wait`** — `Type=simple` reports active as soon as the process forks, so the check ran before the socket was bound and a successful upgrade of a live gateway exited non-zero claiming nothing was listening.

## `changelog.py release --amend`

The window is structural, not a slip: the release commit must name its own version for the download-link check, so it is written before the tag, and anything merging in between is silently dropped from the release it is part of.

`--amend` folds pending entries into a section that is cut but not yet tagged. It appends to the categories already present without re-sorting the entries around them, inserts a missing category in Keep a Changelog order, and refuses a version with no section.

## Checks

```
python3 -m unittest discover -s scripts -p 'test_*.py'   # 85 passed (5 new for --amend)
./scripts/changelog.py check                             # 0 pending, well formed
```

Labeled `changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2