### PR TITLE
fix: recover stale QUIC paths without restart

### DIFF
--- a/changelog.d/recover-stale-quic-udp-associations.fixed.md
+++ b/changelog.d/recover-stale-quic-udp-associations.fixed.md
@@ -1,2 +1,3 @@
-Recover UDP associations after a pooled QUIC stream stops making progress,
-instead of repeatedly reusing the stale connection until the client restarts.
+Recover UDP associations after a pooled QUIC stream stops making progress, and
+replace connections bound to a DHCP address which disappeared after a network
+change, instead of leaving either path stalled until the client restarts.

--- a/changelog.d/recover-stale-quic-udp-associations.fixed.md
+++ b/changelog.d/recover-stale-quic-udp-associations.fixed.md
@@ -1,0 +1,2 @@
+Recover UDP associations after a pooled QUIC stream stops making progress,
+instead of repeatedly reusing the stale connection until the client restarts.

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -1707,10 +1707,26 @@ type controlPoolStreamConn struct {
 	once       sync.Once
 }
 
-func (s *controlPoolStreamConn) transportFailed(error) {
-	if s.generation != nil && s.generation.conn.Context().Err() != nil {
+func (s *controlPoolStreamConn) transportFailed(err error) {
+	if s.generation == nil {
+		return
+	}
+	// A QUIC connection can remain superficially open after one of its streams
+	// has stopped making progress. In that state Context().Err() is still nil,
+	// so keeping the generation makes every later flow reuse the same poisoned
+	// pool. A real I/O timeout is sufficient evidence to retire the generation;
+	// ordinary per-stream EOFs and application closes must not evict it.
+	if s.generation.conn.Context().Err() != nil || pooledTransportTimedOut(err) {
 		s.owner.retireControlQUICGeneration(s.generation, "queqiao pooled connection failed")
 	}
+}
+
+func pooledTransportTimedOut(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var timeout interface{ Timeout() bool }
+	return errors.As(err, &timeout) && timeout.Timeout()
 }
 
 func (s *controlPoolStreamConn) Close() error {

--- a/internal/pep/pool_recovery_test.go
+++ b/internal/pep/pool_recovery_test.go
@@ -375,6 +375,99 @@ func TestControlPoolDialOwnershipAndGenerationGuards(t *testing.T) {
 	}
 }
 
+func TestTimedOutControlStreamRetiresItsQUICGeneration(t *testing.T) {
+	certificate, roots := testCertificate(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	packetConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer packetConn.Close()
+	server, err := NewServer(ServerConfig{
+		ListenAddr: packetConn.LocalAddr().String(), Credentials: certificate,
+		DestinationPolicy: DestinationPolicy{AllowPrivate: true},
+		EnableQUIC:        true, Logger: logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- server.ServePacketConn(ctx, packetConn) }()
+
+	var sockets atomic.Int64
+	client, err := NewClient(ClientConfig{
+		ListenAddr: "127.0.0.1:0", RemoteAddr: packetConn.LocalAddr().String(),
+		LocalAddress: "127.0.0.1", Credentials: roots,
+		Transport: TransportQUIC, EnableQUICPool: true,
+		DialTimeout: 2 * time.Second, HandshakeTimeout: 2 * time.Second,
+		Logger: logger,
+		SocketControl: func(network, _ string, _ syscall.RawConn) error {
+			if strings.HasPrefix(network, "udp") {
+				sockets.Add(1)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := client.dialPooledQUICLane(ctx, congestionConfig{kind: defaultCongestion()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPooled, ok := first.(*controlPoolStreamConn)
+	if !ok {
+		t.Fatalf("pooled lane type = %T", first)
+	}
+	firstGeneration := firstPooled.generation
+	firstPooled.transportFailed(io.EOF)
+	client.quicMu.Lock()
+	afterEOF := client.quicGeneration
+	client.quicMu.Unlock()
+	if afterEOF != firstGeneration {
+		t.Fatal("ordinary stream EOF retired a healthy pooled generation")
+	}
+
+	firstPooled.transportFailed(context.DeadlineExceeded)
+	client.quicMu.Lock()
+	afterTimeout := client.quicGeneration
+	client.quicMu.Unlock()
+	if afterTimeout != nil {
+		t.Fatal("timed-out stream left its pooled generation reusable")
+	}
+	_ = first.Close()
+
+	second, err := client.dialPooledQUICLane(ctx, congestionConfig{kind: defaultCongestion()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	secondPooled, ok := second.(*controlPoolStreamConn)
+	if !ok {
+		t.Fatalf("replacement pooled lane type = %T", second)
+	}
+	if secondPooled.generation == firstGeneration {
+		t.Fatal("next lane reused the timed-out QUIC generation")
+	}
+	if got := sockets.Load(); got != 2 {
+		t.Fatalf("UDP sockets = %d, want one replacement generation", got)
+	}
+
+	client.closeQUICPool()
+	cancel()
+	select {
+	case serveErr := <-serverErr:
+		if serveErr != nil && !errors.Is(serveErr, net.ErrClosed) {
+			t.Fatalf("server shutdown: %v", serveErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("server shutdown timeout")
+	}
+}
+
 func TestCancelledWaiterDoesNotStartAControlPoolDial(t *testing.T) {
 	_, roots := testCertificate(t)
 	var sockets atomic.Int64

--- a/internal/pep/sockerr_other.go
+++ b/internal/pep/sockerr_other.go
@@ -23,9 +23,14 @@ func unreachableRouteErrno(err error) bool {
 // transientRouteWriteErrno reports the codes a local send returns while the
 // route is momentarily absent -- changing networks, a link flapping, or the
 // send queue briefly full. The socket outlives all of them.
+//
+// EADDRNOTAVAIL is deliberately absent. It means the source address a bound
+// socket owns has disappeared, as happens after DHCP assigns a different
+// address on a new Wi-Fi network. That socket cannot adopt the replacement
+// address, so hiding the error would keep QUIC retransmitting forever on a
+// path which cannot send.
 func transientRouteWriteErrno(err error) bool {
 	return unreachableRouteErrno(err) ||
-		errors.Is(err, syscall.EADDRNOTAVAIL) ||
 		errors.Is(err, syscall.ENOBUFS)
 }
 

--- a/internal/pep/sockerr_samples_other_test.go
+++ b/internal/pep/sockerr_samples_other_test.go
@@ -11,9 +11,9 @@ var (
 		{"network unreachable", syscall.ENETUNREACH},
 		{"host down", syscall.EHOSTDOWN},
 		{"host unreachable", syscall.EHOSTUNREACH},
-		{"source address gone", syscall.EADDRNOTAVAIL},
 		{"send queue full", syscall.ENOBUFS},
 	}
+	staleSourceWriteSample  = errnoSample{"source address gone", syscall.EADDRNOTAVAIL}
 	unreachableRouteSamples = []errnoSample{
 		{"network down", syscall.ENETDOWN},
 		{"network unreachable", syscall.ENETUNREACH},

--- a/internal/pep/sockerr_samples_windows_test.go
+++ b/internal/pep/sockerr_samples_windows_test.go
@@ -14,9 +14,9 @@ var (
 		{"network unreachable", windows.WSAENETUNREACH},
 		{"host down", windows.WSAEHOSTDOWN},
 		{"host unreachable", windows.WSAEHOSTUNREACH},
-		{"source address gone", windows.WSAEADDRNOTAVAIL},
 		{"send queue full", windows.WSAENOBUFS},
 	}
+	staleSourceWriteSample  = errnoSample{"source address gone", windows.WSAEADDRNOTAVAIL}
 	unreachableRouteSamples = []errnoSample{
 		{"network down", windows.WSAENETDOWN},
 		{"network unreachable", windows.WSAENETUNREACH},

--- a/internal/pep/sockerr_test.go
+++ b/internal/pep/sockerr_test.go
@@ -84,14 +84,14 @@ func TestTheCodesTheHostActuallyReportsAreClassified(t *testing.T) {
 		accepts func(error) bool
 	}{
 		{
-			// Binding to an address this host does not hold is the one route
+			// Binding to an address this host does not hold is the one source
 			// error a test can provoke without touching the machine's network
-			// configuration. It is in transientRouteWriteError's set because a
-			// source address vanishing mid-connection is exactly what a
-			// network change looks like to a socket.
+			// configuration. A socket bound to an address which vanished cannot
+			// adopt the replacement address, so this must remain fatal instead
+			// of being disguised as one lost datagram.
 			what:    "a source address this host does not hold",
 			draw:    bindToAnAddressThisHostDoesNotHold,
-			accepts: transientRouteWriteError,
+			accepts: func(err error) bool { return !transientRouteWriteError(err) },
 		},
 		{
 			// A write to a socket whose peer has gone reports the local

--- a/internal/pep/sockerr_windows.go
+++ b/internal/pep/sockerr_windows.go
@@ -44,7 +44,6 @@ func unreachableRouteErrno(err error) bool {
 
 func transientRouteWriteErrno(err error) bool {
 	return unreachableRouteErrno(err) ||
-		errors.Is(err, windows.WSAEADDRNOTAVAIL) ||
 		errors.Is(err, windows.WSAENOBUFS)
 }
 

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -583,9 +583,12 @@ func dialQUIC(ctx context.Context, remote string, credentials identity.ClientCre
 // after the route returns. The negotiated idle timeout remains the finite
 // bound for a path that does not return.
 //
-// The wrapper deliberately recognizes only local availability and buffer
-// errors. Permission, descriptor, message-size and peer/protocol errors still
-// reach quic-go and close the unusable transport.
+// The wrapper deliberately recognizes only errors a socket can outlive.
+// EADDRNOTAVAIL / WSAEADDRNOTAVAIL reaches quic-go: a socket explicitly bound
+// to a DHCP address which disappeared cannot migrate to its replacement, and
+// pretending its writes succeeded leaves every stream on it stalled until a
+// process restart. Permission, descriptor, message-size and peer/protocol
+// errors likewise close the unusable transport.
 type transientRoutePacketConn struct {
 	net.PacketConn
 	observe func(error)

--- a/internal/pep/transport_test.go
+++ b/internal/pep/transport_test.go
@@ -35,18 +35,26 @@ type routeErrorOOBConn struct {
 type switchableRouteConn struct {
 	*net.UDPConn
 	failing atomic.Bool
+	err     error
+}
+
+func (c *switchableRouteConn) failure() error {
+	if c.err != nil {
+		return c.err
+	}
+	return injectedRouteError
 }
 
 func (c *switchableRouteConn) WriteTo(payload []byte, addr net.Addr) (int, error) {
 	if c.failing.Load() {
-		return 0, injectedRouteError
+		return 0, c.failure()
 	}
 	return c.UDPConn.WriteTo(payload, addr)
 }
 
 func (c *switchableRouteConn) WriteMsgUDP(payload, oob []byte, addr *net.UDPAddr) (int, int, error) {
 	if c.failing.Load() {
-		return 0, 0, injectedRouteError
+		return 0, 0, c.failure()
 	}
 	return c.UDPConn.WriteMsgUDP(payload, oob, addr)
 }
@@ -84,6 +92,18 @@ func TestPermanentUDPSocketErrorsRemainFatal(t *testing.T) {
 	conn := tolerateTransientRouteErrors(&routeErrorPacketConn{err: want}, nil)
 	if _, err := conn.WriteTo([]byte("packet"), &net.UDPAddr{}); !errors.Is(err, permanentSocketError) {
 		t.Fatalf("permanent socket error = %v, want %v", err, permanentSocketError)
+	}
+}
+
+func TestVanishedSourceAddressRemainsFatal(t *testing.T) {
+	want := &net.OpError{Op: "write", Net: "udp", Err: staleSourceWriteSample.err}
+	observed := 0
+	conn := tolerateTransientRouteErrors(&routeErrorPacketConn{err: want}, func(error) { observed++ })
+	if _, err := conn.WriteTo([]byte("packet"), &net.UDPAddr{}); !errors.Is(err, staleSourceWriteSample.err) {
+		t.Fatalf("vanished source write = %v, want %v", err, staleSourceWriteSample.err)
+	}
+	if observed != 0 {
+		t.Fatalf("vanished source was reported as transient %d times", observed)
 	}
 }
 
@@ -196,6 +216,70 @@ func TestQUICConnectionSurvivesATransientLocalRouteOutage(t *testing.T) {
 	}
 	if err := conn.Context().Err(); err != nil {
 		t.Fatalf("transient route outage closed QUIC connection: %v", err)
+	}
+}
+
+func TestQUICConnectionClosesWhenItsBoundSourceDisappears(t *testing.T) {
+	serverCredentials, clientCredentials := testCertificate(t)
+	serverTLS, err := identity.ServerTLSConfig(serverCredentials, defaultALPN, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTLS, err := tlsClientConfig(clientCredentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverPacket, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverPacket.Close()
+	listener, err := quic.Listen(serverPacket, serverTLS, quicConfig(flowWindows{}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		conn, acceptErr := listener.Accept(ctx)
+		if acceptErr != nil {
+			return
+		}
+		stream, acceptErr := conn.AcceptStream(ctx)
+		if acceptErr == nil {
+			var one [1]byte
+			_, _ = stream.Read(one[:])
+		}
+	}()
+
+	udp, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	faults := &switchableRouteConn{UDPConn: udp, err: staleSourceWriteSample.err}
+	packet := tolerateTransientRouteErrors(faults, nil)
+	remote := serverPacket.LocalAddr().(*net.UDPAddr)
+	conn, err := quic.Dial(ctx, packet, remote, clientTLS, quicConfig(flowWindows{}))
+	if err != nil {
+		_ = packet.Close()
+		t.Fatal(err)
+	}
+	defer packet.Close()
+	stream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	faults.failing.Store(true)
+	_, _ = stream.Write(make([]byte, 64*1024))
+	select {
+	case <-conn.Context().Done():
+		if conn.Context().Err() == nil {
+			t.Fatal("closed connection has no terminal error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("QUIC kept a connection whose bound source address disappeared")
 	}
 }
 

--- a/internal/pep/udp.go
+++ b/internal/pep/udp.go
@@ -400,18 +400,44 @@ type udpAssociation struct {
 	token  []byte
 }
 
+type udpAssociationOpenTransportError struct {
+	operation string
+	err       error
+}
+
+func (e *udpAssociationOpenTransportError) Error() string {
+	return e.operation + ": " + e.err.Error()
+}
+
+func (e *udpAssociationOpenTransportError) Unwrap() error { return e.err }
+
 func (c *Client) openUDPAssociation(ctx context.Context, resume []byte) (*udpAssociation, error) {
-	return c.openUDPAssociationMode(ctx, resume, false, false)
+	association, err := c.openUDPAssociationMode(ctx, resume, false, false)
+	if err == nil || ctx.Err() != nil {
+		return association, err
+	}
+	var transportErr *udpAssociationOpenTransportError
+	if !errors.As(err, &transportErr) {
+		return nil, err
+	}
+	// The first failure has already retired a timed-out pooled QUIC
+	// generation. AUTO uses its authenticated TCP path for this one bounded
+	// retry, while later associations are free to establish a fresh QUIC pool.
+	retry, retryErr := c.openUDPAssociationMode(ctx, resume, true, false)
+	if retryErr != nil {
+		return nil, fmt.Errorf("UDP association open failed (%v); fast retry failed: %w", err, retryErr)
+	}
+	return retry, nil
 }
 
 func (c *Client) openUDPAssociationMode(ctx context.Context, resume []byte, fastRetry, rescue bool) (*udpAssociation, error) {
 	var lane *authenticatedLane
 	var err error
-	if rescue && c.cfg.Transport == TransportAuto {
+	if (fastRetry || rescue) && c.cfg.Transport == TransportAuto {
 		// An established association already failed. Waiting for another QUIC
-		// dial proves nothing about the endpoint and can exceed the preserved
-		// SOCKS datagram's useful lifetime, so recover this flow over the warm
-		// standby transport without changing global UDP health.
+		// dial -- or retrying a just-failed association on the same path -- can
+		// exceed the preserved SOCKS datagram's useful lifetime, so recover this
+		// flow over the warm standby transport without changing global UDP health.
 		c.metrics.Fallback()
 		lane, err = c.dialAuthenticatedCandidate(ctx, TransportTCP)
 	} else {
@@ -436,13 +462,11 @@ func (c *Client) openUDPAssociationMode(ctx context.Context, resume []byte, fast
 		Version: protocol.Version, Type: protocol.TypeOpen, SessionID: lane.sessionID,
 		FlowID: flowID, Class: protocol.ClassInteractive,
 	}, Payload: payload}); err != nil {
-		_ = lane.fc.Close()
-		return nil, fmt.Errorf("send UDP association open: %w", err)
+		return nil, failUDPAssociationOpenLane(lane, "send UDP association open", err)
 	}
 	response, err := lane.fc.Read()
 	if err != nil {
-		_ = lane.fc.Close()
-		return nil, fmt.Errorf("read UDP association acknowledgement: %w", err)
+		return nil, failUDPAssociationOpenLane(lane, "read UDP association acknowledgement", err)
 	}
 	if response.Header.SessionID != lane.sessionID || response.Header.FlowID != flowID {
 		_ = lane.fc.Close()
@@ -471,6 +495,17 @@ func (c *Client) openUDPAssociationMode(ctx context.Context, resume []byte, fast
 	}
 	_ = lane.outer.SetDeadline(time.Time{})
 	return association, nil
+}
+
+func failUDPAssociationOpenLane(lane *authenticatedLane, operation string, err error) error {
+	transportErr := &udpAssociationOpenTransportError{operation: operation, err: err}
+	if lane != nil && lane.fc != nil {
+		if observer, ok := lane.fc.transport().(interface{ transportFailed(error) }); ok {
+			observer.transportFailed(transportErr)
+		}
+		_ = lane.fc.Close()
+	}
+	return transportErr
 }
 
 func (c *Client) runClientUDPUplink(ctx context.Context, udpConn *net.UDPConn, fc *frameConn, sessionID [16]byte, flowID uint64, peerMu *sync.RWMutex, peer **net.UDPAddr, activity chan<- struct{}, counters *udpCounters) error {

--- a/internal/pep/udp_rescue_test.go
+++ b/internal/pep/udp_rescue_test.go
@@ -3,15 +3,129 @@ package pep
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/protocol"
+	"github.com/bojieli/queqiao/internal/session"
 	"github.com/bojieli/queqiao/internal/socks5"
 )
+
+type observedUDPAssociationConn struct {
+	net.Conn
+	failure chan error
+}
+
+func (c *observedUDPAssociationConn) transportFailed(err error) {
+	c.failure <- err
+}
+
+func TestUDPAssociationOpenTimeoutRetiresLaneAndFastRetriesOnTCP(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := &Client{
+		cfg: ClientConfig{
+			Transport: TransportAuto, FallbackDelay: time.Second,
+			HandshakeTimeout: 25 * time.Millisecond, Logger: logger,
+		},
+		udpHealth: newUDPHealth(1, time.Minute),
+		metrics:   metrics.New(),
+	}
+
+	var dialMu sync.Mutex
+	var dialed []TransportKind
+	transportFailure := make(chan error, 1)
+	client.dialAuthenticatedLaneForTest = func(_ context.Context, kind TransportKind) (*authenticatedLane, error) {
+		dialMu.Lock()
+		dialed = append(dialed, kind)
+		dialMu.Unlock()
+
+		local, remote := net.Pipe()
+		if kind == TransportQUIC {
+			observed := &observedUDPAssociationConn{Conn: local, failure: transportFailure}
+			go func() {
+				defer remote.Close()
+				// Consume OPEN but deliberately never acknowledge it. This is the
+				// half-alive pooled-stream state that used to poison every later
+				// UDP association.
+				_, _ = newFrameConn(remote).Read()
+				time.Sleep(100 * time.Millisecond)
+			}()
+			return &authenticatedLane{fc: newFrameConn(observed), outer: observed, kind: kind}, nil
+		}
+
+		go func() {
+			defer remote.Close()
+			frames := newFrameConn(remote)
+			request, err := frames.Read()
+			if err != nil {
+				return
+			}
+			var token [session.UDPResumeTokenSize]byte
+			token[0] = 1
+			_ = frames.Write(protocol.Frame{Header: protocol.Header{
+				Version: protocol.Version, Type: protocol.TypeOpenOK,
+				SessionID: request.Header.SessionID, FlowID: request.Header.FlowID,
+			}, Payload: session.EncodeUDPResumeGrant(false, token)})
+		}()
+		return &authenticatedLane{fc: newFrameConn(local), outer: local, kind: kind}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	association, err := client.openUDPAssociation(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer association.lane.fc.Close()
+	if association.lane.kind != TransportTCP {
+		t.Fatalf("fast-retry transport = %s, want TCP", association.lane.kind)
+	}
+	select {
+	case failure := <-transportFailure:
+		var openErr *udpAssociationOpenTransportError
+		if !errors.As(failure, &openErr) || !pooledTransportTimedOut(failure) {
+			t.Fatalf("reported failure = %T %v, want timed-out UDP open", failure, failure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed-out UDP open was not reported to pooled transport")
+	}
+
+	dialMu.Lock()
+	gotDialed := append([]TransportKind(nil), dialed...)
+	dialMu.Unlock()
+	if len(gotDialed) != 2 || gotDialed[0] != TransportQUIC || gotDialed[1] != TransportTCP {
+		t.Fatalf("dial sequence = %v, want [quic tcp]", gotDialed)
+	}
+	if got := client.metrics.Snapshot().Fallbacks; got != 1 {
+		t.Fatalf("fallbacks = %d, want 1", got)
+	}
+}
+
+func TestPooledTransportTimeoutClassification(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "deadline", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped deadline", err: errors.Join(errors.New("read failed"), context.DeadlineExceeded), want: true},
+		{name: "EOF", err: io.EOF, want: false},
+		{name: "application close", err: net.ErrClosed, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := pooledTransportTimedOut(test.err); got != test.want {
+				t.Fatalf("pooledTransportTimedOut(%v) = %v, want %v", test.err, got, test.want)
+			}
+		})
+	}
+}
 
 // TestUDPAssociationRescuesToTCP keeps the SOCKS UDP endpoint fixed while the
 // established QUIC listener is deliberately withdrawn. The second datagram


### PR DESCRIPTION
## Summary

Recover two stale QUIC client states which previously persisted until the
Queqiao client was restarted:

1. a stream on a shared QUIC generation times out while the QUIC connection
   still appears alive; and
2. a QUIC UDP socket remains bound to a DHCP address which disappeared after a
   Wi-Fi or network change.

The first case now retires the affected pool generation and retries one UDP
association open. The second lets the permanent source-address error terminate
the unusable QUIC connection so the existing pool rebuild path resolves the
configured interface again and dials from its current address.

No wire format, authentication behavior, configuration schema, protocol
version, watchdog, polling loop, or external recovery script is added.

## User-visible failures

### Stalled UDP association setup

The client could keep reusing a pooled QUIC generation after a SOCKS5 UDP
association timed out waiting for `OPEN_OK`. TCP and the outer QUIC connection
could still look present, but each new UDP association selected the same stale
generation and repeated the timeout. Restarting the client created a fresh
generation and restored UDP.

### Network switch keeps the old source address

With `--local-address if:<interface>`, changing networks can replace the
interface's DHCP address. The path watcher already notices the change and
re-resolves the interface for new dials, but an existing UDP socket is still
explicitly bound to the vanished address.

The packet wrapper previously classified `EADDRNOTAVAIL` (and Windows
`WSAEADDRNOTAVAIL`) as transient packet loss and reported a successful write to
quic-go. Unlike a temporary route outage or a full send buffer, that socket can
never outlive the condition or adopt the replacement address. Hiding the error
therefore leaves QUIC retransmitting on an impossible path and can cause both a
long outage and high CPU until restart.

## Fix

### Retire a pooled generation only on transport evidence

`controlPoolStreamConn.transportFailed` retires its own generation when the
QUIC connection context is terminal or the stream reports a timeout. Generation
identity remains part of retirement, so a late error from an old stream cannot
close a healthy replacement.

Ordinary per-stream `EOF` and application-close errors do not retire the pool.

### Report UDP open transport failures and retry once

Failures while writing UDP `OPEN` or reading its acknowledgement are reported
to the lane's transport observer before the stream closes.

The current association gets one bounded retry:

- `auto` retries on authenticated TCP;
- `quic` remains QUIC-only and acquires a fresh generation;
- `tcp` remains TCP-only.

If that retry fails, the returned error contains both attempts. There is no
unbounded retry loop.

### Treat a vanished bound source as fatal

The transient-route wrapper continues to absorb errors a socket can really
outlive: temporary network/host unreachable, link-down, and send-buffer-full
conditions. It no longer absorbs `EADDRNOTAVAIL` or
`WSAEADDRNOTAVAIL`.

The permanent write error now reaches quic-go, closes the affected connection,
and lets Queqiao's existing generation retirement/singleflight rebuild path
create a new UDP socket. A configuration such as `if:<interface>` is resolved
again during that dial, so the new socket uses the interface's current address.

## Resource and compatibility bounds

- At most one extra association-open attempt is made after an initial transport
  failure.
- Concurrent recovery callers still coalesce through the existing singleflight
  pool rebuild path; there is no dial stampede.
- Healthy streams do not pay an extra dial or fallback cost.
- No permanent goroutine, timer, watchdog, polling loop, or script is added.
- Wire protocol remains version 1.
- Existing profiles and command-line options remain valid.
- Client and gateway do not require a coordinated protocol change.

## Regression coverage

The tests cover both state transitions and real local QUIC behavior:

- `TestUDPAssociationOpenTimeoutRetiresLaneAndFastRetriesOnTCP`
  verifies timeout propagation, pool retirement, and exactly one TCP retry.
- `TestPooledTransportTimeoutClassification` rejects EOF/application close as
  pool-wide evidence while accepting direct and wrapped deadlines.
- `TestTimedOutControlStreamRetiresItsQUICGeneration` uses real QUIC
  connections and verifies a timed-out generation is replaced exactly once.
- `TestVanishedSourceAddressRemainsFatal` verifies source-address loss is not
  disguised as transient packet loss.
- `TestQUICConnectionClosesWhenItsBoundSourceDisappears` uses a real local QUIC
  client/server pair and verifies the affected connection terminates promptly.
- `TestQUICConnectionSurvivesATransientLocalRouteOutage` verifies genuinely
  transient route loss is still tolerated.
- Platform-specific errno samples compile and pass on Unix and Windows.

## Checks run

The branch was checked with the repository-required Go 1.25.13 toolchain:

```text
go test -short -timeout 20m ./...
go test -timeout 50m ./...
go test -race -timeout 45m ./internal/pep
go vet ./...
staticcheck ./...
python3 -m unittest discover -s scripts -p 'test_*.py'
./scripts/changelog.py check
test -z "$(gofmt -l .)"
./scripts/fallback_soak.sh --runs 20 --race-runs 5 --output-dir <temp>
```

After adding the network-change fix, the affected package and failure modes
were rechecked separately:

```text
go test ./internal/pep -count=1
go test -short ./...
go test -race ./internal/pep -run '<affected recovery tests>' -count=20
GOOS=linux GOARCH=amd64 go test -c ./internal/pep
GOOS=windows GOARCH=amd64 go test -c ./internal/pep
go vet ./internal/pep
staticcheck ./internal/pep
```

Results: full and short suites pass; the full `internal/pep` package and the
targeted race repetition pass; Python tests pass 85/85; fallback soak passes
20/20 normal and 5/5 race iterations; vet, staticcheck, formatting, changelog,
cross-compilation, and staged secret scans pass.

## Field validation

Patched darwin/arm64 and linux/amd64 binaries were built from the same commit
with Go 1.25.13 and deployed as a client/gateway pair.

- direct Queqiao TCP returned a successful HTTP 204;
- one persistent SOCKS5 UDP association completed 10/10 DNS replies after the
  final build was deployed;
- the client UDP socket was verified bound to the interface's current address;
- client metrics reported zero flow failures, fallbacks, UDP-path-unavailable
  events, transient-send events, or rescue failures after the check;
- both services remained active with no warning-level log entries.

No hostnames, public addresses, credentials, profiles, packet captures, or
private traffic are included in this pull request.

## Same-address uplink reconnect

A later field failure exposed a second network-change edge case: a configured dynamic interface became temporarily unavailable, then a different network assigned the same private IPv4 address. The watcher previously ignored the unavailable observation and compared only address strings, so it missed the path boundary and kept the old QUIC generation until a later timeout.

The watcher now treats a definite outage of an `auto` or `if:NAME` binding as a path boundary. When the interface becomes usable again it retires the previous pool and prewarms a new generation even if the address string is unchanged. Empty results from an unbound route probe remain inconclusive, preventing one resolver or endpoint error from churning a healthy pool.

Regression coverage includes same-address reconnect, changed-address reconnect, an inconclusive empty probe, and startup without an address followed by recovery. The full `internal/pep` suite, 20 targeted race repetitions, vet, staticcheck, changelog validation, secret scan, and Linux/Windows cross-compilation pass.