### PR TITLE
fix: count QUIC connection telemetry once per connection

### DIFF
--- a/cmd/queqiaod/main_test.go
+++ b/cmd/queqiaod/main_test.go
@@ -171,9 +171,12 @@ func TestPerformanceSnapshotIsMachineReadable(t *testing.T) {
 	registry := metrics.New()
 	registry.FlowStarted()
 	registry.ObserveQUIC(1, metrics.QUICObservation{
-		Lanes: 1, SmoothedRTT: 210 * time.Millisecond, BytesSent: 1234, BytesReceived: 5678,
-		PacketsSent: 123, PacketsReceived: 119, PacketsLost: 3, ControllerKind: "bbr-tuic",
+		Lanes: 1, SmoothedRTT: 210 * time.Millisecond, ControllerKind: "bbr-tuic",
 		ControllerPacingRate: 9999, ControllerErasureFloor: 0.025,
+	})
+	registry.AddQUICConnectionCounters(metrics.QUICConnectionCounters{
+		BytesSent: 1234, BytesReceived: 5678,
+		PacketsSent: 123, PacketsReceived: 119, PacketsLost: 3,
 	})
 	logPerformanceSnapshot(logger, registry.Snapshot(), 5*time.Second)
 	var record map[string]any

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -115,9 +115,25 @@ Prometheus `/metrics` names. They cover:
   transitions.
 
 The dashboard calculates interval packet loss from changes in sent and lost
-packet counters. QUIC can later recognize a packet previously declared lost,
-so its lost byte/packet counters are allowed to decrease; the dashboard skips
-that interval instead of displaying a fabricated negative loss rate.
+packet counters. Those counters are process-wide monotonic totals: they are
+accumulated from the forward movement of each QUIC connection, measured once
+per connection against a baseline the connection itself holds.
+
+That scoping is what makes the difference between two scrapes mean something.
+A QUIC connection here is pooled, so at any moment several lanes belonging to
+several flows are reading the same counters out of the same connection, and
+each of those flows publishes telemetry on its own timer. Adding up what the
+live flows currently report would count one connection once per flow
+referencing it, and would move the total up and down as flows start and end --
+so an interval difference would measure flow churn rather than the path, in
+both the numerator and the denominator. Neither a flow ending nor its
+telemetry expiring moves these counters now; both only retire gauges.
+
+Within one interval a counter can still fail to advance. QUIC may recognize a
+packet it previously declared lost, and a pooled connection replaced by a new
+generation restarts its counters at zero. Both are read as no forward
+movement rather than as a negative or a wrapped-around jump, and the
+connection is re-baselined at the new reading.
 
 A gateway that refuses a lane join writes `msg="lane join refused"` with the
 reason at `info`, or at `warn` for a flow or principal mismatch, which are a

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -95,8 +95,13 @@ type Registry struct {
 	// warning an operator gets that the aggregate is being held up by a
 	// measurement that is no longer being taken.
 	quicObservationsExpired atomic.Uint64
-	telemetryMu             sync.Mutex
-	quicFlows               map[uint64]quicObservation
+	// quicCounters are the process-wide monotonic QUIC totals.  They are
+	// accumulated from per-connection forward deltas rather than derived by
+	// summing the live flows, because the connections they measure are shared
+	// by many flows and outlive any one of them.  See QUICConnectionCounters.
+	quicCounters quicCounterTotals
+	telemetryMu  sync.Mutex
+	quicFlows    map[uint64]quicObservation
 	// clock is the time source for observation freshness. Tests replace it;
 	// production leaves it nil and reads the wall clock.
 	clock func() time.Time
@@ -204,6 +209,59 @@ type quicObservation struct {
 	updated time.Time
 }
 
+// quicCounterTotals holds the process-wide QUIC counters.  They are atomics
+// rather than fields under telemetryMu so that publishing a connection's
+// forward movement never contends with a scrape walking the flow map.
+type quicCounterTotals struct {
+	bytesSent               atomic.Uint64
+	bytesReceived           atomic.Uint64
+	packetsSent             atomic.Uint64
+	packetsReceived         atomic.Uint64
+	bytesLost               atomic.Uint64
+	packetsLost             atomic.Uint64
+	controllerBytesLost     atomic.Uint64
+	controllerPacketsLost   atomic.Uint64
+	controllerSamples       atomic.Uint64
+	controllerNonAppSamples atomic.Uint64
+	controllerAppSamples    atomic.Uint64
+	controllerStateMisses   atomic.Uint64
+	controllerZeroSamples   atomic.Uint64
+}
+
+func (t *quicCounterTotals) add(d QUICConnectionCounters) {
+	t.bytesSent.Add(d.BytesSent)
+	t.bytesReceived.Add(d.BytesReceived)
+	t.packetsSent.Add(d.PacketsSent)
+	t.packetsReceived.Add(d.PacketsReceived)
+	t.bytesLost.Add(d.BytesLost)
+	t.packetsLost.Add(d.PacketsLost)
+	t.controllerBytesLost.Add(d.ControllerBytesLost)
+	t.controllerPacketsLost.Add(d.ControllerPacketsLost)
+	t.controllerSamples.Add(d.ControllerSamples)
+	t.controllerNonAppSamples.Add(d.ControllerNonAppSamples)
+	t.controllerAppSamples.Add(d.ControllerAppSamples)
+	t.controllerStateMisses.Add(d.ControllerStateMisses)
+	t.controllerZeroSamples.Add(d.ControllerZeroSamples)
+}
+
+func (t *quicCounterTotals) load() QUICConnectionCounters {
+	return QUICConnectionCounters{
+		BytesSent:               t.bytesSent.Load(),
+		BytesReceived:           t.bytesReceived.Load(),
+		PacketsSent:             t.packetsSent.Load(),
+		PacketsReceived:         t.packetsReceived.Load(),
+		BytesLost:               t.bytesLost.Load(),
+		PacketsLost:             t.packetsLost.Load(),
+		ControllerBytesLost:     t.controllerBytesLost.Load(),
+		ControllerPacketsLost:   t.controllerPacketsLost.Load(),
+		ControllerSamples:       t.controllerSamples.Load(),
+		ControllerNonAppSamples: t.controllerNonAppSamples.Load(),
+		ControllerAppSamples:    t.controllerAppSamples.Load(),
+		ControllerStateMisses:   t.controllerStateMisses.Load(),
+		ControllerZeroSamples:   t.controllerZeroSamples.Load(),
+	}
+}
+
 type Snapshot struct {
 	ActiveFlows, FlowsStarted, FlowsCompleted, FlowsFailed        int64
 	BytesUp, BytesDown, LaneFailures, LaneReplacements, Fallbacks uint64
@@ -247,39 +305,119 @@ type Snapshot struct {
 
 // QUICObservation is a point-in-time aggregate over the lanes of one logical
 // flow.  RTT is represented as a maximum so an operator can see the worst
-// active lane without any user-controlled labels.  Byte and loss values are
-// the sum of the QUIC connection counters at that point.
+// active lane without any user-controlled labels.
+//
+// Everything here is a gauge: it describes the transport as it stands at the
+// moment of the observation, so replacing it wholesale on every publication
+// and dropping it when the flow ends are both correct.  The cumulative
+// counters a QUIC connection also reports are deliberately not in this type;
+// they are connection-scoped and are published separately.  See
+// QUICConnectionCounters.
 type QUICObservation struct {
 	Lanes                      int
 	LatestRTT                  time.Duration
 	SmoothedRTT                time.Duration
-	BytesSent                  uint64
-	BytesReceived              uint64
-	PacketsSent                uint64
-	PacketsReceived            uint64
-	BytesLost                  uint64
-	PacketsLost                uint64
 	ControllerKind             string
 	ControllerMode             uint32
 	ControllerMaxBandwidth     uint64
 	ControllerLatestSample     uint64
 	ControllerLatestAckRate    uint64
 	ControllerLatestSendRate   uint64
-	ControllerSamples          uint64
-	ControllerNonAppSamples    uint64
-	ControllerAppSamples       uint64
-	ControllerStateMisses      uint64
-	ControllerZeroSamples      uint64
 	ControllerRound            uint64
 	ControllerPacingRate       uint64
 	ControllerCongestionWindow uint64
 	ControllerBytesInFlight    uint64
-	ControllerBytesLost        uint64
-	ControllerPacketsLost      uint64
 	ControllerMinRTT           time.Duration
 	ControllerErasureFloor     float64
 	ControllerInRecovery       bool
 }
+
+// QUICConnectionCounters is the cumulative half of one QUIC connection's
+// telemetry.  Every field counts since that connection was established and
+// only ever moves forward.
+//
+// These are connection-scoped, and a connection is not a flow.  Connections
+// are pooled: many lanes belonging to many flows read the same numbers from
+// the same connection.  Summing what every live flow currently reports
+// therefore counts one connection once per flow that references it, and makes
+// the process total rise and fall as flows and lanes enter and leave the live
+// set.  A value that moves in both directions is not a counter, and a
+// dashboard differencing it reports whatever the churn happened to be rather
+// than what the path did -- a loss rate assembled from two such differences is
+// noise in both the numerator and the denominator.
+//
+// The process totals are accumulated from forward deltas measured once per
+// connection instead.  See AddQUICConnectionCounters.
+type QUICConnectionCounters struct {
+	BytesSent               uint64
+	BytesReceived           uint64
+	PacketsSent             uint64
+	PacketsReceived         uint64
+	BytesLost               uint64
+	PacketsLost             uint64
+	ControllerBytesLost     uint64
+	ControllerPacketsLost   uint64
+	ControllerSamples       uint64
+	ControllerNonAppSamples uint64
+	ControllerAppSamples    uint64
+	ControllerStateMisses   uint64
+	ControllerZeroSamples   uint64
+}
+
+// Advance returns the forward movement of every counter between two readings
+// of the same connection, which is what may be added to a process total.
+//
+// A field that did not move contributes nothing, and so does a field that
+// moved backwards.  Both cases are ordinary rather than defensive: quic-go is
+// allowed to un-declare a loss it later decides was reordering, and a pooled
+// connection replaced by a new generation restarts its counters at zero.  The
+// alternative -- treating a decrease as a huge increase by wrapping the
+// subtraction -- is how an unsigned counter reports a terabyte of loss for a
+// packet that arrived after all.
+func (c QUICConnectionCounters) Advance(previous QUICConnectionCounters) QUICConnectionCounters {
+	forward := func(now, before uint64) uint64 {
+		if now <= before {
+			return 0
+		}
+		return now - before
+	}
+	return QUICConnectionCounters{
+		BytesSent:               forward(c.BytesSent, previous.BytesSent),
+		BytesReceived:           forward(c.BytesReceived, previous.BytesReceived),
+		PacketsSent:             forward(c.PacketsSent, previous.PacketsSent),
+		PacketsReceived:         forward(c.PacketsReceived, previous.PacketsReceived),
+		BytesLost:               forward(c.BytesLost, previous.BytesLost),
+		PacketsLost:             forward(c.PacketsLost, previous.PacketsLost),
+		ControllerBytesLost:     forward(c.ControllerBytesLost, previous.ControllerBytesLost),
+		ControllerPacketsLost:   forward(c.ControllerPacketsLost, previous.ControllerPacketsLost),
+		ControllerSamples:       forward(c.ControllerSamples, previous.ControllerSamples),
+		ControllerNonAppSamples: forward(c.ControllerNonAppSamples, previous.ControllerNonAppSamples),
+		ControllerAppSamples:    forward(c.ControllerAppSamples, previous.ControllerAppSamples),
+		ControllerStateMisses:   forward(c.ControllerStateMisses, previous.ControllerStateMisses),
+		ControllerZeroSamples:   forward(c.ControllerZeroSamples, previous.ControllerZeroSamples),
+	}
+}
+
+// Add folds one connection's forward movement into a running total.
+func (c *QUICConnectionCounters) Add(delta QUICConnectionCounters) {
+	c.BytesSent += delta.BytesSent
+	c.BytesReceived += delta.BytesReceived
+	c.PacketsSent += delta.PacketsSent
+	c.PacketsReceived += delta.PacketsReceived
+	c.BytesLost += delta.BytesLost
+	c.PacketsLost += delta.PacketsLost
+	c.ControllerBytesLost += delta.ControllerBytesLost
+	c.ControllerPacketsLost += delta.ControllerPacketsLost
+	c.ControllerSamples += delta.ControllerSamples
+	c.ControllerNonAppSamples += delta.ControllerNonAppSamples
+	c.ControllerAppSamples += delta.ControllerAppSamples
+	c.ControllerStateMisses += delta.ControllerStateMisses
+	c.ControllerZeroSamples += delta.ControllerZeroSamples
+}
+
+// IsZero reports whether nothing moved, which lets a caller skip the atomic
+// writes entirely on the common idle publication.
+func (c QUICConnectionCounters) IsZero() bool { return c == QUICConnectionCounters{} }
 
 func New() *Registry { return &Registry{quicFlows: make(map[uint64]quicObservation)} }
 
@@ -431,6 +569,22 @@ func (r *Registry) ObserveQUIC(key uint64, o QUICObservation) {
 	r.telemetryMu.Unlock()
 }
 
+// AddQUICConnectionCounters folds one connection's forward movement into the
+// process totals.
+//
+// The caller measures the delta against a baseline held per connection, so
+// two flows sharing a pooled connection do not both contribute it: whichever
+// publishes first moves the baseline, and the other adds nothing.  That is
+// what makes these totals independent of how many flows happen to reference a
+// connection, and what lets a flow's telemetry be dropped the moment it ends
+// without the totals moving backwards.
+func (r *Registry) AddQUICConnectionCounters(delta QUICConnectionCounters) {
+	if r == nil || delta.IsZero() {
+		return
+	}
+	r.quicCounters.add(delta)
+}
+
 func (r *Registry) RemoveQUIC(key uint64) {
 	if key == 0 {
 		return
@@ -476,14 +630,12 @@ func (r *Registry) Snapshot() Snapshot {
 	r.telemetryMu.Lock()
 	var quicLanes int64
 	var latestRTT, smoothedRTT time.Duration
-	var bytesSent, bytesReceived, packetsSent, packetsReceived, bytesLost, packetsLost uint64
 	var controllerKind string
 	var controllerMode uint32
 	var controllerMaxBandwidth, controllerPacingRate, controllerCwnd, controllerBytesInFlight uint64
-	var controllerLatestSample, controllerSamples, controllerNonAppSamples, controllerAppSamples uint64
+	var controllerLatestSample uint64
 	var controllerLatestAckRate, controllerLatestSendRate uint64
-	var controllerStateMisses, controllerZeroSamples, controllerRound uint64
-	var controllerBytesLost, controllerPacketsLost uint64
+	var controllerRound uint64
 	var controllerMinRTT time.Duration
 	var controllerErasureFloor float64
 	var controllerRecovery bool
@@ -505,12 +657,6 @@ func (r *Registry) Snapshot() Snapshot {
 		if o.SmoothedRTT > smoothedRTT {
 			smoothedRTT = o.SmoothedRTT
 		}
-		bytesSent += o.BytesSent
-		bytesReceived += o.BytesReceived
-		packetsSent += o.PacketsSent
-		packetsReceived += o.PacketsReceived
-		bytesLost += o.BytesLost
-		packetsLost += o.PacketsLost
 		if o.ControllerKind != "" {
 			if controllerKind == "" {
 				controllerKind = o.ControllerKind
@@ -532,11 +678,6 @@ func (r *Registry) Snapshot() Snapshot {
 			if o.ControllerLatestSendRate > controllerLatestSendRate {
 				controllerLatestSendRate = o.ControllerLatestSendRate
 			}
-			controllerSamples += o.ControllerSamples
-			controllerNonAppSamples += o.ControllerNonAppSamples
-			controllerAppSamples += o.ControllerAppSamples
-			controllerStateMisses += o.ControllerStateMisses
-			controllerZeroSamples += o.ControllerZeroSamples
 			if o.ControllerRound > controllerRound {
 				controllerRound = o.ControllerRound
 			}
@@ -549,8 +690,6 @@ func (r *Registry) Snapshot() Snapshot {
 			if o.ControllerBytesInFlight > controllerBytesInFlight {
 				controllerBytesInFlight = o.ControllerBytesInFlight
 			}
-			controllerBytesLost += o.ControllerBytesLost
-			controllerPacketsLost += o.ControllerPacketsLost
 			if o.ControllerMinRTT > controllerMinRTT {
 				controllerMinRTT = o.ControllerMinRTT
 			}
@@ -568,29 +707,32 @@ func (r *Registry) Snapshot() Snapshot {
 	s.QUICLanes = quicLanes
 	s.QUICLatestRTT = latestRTT
 	s.QUICSmoothedRTT = smoothedRTT
-	s.QUICBytesSent = bytesSent
-	s.QUICBytesReceived = bytesReceived
-	s.QUICPacketsSent = packetsSent
-	s.QUICPacketsReceived = packetsReceived
-	s.QUICBytesLost = bytesLost
-	s.QUICPacketsLost = packetsLost
+	// The counters come from the process totals, not from the flows above.
+	// They must not depend on which flows happen to be live at scrape time.
+	counters := r.quicCounters.load()
+	s.QUICBytesSent = counters.BytesSent
+	s.QUICBytesReceived = counters.BytesReceived
+	s.QUICPacketsSent = counters.PacketsSent
+	s.QUICPacketsReceived = counters.PacketsReceived
+	s.QUICBytesLost = counters.BytesLost
+	s.QUICPacketsLost = counters.PacketsLost
 	s.QUICControllerKind = controllerKind
 	s.QUICControllerMode = controllerMode
 	s.QUICControllerMaxBandwidth = controllerMaxBandwidth
 	s.QUICControllerLatestSample = controllerLatestSample
 	s.QUICControllerLatestAckRate = controllerLatestAckRate
 	s.QUICControllerLatestSendRate = controllerLatestSendRate
-	s.QUICControllerSamples = controllerSamples
-	s.QUICControllerNonAppSamples = controllerNonAppSamples
-	s.QUICControllerAppSamples = controllerAppSamples
-	s.QUICControllerStateMisses = controllerStateMisses
-	s.QUICControllerZeroSamples = controllerZeroSamples
+	s.QUICControllerSamples = counters.ControllerSamples
+	s.QUICControllerNonAppSamples = counters.ControllerNonAppSamples
+	s.QUICControllerAppSamples = counters.ControllerAppSamples
+	s.QUICControllerStateMisses = counters.ControllerStateMisses
+	s.QUICControllerZeroSamples = counters.ControllerZeroSamples
 	s.QUICControllerRound = controllerRound
 	s.QUICControllerPacingRate = controllerPacingRate
 	s.QUICControllerCongestionWindow = controllerCwnd
 	s.QUICControllerBytesInFlight = controllerBytesInFlight
-	s.QUICControllerBytesLost = controllerBytesLost
-	s.QUICControllerPacketsLost = controllerPacketsLost
+	s.QUICControllerBytesLost = counters.ControllerBytesLost
+	s.QUICControllerPacketsLost = counters.ControllerPacketsLost
 	s.QUICControllerMinRTT = controllerMinRTT
 	s.QUICControllerErasureFloor = controllerErasureFloor
 	s.QUICControllerInRecovery = controllerRecovery

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -24,16 +24,19 @@ func TestRegistryCountersAndHandler(t *testing.T) {
 	r.FlowTimeout()
 	r.ObserveQUIC(1, QUICObservation{
 		Lanes: 2, LatestRTT: 250 * time.Millisecond, SmoothedRTT: 200 * time.Millisecond,
-		BytesSent: 100, BytesReceived: 200, PacketsSent: 80, PacketsReceived: 75, BytesLost: 3, PacketsLost: 4,
 		ControllerKind: "bbr", ControllerMode: 3, ControllerMaxBandwidth: 1_000_000,
 		ControllerLatestSample: 900_000, ControllerLatestAckRate: 1_100_000,
-		ControllerLatestSendRate: 900_000, ControllerSamples: 12,
-		ControllerNonAppSamples: 10, ControllerAppSamples: 2,
-		ControllerStateMisses: 1, ControllerZeroSamples: 3, ControllerRound: 7,
+		ControllerLatestSendRate: 900_000, ControllerRound: 7,
 		ControllerPacingRate: 1_250_000, ControllerCongestionWindow: 400_000,
 		ControllerBytesInFlight: 200_000, ControllerMinRTT: 190 * time.Millisecond,
 		ControllerErasureFloor: 0.0475,
 		ControllerInRecovery:   true,
+	})
+	r.AddQUICConnectionCounters(QUICConnectionCounters{
+		BytesSent: 100, BytesReceived: 200, PacketsSent: 80, PacketsReceived: 75,
+		BytesLost: 3, PacketsLost: 4, ControllerSamples: 12,
+		ControllerNonAppSamples: 10, ControllerAppSamples: 2,
+		ControllerStateMisses: 1, ControllerZeroSamples: 3,
 	})
 	r.FlowFinished(10, 20, false)
 	r.FlowStarted()
@@ -271,4 +274,111 @@ func TestLaneJoinRefusalsAreCountedByReason(t *testing.T) {
 
 	var nilRegistry *Registry
 	nilRegistry.LaneJoinRefused(LaneJoinUnknownSession)
+}
+
+// The QUIC counters used to be derived by summing what every live flow
+// reported, and each flow reported the cumulative counters of the connections
+// its lanes sat on. That made the exported total a function of which flows
+// happened to be live at scrape time: it rose when a long-lived flow appeared
+// and fell when one ended, so a dashboard differencing consecutive scrapes
+// read the churn rather than the path. A counter that falls is not a counter.
+func TestQUICCountersDoNotFallWhenTheFlowsReportingThemEnd(t *testing.T) {
+	r := New()
+	r.AddQUICConnectionCounters(QUICConnectionCounters{
+		BytesSent: 4096, PacketsSent: 40, PacketsLost: 2, ControllerPacketsLost: 3,
+	})
+	r.ObserveQUIC(1, QUICObservation{Lanes: 2, SmoothedRTT: 200 * time.Millisecond})
+	before := r.Snapshot()
+	if before.QUICBytesSent != 4096 || before.QUICPacketsSent != 40 {
+		t.Fatalf("counters not exported: %+v", before)
+	}
+
+	// Every flow ends. The connections they were reading may well still be
+	// open, and what they already carried certainly still happened.
+	r.RemoveQUIC(1)
+	after := r.Snapshot()
+	if after.QUICBytesSent != before.QUICBytesSent || after.QUICPacketsSent != before.QUICPacketsSent {
+		t.Fatalf("counters fell when the flow ended: before=%d/%d after=%d/%d",
+			before.QUICBytesSent, before.QUICPacketsSent, after.QUICBytesSent, after.QUICPacketsSent)
+	}
+	if after.QUICPacketsLost != 2 || after.QUICControllerPacketsLost != 3 {
+		t.Fatalf("loss counters fell when the flow ended: %+v", after)
+	}
+	if after.QUICLanes != 0 {
+		t.Fatalf("lane gauge = %d after the flow ended, want 0", after.QUICLanes)
+	}
+}
+
+// A flow's telemetry entry expiring must not disturb the counters either. The
+// gauges it was holding up go away, which is the point of the expiry; the
+// bytes the connection carried do not.
+func TestExpiringFlowTelemetryLeavesTheCountersAlone(t *testing.T) {
+	r := New()
+	now := time.Now()
+	r.clock = func() time.Time { return now }
+	r.ObserveQUIC(1, QUICObservation{Lanes: 1, SmoothedRTT: 300 * time.Millisecond})
+	r.AddQUICConnectionCounters(QUICConnectionCounters{BytesSent: 900, PacketsSent: 9})
+	now = now.Add(quicObservationTTL + time.Second)
+
+	got := r.Snapshot()
+	if got.QUICObservationsExpired != 1 || got.QUICLanes != 0 || got.QUICSmoothedRTT != 0 {
+		t.Fatalf("stale gauges survived expiry: %+v", got)
+	}
+	if got.QUICBytesSent != 900 || got.QUICPacketsSent != 9 {
+		t.Fatalf("expiry moved the counters: %+v", got)
+	}
+}
+
+// Observing flows must not move the counters at all. Their numbers come from
+// the connections, published once each, and a flow republishing every second
+// would otherwise multiply them by the scrape rate.
+func TestFlowObservationsDoNotContributeToTheCounters(t *testing.T) {
+	r := New()
+	for i := 0; i < 20; i++ {
+		r.ObserveQUIC(uint64(i+1), QUICObservation{Lanes: 3, SmoothedRTT: time.Second})
+	}
+	if got := r.Snapshot(); got.QUICBytesSent != 0 || got.QUICPacketsSent != 0 || got.QUICPacketsLost != 0 {
+		t.Fatalf("flow gauges leaked into the counters: %+v", got)
+	}
+}
+
+// quic-go is allowed to withdraw a loss it later decides was reordering, and a
+// pooled connection replaced by a new generation restarts at zero. Measuring
+// the distance between two readings with unsigned arithmetic turns either into
+// an enormous forward jump, which is the same fabricated-traffic failure this
+// change exists to remove.
+func TestConnectionCountersIgnoreBackwardMovement(t *testing.T) {
+	first := QUICConnectionCounters{BytesSent: 10_000, PacketsSent: 100, PacketsLost: 9}
+	// The peer acknowledges a packet previously declared lost.
+	second := QUICConnectionCounters{BytesSent: 11_000, PacketsSent: 110, PacketsLost: 7}
+	delta := second.Advance(first)
+	if delta.BytesSent != 1000 || delta.PacketsSent != 10 {
+		t.Fatalf("forward movement mismeasured: %+v", delta)
+	}
+	if delta.PacketsLost != 0 {
+		t.Fatalf("withdrawn loss reported as %d packets of new loss", delta.PacketsLost)
+	}
+
+	// A fresh connection generation restarts every counter at zero.
+	restarted := QUICConnectionCounters{BytesSent: 12, PacketsSent: 1}
+	if delta := restarted.Advance(second); !delta.IsZero() {
+		t.Fatalf("a restarted connection reported movement: %+v", delta)
+	}
+}
+
+// The same reading published twice -- which is exactly what two flows sharing
+// one pooled connection produce -- must count once.
+func TestRepublishingTheSameConnectionReadingCountsOnce(t *testing.T) {
+	r := New()
+	reading := QUICConnectionCounters{BytesSent: 5000, PacketsSent: 50}
+	var baseline QUICConnectionCounters
+	for i := 0; i < 5; i++ {
+		delta := reading.Advance(baseline)
+		baseline = reading
+		r.AddQUICConnectionCounters(delta)
+	}
+	if got := r.Snapshot(); got.QUICBytesSent != 5000 || got.QUICPacketsSent != 50 {
+		t.Fatalf("one connection reading counted %d bytes / %d packets, want 5000/50",
+			got.QUICBytesSent, got.QUICPacketsSent)
+	}
 }

--- a/internal/pep/conntelemetry.go
+++ b/internal/pep/conntelemetry.go
@@ -1,0 +1,144 @@
+package pep
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/apernet/quic-go"
+	"github.com/bojieli/queqiao/internal/metrics"
+)
+
+// A QUIC connection's cumulative counters belong to the connection, not to
+// any flow that borrows it. Connections here are pooled, so at any moment
+// several lanes across several flows are reading the same numbers out of the
+// same connection, and each of those flows publishes telemetry on its own
+// timer. Whatever consumes those publications has to fold one connection's
+// movement in exactly once, however many flows saw it.
+//
+// This file is where that happens. Each connection keeps the last reading
+// anybody published, and a publication contributes only the distance from it.
+// A second flow reading the same connection in the same interval therefore
+// contributes nothing rather than a duplicate, and a flow that ends between
+// two readings costs the total nothing, because what it already published was
+// banked at the time.
+type connTelemetry struct {
+	id uint64
+	mu sync.Mutex
+	// previous is the last reading folded into the process totals. The zero
+	// value is the correct starting point for a live connection: its counters
+	// start at zero when it is established, so the first reading is itself the
+	// distance travelled so far.
+	previous metrics.QUICConnectionCounters
+}
+
+var (
+	// connTelemetryMu serialises creation so two lanes racing on a new
+	// connection cannot each install an entry and each bank the same first
+	// reading.
+	connTelemetryMu sync.Mutex
+	// connTelemetries maps *quic.Conn to *connTelemetry. It follows the
+	// lifetime of the connection: the entry is dropped once the connection's
+	// context is done, the same way the coded bulk path is.
+	connTelemetries sync.Map
+	// connTelemetrySeq names connections for the lifetime of the process. It
+	// is never reused, so an identifier is safe to deduplicate on within one
+	// round of observations.
+	connTelemetrySeq atomic.Uint64
+)
+
+// connTelemetryFor returns the bookkeeping for one connection, creating it on
+// first sight.
+//
+// current is the reading that prompted the lookup, and it matters only for a
+// connection that has already closed. Dropping the entry at close is what
+// keeps this map bounded, but a lane can still be polled for a moment after
+// the connection it sat on went away, and re-creating an entry from the zero
+// baseline would read that connection's entire lifetime as movement and add
+// all of it a second time. Seeding a posthumous entry at the current reading
+// makes such a publication contribute nothing, which is the honest answer:
+// everything this connection did was already banked while it was alive.
+func connTelemetryFor(conn *quic.Conn, current metrics.QUICConnectionCounters) *connTelemetry {
+	if conn == nil {
+		return nil
+	}
+	if existing, ok := connTelemetries.Load(conn); ok {
+		return existing.(*connTelemetry)
+	}
+	connTelemetryMu.Lock()
+	defer connTelemetryMu.Unlock()
+	if existing, ok := connTelemetries.Load(conn); ok {
+		return existing.(*connTelemetry)
+	}
+	created := &connTelemetry{id: connTelemetrySeq.Add(1)}
+	context := conn.Context()
+	if context.Err() != nil {
+		created.previous = current
+		return created
+	}
+	connTelemetries.Store(conn, created)
+	go func() {
+		<-context.Done()
+		connTelemetryMu.Lock()
+		connTelemetries.Delete(conn)
+		connTelemetryMu.Unlock()
+	}()
+	return created
+}
+
+// advance banks a reading and reports how far the connection moved since the
+// last one.
+func (t *connTelemetry) advance(current metrics.QUICConnectionCounters) metrics.QUICConnectionCounters {
+	if t == nil {
+		return metrics.QUICConnectionCounters{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delta := current.Advance(t.previous)
+	// Re-baseline on every reading, including one that went backwards. A
+	// counter that decreased is quic-go withdrawing a loss it decided was
+	// reordering after all, or a pooled connection replaced by a fresh
+	// generation; in both cases the new reading is the truth to measure the
+	// next one against.
+	t.previous = current
+	return delta
+}
+
+// connectionCounters is the cumulative half of a lane's transport statistics,
+// named at the scope it is actually measured at.
+func connectionCounters(stats laneTransportStats) metrics.QUICConnectionCounters {
+	return metrics.QUICConnectionCounters{
+		BytesSent:               stats.bytesSent,
+		BytesReceived:           stats.bytesReceived,
+		PacketsSent:             stats.packetsSent,
+		PacketsReceived:         stats.packetsReceived,
+		BytesLost:               stats.bytesLost,
+		PacketsLost:             stats.packetsLost,
+		ControllerBytesLost:     stats.controller.BytesLost,
+		ControllerPacketsLost:   stats.controller.PacketsLost,
+		ControllerSamples:       stats.controller.Samples,
+		ControllerNonAppSamples: stats.controller.NonAppSamples,
+		ControllerAppSamples:    stats.controller.AppSamples,
+		ControllerStateMisses:   stats.controller.StateMisses,
+		ControllerZeroSamples:   stats.controller.ZeroSamples,
+	}
+}
+
+// laneConnectionProvider is a lane that sits on a QUIC connection it may be
+// sharing. Reporting the connection's identity alongside its movement is what
+// lets one round of observations fold connection-scoped values in once rather
+// than once per lane.
+type laneConnectionProvider interface {
+	connectionTelemetry(laneTransportStats) (uint64, metrics.QUICConnectionCounters)
+}
+
+func (c *quicStreamConn) connectionTelemetry(stats laneTransportStats) (uint64, metrics.QUICConnectionCounters) {
+	if c == nil || c.conn == nil {
+		return 0, metrics.QUICConnectionCounters{}
+	}
+	current := connectionCounters(stats)
+	entry := connTelemetryFor(c.conn, current)
+	if entry == nil {
+		return 0, metrics.QUICConnectionCounters{}
+	}
+	return entry.id, entry.advance(current)
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -615,6 +615,17 @@ func (f *multipathFlow) noteRemoteAbort() {
 
 func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 	var observation metrics.QUICObservation
+	// moved is how far the connections under this flow travelled since anyone
+	// last read them. It is not a per-flow quantity: the connections are
+	// pooled, so it is measured against a baseline the connection itself
+	// holds, and a connection two flows share contributes to whichever of
+	// them reads it first rather than to both.
+	var moved metrics.QUICConnectionCounters
+	// folded names the connections whose connection-scoped values have already
+	// been added to this observation. Several lanes of one flow routinely sit
+	// on one pooled connection, and a congestion window or pacing rate added
+	// once per lane describes a transport that does not exist.
+	var folded map[uint64]struct{}
 	for _, lane := range lanes {
 		provider, ok := lane.fc.transport().(laneStatsProvider)
 		if !ok {
@@ -628,12 +639,17 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 		if stats.smoothedRTT > observation.SmoothedRTT {
 			observation.SmoothedRTT = stats.smoothedRTT
 		}
-		observation.BytesSent += stats.bytesSent
-		observation.BytesReceived += stats.bytesReceived
-		observation.PacketsSent += stats.packetsSent
-		observation.PacketsReceived += stats.packetsReceived
-		observation.BytesLost += stats.bytesLost
-		observation.PacketsLost += stats.packetsLost
+		if counted, ok := provider.(laneConnectionProvider); ok {
+			id, delta := counted.connectionTelemetry(stats)
+			moved.Add(delta)
+			if _, seen := folded[id]; seen {
+				continue
+			}
+			if folded == nil {
+				folded = make(map[uint64]struct{}, len(lanes))
+			}
+			folded[id] = struct{}{}
+		}
 		controller := stats.controller
 		if controller.Kind != "" {
 			if observation.ControllerKind == "" {
@@ -654,19 +670,12 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 			if controller.LatestSendRate > observation.ControllerLatestSendRate {
 				observation.ControllerLatestSendRate = controller.LatestSendRate
 			}
-			observation.ControllerSamples += controller.Samples
-			observation.ControllerNonAppSamples += controller.NonAppSamples
-			observation.ControllerAppSamples += controller.AppSamples
-			observation.ControllerStateMisses += controller.StateMisses
-			observation.ControllerZeroSamples += controller.ZeroSamples
 			if controller.Round > observation.ControllerRound {
 				observation.ControllerRound = controller.Round
 			}
 			observation.ControllerPacingRate += controller.PacingRate
 			observation.ControllerCongestionWindow += controller.CongestionWindow
 			observation.ControllerBytesInFlight += controller.BytesInFlight
-			observation.ControllerBytesLost += controller.BytesLost
-			observation.ControllerPacketsLost += controller.PacketsLost
 			if controller.MinRTT > observation.ControllerMinRTT {
 				observation.ControllerMinRTT = controller.MinRTT
 			}
@@ -680,6 +689,12 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 		f.currentRTTNS.Store(observation.SmoothedRTT.Nanoseconds())
 		f.baselineRTTNS.CompareAndSwap(0, observation.SmoothedRTT.Nanoseconds())
 	}
+	// The connection totals are banked whether or not this flow may still
+	// publish its own gauges. They are monotonic and belong to the connection,
+	// so a late reading can neither pin nor inflate them, and discarding it
+	// would drop bytes the connection really did carry. A nil registry counts
+	// nothing at all, and the call is a no-op against one.
+	f.metrics.AddQUICConnectionCounters(moved)
 	// A finished flow must not publish again. Its registry entry is removed
 	// during teardown, and the lane managers keep polling this snapshot for a
 	// moment after that; a late publication would reinstate an entry with

--- a/internal/pep/telemetry_test.go
+++ b/internal/pep/telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	wancongestion "github.com/bojieli/queqiao/internal/congestion"
 	"github.com/bojieli/queqiao/internal/metrics"
 )
 
@@ -48,5 +49,152 @@ func TestFinishedFlowStopsPublishingQUICTelemetry(t *testing.T) {
 	flow.snapshot()
 	if got := registry.Snapshot(); got.QUICLanes != 0 || got.QUICSmoothedRTT != 0 {
 		t.Fatalf("finished flow republished telemetry: lanes=%d smoothed=%s", got.QUICLanes, got.QUICSmoothedRTT)
+	}
+}
+
+// pooledStatsConn is a lane sitting on a QUIC connection it shares with other
+// lanes and other flows, which is what the client connection pool hands out.
+// Every such lane reads the same cumulative counters out of the same
+// connection.
+type pooledStatsConn struct {
+	stats  laneTransportStats
+	shared *connTelemetry
+}
+
+func (c *pooledStatsConn) Read([]byte) (int, error)           { return 0, io.EOF }
+func (c *pooledStatsConn) Write(p []byte) (int, error)        { return len(p), nil }
+func (c *pooledStatsConn) Close() error                       { return nil }
+func (c *pooledStatsConn) transportStats() laneTransportStats { return c.stats }
+
+func (c *pooledStatsConn) connectionTelemetry(stats laneTransportStats) (uint64, metrics.QUICConnectionCounters) {
+	return c.shared.id, c.shared.advance(connectionCounters(stats))
+}
+
+func pooledLane(id uint64, shared *connTelemetry, stats laneTransportStats) *mpLane {
+	return &mpLane{id: id, kind: TransportQUIC, fc: newFrameConn(&pooledStatsConn{stats: stats, shared: shared})}
+}
+
+// A flow routinely runs several lanes over one pooled connection. The
+// connection's counters describe the connection, so folding them in once per
+// lane reports traffic and loss that never happened -- and the congestion
+// window it reports is likewise the connection's, not a number to be added up
+// per stream sharing it.
+func TestPooledConnectionCountsOncePerConnectionNotPerLane(t *testing.T) {
+	registry := metrics.New()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	flow := newMultipathFlow(context.Background(), local, [16]byte{1}, 7, 0, 0, 0, nil, registry)
+
+	shared := &connTelemetry{id: 1}
+	stats := laneTransportStats{
+		smoothedRTT: 200 * time.Millisecond,
+		bytesSent:   10_000, packetsSent: 100, packetsLost: 4,
+		controller: wancongestion.ControllerTelemetry{
+			Kind: "erasure", CongestionWindow: 400_000, PacingRate: 1_250_000,
+			PacketsLost: 4, Samples: 12,
+		},
+	}
+	flow.lanes[0] = pooledLane(0, shared, stats)
+	flow.lanes[1] = pooledLane(1, shared, stats)
+	flow.lanes[2] = pooledLane(2, shared, stats)
+
+	flow.snapshot()
+
+	got := registry.Snapshot()
+	if got.QUICLanes != 3 {
+		t.Fatalf("lane gauge = %d, want the true lane count 3", got.QUICLanes)
+	}
+	if got.QUICBytesSent != 10_000 || got.QUICPacketsSent != 100 {
+		t.Fatalf("three lanes on one connection counted %d bytes / %d packets, want 10000/100",
+			got.QUICBytesSent, got.QUICPacketsSent)
+	}
+	if got.QUICPacketsLost != 4 || got.QUICControllerPacketsLost != 4 {
+		t.Fatalf("loss multiplied by the lane count: packets=%d controller=%d, want 4/4",
+			got.QUICPacketsLost, got.QUICControllerPacketsLost)
+	}
+	if got.QUICControllerSamples != 12 {
+		t.Fatalf("controller samples = %d, want 12", got.QUICControllerSamples)
+	}
+	if got.QUICControllerCongestionWindow != 400_000 || got.QUICControllerPacingRate != 1_250_000 {
+		t.Fatalf("connection gauges added per lane: cwnd=%d pacing=%d, want 400000/1250000",
+			got.QUICControllerCongestionWindow, got.QUICControllerPacingRate)
+	}
+}
+
+// Two flows sharing one pooled connection each publish on their own timer.
+// Whichever reads it first banks the movement; the other must add nothing.
+func TestTwoFlowsSharingAConnectionCountItOnce(t *testing.T) {
+	registry := metrics.New()
+	shared := &connTelemetry{id: 1}
+	stats := laneTransportStats{
+		bytesSent: 8_000, packetsSent: 80,
+		controller: wancongestion.ControllerTelemetry{Kind: "erasure", Samples: 5},
+	}
+
+	for _, flowID := range []uint64{7, 9} {
+		local, remote := net.Pipe()
+		t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+		flow := newMultipathFlow(context.Background(), local, [16]byte{1}, flowID, 0, 0, 0, nil, registry)
+		flow.lanes[0] = pooledLane(0, shared, stats)
+		flow.snapshot()
+	}
+
+	if got := registry.Snapshot(); got.QUICBytesSent != 8_000 || got.QUICPacketsSent != 80 || got.QUICControllerSamples != 5 {
+		t.Fatalf("a shared connection counted once per flow: bytes=%d packets=%d samples=%d, want 8000/80/5",
+			got.QUICBytesSent, got.QUICPacketsSent, got.QUICControllerSamples)
+	}
+}
+
+// Publishing on a timer must not multiply a connection by the scrape rate:
+// only what moved between two readings is new.
+func TestRepeatedPublicationCountsOnlyWhatMoved(t *testing.T) {
+	registry := metrics.New()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	flow := newMultipathFlow(context.Background(), local, [16]byte{1}, 7, 0, 0, 0, nil, registry)
+
+	shared := &connTelemetry{id: 1}
+	lane := &pooledStatsConn{shared: shared, stats: laneTransportStats{bytesSent: 1_000, packetsSent: 10}}
+	flow.lanes[0] = &mpLane{id: 0, kind: TransportQUIC, fc: newFrameConn(lane)}
+
+	flow.snapshot()
+	flow.snapshot()
+	flow.snapshot()
+	if got := registry.Snapshot(); got.QUICBytesSent != 1_000 {
+		t.Fatalf("an idle connection published three times counted %d bytes, want 1000", got.QUICBytesSent)
+	}
+
+	// The connection carries more, and only the difference is new.
+	lane.stats.bytesSent = 2_500
+	lane.stats.packetsSent = 25
+	flow.snapshot()
+	if got := registry.Snapshot(); got.QUICBytesSent != 2_500 || got.QUICPacketsSent != 25 {
+		t.Fatalf("counters = %d bytes / %d packets, want 2500/25", got.QUICBytesSent, got.QUICPacketsSent)
+	}
+}
+
+// A finished flow stops publishing its gauges, but the connection under it may
+// still be carrying other flows, and what it moved before this flow's last
+// reading is not the finished flow's to withdraw.
+func TestFinishedFlowStillBanksConnectionMovement(t *testing.T) {
+	registry := metrics.New()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	flow := newMultipathFlow(context.Background(), local, [16]byte{1}, 7, 0, 0, 0, nil, registry)
+
+	shared := &connTelemetry{id: 1}
+	lane := &pooledStatsConn{shared: shared, stats: laneTransportStats{bytesSent: 600, packetsSent: 6}}
+	flow.lanes[0] = &mpLane{id: 0, kind: TransportQUIC, fc: newFrameConn(lane)}
+
+	flow.finished.Store(true)
+	registry.RemoveQUIC(flow.telemetryID)
+	flow.snapshot()
+
+	got := registry.Snapshot()
+	if got.QUICLanes != 0 {
+		t.Fatalf("finished flow republished its gauges: lanes=%d", got.QUICLanes)
+	}
+	if got.QUICBytesSent != 600 {
+		t.Fatalf("connection movement discarded with the finished flow: %d bytes, want 600", got.QUICBytesSent)
 	}
 }


### PR DESCRIPTION
## What this fixes

The exported `queqiao_quic_*` counters were derived by summing, over every live flow, the cumulative counters of the connections that flow's lanes sat on (`internal/metrics/metrics.go`, the `for key, entry := range r.quicFlows` loop). Both halves of that are wrong, and they compound.

**A connection is not a flow.** Connections here are pooled — `quicStreamConn` values share `generation.conn` / `entry.conn` with `closeConn: false`, and `transportStats()` returns `c.conn.ConnectionStats()`. So several lanes belonging to several flows read the same numbers out of the same connection, and each flow publishes on its own timer. One connection was counted once per flow referencing it, once per publication.

**A cumulative counter summed over a live set is not a counter.** The total rose when a long-lived flow appeared and fell when one ended, so differencing two scrapes measured flow churn rather than the path.

`tools/visualizer/parser.js` differences these as `_total` counters and builds `packet_loss_percent` from two of them, so both the numerator and the denominator were noise.

## Evidence

Same sustained workload (four rate-limited flows plus churn) against an isolated gateway, before and after:

| | `origin/main` (c17ef26) | this branch |
| --- | ---: | ---: |
| counter decreases | **3 of 14 samples** | **0** |
| total walked backwards | **1147 MB** (largest drop 710 MB) | — |
| peak `quic_bytes_sent` | **993 MB** | 129 MB |
| application bytes actually moved | 0.1 MB | 24.6 MB |
| derived packet loss | fabricated | 0.000% (lossless loopback) |

On a production gateway the same defect reported **45% packet loss** across a 60 s window in which the monotonic application counters showed ~35 kbit/s and the flows' own FEC records showed a residual loss of 0.08%. That gateway's real upstream erasure over 4,667 flows was p50 3.8% / p90 11.5%, repaired by FEC to ≤0.18% residual — so the transport was behaving while the dashboard said it was not.

## The fix

Aggregate each value at the scope it is measured at.

- `QUICConnectionCounters` is the cumulative half, published **per connection** against a baseline the connection itself holds (`internal/pep/conntelemetry.go`). Only forward movement is added to a process-wide monotonic total.
- Publishing one reading twice adds nothing, which is what makes a shared connection count once however many flows see it. A flow ending or its telemetry expiring no longer moves the total, because what it published was banked when it published it.
- `QUICObservation` keeps only gauges — what an observation replaced wholesale each publication and dropped at flow end can correctly carry.
- The same per-connection identity folds connection-scoped **gauges** (congestion window, pacing rate, bytes in flight) once per connection rather than once per lane sharing it.

Edge cases handled deliberately rather than defensively:

- A counter that moves backwards is read as no forward movement, not wrapped into a huge positive jump. quic-go produces one when it withdraws a loss it decides was reordering; a pooled connection replaced by a fresh generation restarts at zero.
- An entry re-created after its connection closed is seeded at the current reading, so a lane polled during teardown cannot bank that connection's lifetime a second time.

No metric was renamed and no exposition line changed, so the visualizer and any existing dashboard keep working — their inputs simply become counters.

## Tests

New regression tests, each verified against a negative control that reproduces the old behaviour and fails:

- `TestPooledConnectionCountsOncePerConnectionNotPerLane` — three lanes on one connection; without the fix, cwnd reads 1,200,000 instead of 400,000.
- `TestTwoFlowsSharingAConnectionCountItOnce` — without the fix, 16,000 bytes instead of 8,000.
- `TestRepeatedPublicationCountsOnlyWhatMoved` — without the fix, 3,000 bytes instead of 1,000.
- `TestQUICCountersDoNotFallWhenTheFlowsReportingThemEnd`, `TestExpiringFlowTelemetryLeavesTheCountersAlone`, `TestFlowObservationsDoNotContributeToTheCounters`, `TestConnectionCountersIgnoreBackwardMovement`, `TestFinishedFlowStillBanksConnectionMovement`.

`go test ./...`, `go vet ./...` and `gofmt` are clean.

No changelog fragment, as requested.

## Not in this PR

Two things found while investigating, left alone deliberately:

1. `queqiao_quic_controller_erasure_floor_ratio` is a **max** across live flows, so it reports the worst single flow as though it were a path property (it read 0.018, 0.035 and 0.069 within minutes on the production gateway). A byte-weighted mean would describe the shared path the design is built around.
2. Flow failures on that gateway run ~8% cumulative, 79% of them `lane N: timeout: no recent network activity` → `lane replacement timeout`. `MaxIdleTimeout` is 15s against a 5s keepalive (`internal/baseline/baseline.go:77`); on a path with double-digit p90 erasure, three lost keepalives kill a lane. Worth revisiting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dCyj1XmWdWhZ56Z1PT9YM
