### PR TITLE
fix: make two release checks report what they actually know

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,26 @@ jobs:
           NUMBER: ${{ github.event.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet "origin/${BASE_REF}...HEAD" -- CHANGELOG.md; then
+          # "I cannot compare" is not "you edited it". Saying so cost an hour
+          # once already: a pull request whose base branch had been deleted
+          # failed this step reporting a changelog edit it had not made.
+          base="origin/${BASE_REF}"
+          if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+            echo "Cannot resolve ${base}, so this check cannot tell whether"
+            echo "CHANGELOG.md was edited. That is a checkout or base-branch"
+            echo "problem rather than a changelog one: the base branch may have"
+            echo "been deleted or renamed while this pull request was open."
+            exit 1
+          fi
+          changed=0
+          git diff --quiet "${base}...HEAD" -- CHANGELOG.md || changed=$?
+          if [ "$changed" -eq 0 ]; then
             exit 0
+          fi
+          if [ "$changed" -ne 1 ]; then
+            echo "git diff against ${base} failed with status ${changed}, so"
+            echo "whether CHANGELOG.md was edited is unknown."
+            exit 1
           fi
           # Read the label from the API rather than from the event payload,
           # which is a snapshot taken when the pull request was opened. Adding

--- a/scripts/sign_macos_release.sh
+++ b/scripts/sign_macos_release.sh
@@ -42,6 +42,12 @@ test -d "$dist" || { echo "no such dist directory: $dist" >&2; exit 1; }
 : "${APPLE_API_KEY_ID:?App Store Connect key ID is required}"
 : "${APPLE_API_ISSUER_ID:?App Store Connect issuer ID is required}"
 
+# How long to wait for an accepted ticket to become resolvable. See the poll
+# below for why this is not zero. Overridable so a run can be made stricter or
+# more patient without editing the script.
+ticket_attempts=${QUEQIAO_TICKET_ATTEMPTS:-20}
+ticket_interval=${QUEQIAO_TICKET_INTERVAL:-15}
+
 work=$(mktemp -d)
 keychain="$work/queqiao-signing.keychain-db"
 keychain_password=$(uuidgen)
@@ -147,13 +153,41 @@ for arch in amd64 arm64; do
     # "Notarized Developer ID" only once Apple's ticket resolves for this exact
     # cdhash, and "Unnotarized Developer ID" for a correctly signed binary that
     # was never submitted.
+    #
+    # This is polled rather than asked once. Because the ticket for a bare
+    # executable is resolved online rather than stapled, notarytool returning
+    # Accepted means Apple recorded the ticket, not that the service answering
+    # Gatekeeper has caught up. v0.2.0 failed here three seconds after an
+    # accepted submission and then passed on a re-run that changed nothing but
+    # the clock, which makes every release a coin flip on a step that says
+    # nothing about whether the build is good.
+    #
+    # "Unnotarized Developer ID" is the one verdict worth waiting on: it means
+    # the signature is valid and only the ticket is missing. Any other verdict
+    # is a real signing failure and fails immediately instead of after the wait.
+    #
     # spctl exits non-zero on a rejected assessment, so its status is captured
     # rather than allowed to abort the script before the reason is reported.
-    spctl --assess --type open --context context:primary-signature -vvv \
-        "$stage/queqiaod" > "$work/spctl-$arch.txt" 2>&1 || true
+    resolved=
+    attempt=1
+    while :; do
+        spctl --assess --type open --context context:primary-signature -vvv \
+            "$stage/queqiaod" > "$work/spctl-$arch.txt" 2>&1 || true
+        if grep -qx 'source=Notarized Developer ID' "$work/spctl-$arch.txt"; then
+            resolved=yes
+            break
+        fi
+        grep -qx 'source=Unnotarized Developer ID' "$work/spctl-$arch.txt" || break
+        test "$attempt" -lt "$ticket_attempts" || break
+        echo "ticket for $base is accepted but not resolvable yet;" \
+            "retrying in ${ticket_interval}s ($attempt/$ticket_attempts)"
+        sleep "$ticket_interval"
+        attempt=$((attempt + 1))
+    done
     cat "$work/spctl-$arch.txt"
-    grep -qx 'source=Notarized Developer ID' "$work/spctl-$arch.txt" || {
-        echo "notarization ticket did not resolve for $base" >&2
+    test -n "$resolved" || {
+        echo "notarization ticket did not resolve for $base after" \
+            "$attempt attempt(s) over $((attempt * ticket_interval))s" >&2
         exit 1
     }
 done


### PR DESCRIPTION
Both checks failed on something other than what they were testing, and both said the wrong thing about why.

## 1. macOS notarization was a coin flip

`macos-signing` failed the v0.2.0 release **three seconds after Apple accepted the notarization**:

```
Current status: Accepted.....Processing complete
  id: 95fa222a-de9c-4883-8a9e-867687bed340
  status: Accepted
...
queqiaod: rejected
source=Unnotarized Developer ID
notarization ticket did not resolve for queqiaod_v0.2.0_darwin_amd64
```

It then passed on a re-run that changed nothing but the clock.

A bare Mach-O cannot carry a stapled ticket — stapling is defined for `.app`, `.dmg`, `.pkg`, `.kext`, as this script's own header says — so Gatekeeper resolves the ticket **online**. `notarytool --wait` returning `Accepted` means Apple *recorded* the ticket, not that the service answering `spctl` has caught up. Asking once made every release a coin flip on a step that says nothing about whether the build is good.

It now **polls** for the ticket: 20 attempts, 15s apart, overridable via `QUEQIAO_TICKET_ATTEMPTS` / `QUEQIAO_TICKET_INTERVAL`.

`Unnotarized Developer ID` is the one verdict worth waiting on — the signature is valid and only the ticket is missing. **Any other verdict is a real signing failure and still fails on the first assessment**, not after five minutes of pointless waiting.

Verified against a scripted `spctl`:

| scenario | result |
|---|---|
| ticket propagates on 3rd poll (the v0.2.0 case) | resolved, 3 calls |
| never propagates | bounded failure at 4/4, no hang |
| genuinely bad signature | fails on call 1, no waiting |

## 2. The changelog guard could not tell "changed" from "cannot compare"

`git diff --quiet` exits non-zero both for a difference *and* for an unresolvable ref, and the step treated both as the first. #44 — whose base branch was deleted while it was open — failed claiming a changelog edit it had not made, and no re-run could have cleared it.

The base ref is now verified before the comparison, and a diff status other than 0 or 1 is reported as *not knowing* rather than as a verdict.

## Checks

```
python3 -m unittest discover -s scripts -p 'test_*.py'   # 85 passed
./scripts/changelog.py check                             # 0 pending, well formed
bash -n scripts/sign_macos_release.sh                    # ok
actionlint .github/workflows/ci.yml                      # nothing beyond pre-existing runner labels
```

The notarization path can only be exercised by a real release; the poll logic is verified against fakes above.

Release and CI tooling only, so no `changelog.d/` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hx4Trw9REnLDb2dBumqNu2