### PR TITLE
fix: size the code for the erasure the path is measured to be doing

### DIFF
--- a/changelog.d/code-sized-from-the-measured-erasure.fixed.md
+++ b/changelog.d/code-sized-from-the-measured-erasure.fixed.md
@@ -1,0 +1,20 @@
+Forward error correction is now sized for the erasure the path is measured to
+be applying, and no longer for the congestion controller's floor. The floor is
+biased low so that pacing errs towards slowing down, and the coded layer built
+its whole view of the channel out of that one number, so on a path erasing
+19.9% it sized parity for 1.76% and handed 11% of the payload back to the
+session to re-issue a round trip later. Of the flows measured during the
+incident that saw more than 5% erasure, every one ran a code sized for less
+than half of it and 97% ran no code at all. The shared path model now carries
+the measured erasure and its burstiness alongside the floor, and each consumer
+reads the one whose error it can survive.
+
+The code rate is also chosen differently. There is no residual target any
+more -- a sender never observes the residual it chose, so it was an
+unverifiable setpoint -- and no minimum coded loss below which parity was
+refused. Both are replaced by choosing the rate that delivers a block soonest,
+counting what an unrepairable block costs in round trips before its data
+arrives, so a clean path buys no parity and a lossy one buys as much as it is
+worth without either case needing a constant. A channel too lossy for any
+allowed rate to repair a block more often than not is now reported as such
+rather than being given a code that cannot work.

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -1,9 +1,9 @@
 # Control redesign: delay-bounded goodput
 
 > [!IMPORTANT]
-> **Status:** Proposed. Steps 2 and 3 of [Sequencing](#sequencing) are
-> implemented; the controller half is not. Nothing here is validated on a real
-> path yet -- see [Falsification](#falsification).
+> **Status:** Partly implemented. The coding half and the bandwidth estimate
+> have landed; the delay bound and the receiver report have not. Nothing here
+> is validated on a real path yet -- see [Falsification](#falsification).
 >
 > **Wire impact:** None for the controller and coding changes. The receiver
 > report in [Closing the residual loop](#closing-the-residual-loop) is additive
@@ -85,6 +85,14 @@ is dead code, because `Loss` *is* `Floor`. When the floor is zero both are zero.
 whenever loss clusters.
 
 ### The bandwidth filter ratchets up
+
+> [!NOTE]
+> Fixed. A sample now expires on rounds or on wall time, whichever comes first,
+> with the wall-clock window derived from the measured round trip. An
+> application-limited sample may also replace an estimate that has already
+> expired, without which an always-application-limited connection would have
+> emptied its own model. What follows is what shipped and what it did.
+
 
 `tuicMinMax` is a three-sample max filter with a **ten-round** window, and
 `updateMax` collapses all three samples to the newest whenever it is the
@@ -225,20 +233,38 @@ B = S + R
 ```
 
 Congestion control owns how much goes on the wire. Coding owns how that budget
-is spent. Repair symbols are charged to the same aggregate budget as source
-payload, so raising the erasure estimate can never add a byte of load — it can
-only shift the mix.
+is spent. Raising the erasure estimate then changes the mix -- more parity,
+less payload -- and never the total.
 
-`B` is produced by the controller, not configured, so `--aggregate-bytes-per-sec`
-is not the mechanism. What is needed is the aggregate *enforcement point*: one
-place where every lane draws from a single controller-set rate instead of
-pacing independently. `internal/limiter` already provides it and is currently
-fed by a flag.
+**This mechanism already existed, and an earlier draft of this document was
+wrong about it.** The draft said parity was additive and that an aggregate
+enforcement point had to be built, pointing at `internal/limiter` and the
+`aggregate_bytes_per_second` flag that reads zero on the live gateway. That is
+an optional application-level pacer and it is not the budget. The budget is the
+congestion window:
 
-The honest cost: under heavy erasure, goodput visibly drops, because budget is
-openly spent on parity. That cost is already being paid as retransmissions at
-one round trip each; this makes it visible and latency-free. On a 194–430 ms
-path that is the trade this project exists to make.
+- `coded.QUICCarrier` runs the coded path over QUIC datagrams, and *"the
+  congestion controller, the pacer and the loss detector on the connection all
+  still apply"*. A repair symbol crosses the same window as a source symbol.
+- `ErasureSender.bandwidth` caps that window at this lane's share of the
+  endpoint pair's measured bottleneck, *"so the aggregate on the wire is what a
+  single sender would have put there"*. Lanes cannot compound.
+
+What was actually broken is that the window was not fixed in practice. The
+bandwidth estimate behind the cap could be latched at a burst rate for the
+better part of an hour, so the share was computed from a figure the path had
+never sustained, and a cap computed from a fantasy never binds. That is a
+defect in the estimate, not a missing mechanism, and it is fixed in the filter.
+
+`TestParityCostsACodeRateAndNotAByteRate` holds the invariant directly: the
+same payload through a carrier with a fixed byte allowance puts 408,955 bytes
+on the wire uncoded and 409,573 coded for 19.9% erasure, against a 409,600
+allowance. The parity was spent out of the window rather than added to it.
+
+The honest cost stands: under heavy erasure, goodput visibly drops, because
+budget is openly spent on parity. That cost is already being paid as
+retransmissions at one round trip each, invisibly. On a 194-430 ms path that is
+the trade this project exists to make.
 
 ## Closing the residual loop
 
@@ -332,9 +358,9 @@ implementation before the change lands.
 
 | # | Case | Passes if |
 | --- | --- | --- |
-| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate |
-| 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows |
-| 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation |
+| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing**; end-to-end needs a burst-depth knob in `internal/pathsim`, which has none |
+| 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Open** |
+| 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation. **Filter-level test passing** |
 | 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked |
 | 5 | Clean path, no erasure | `r = 1`; no parity is sent, without a `minCodedLoss` constant |
 | 6 | Self-limiting claim | The climb stops; `B` does not grow without bound |
@@ -347,33 +373,33 @@ to document the path class as unbraked rather than to reintroduce a classifier.
 
 ## Sequencing
 
-Ratchet removal is only safe once parity is budgeted, which fixes the order.
+An earlier draft opened with "aggregate enforcement point driven by the
+controller, not a flag". That step does not exist: the enforcement point is the
+congestion window capped at the pooled share, and it was already there. What it
+needed was an estimate that could fall.
 
-1. Aggregate enforcement point driven by the controller, not a flag.
-2. Parity charged to that budget; objective switched to maximum goodput;
+1. **Done.** Bandwidth filter expires on rounds or wall time, whichever first;
+   an application-limited sample may replace an expired estimate.
+2. **Done.** The shared path model carries the measured erasure and burst
+   alongside the controller's floor, and `channel()` reads the measurement
+   instead of fabricating a snapshot from one scalar.
+3. **Done.** Parity sized by the rate that delivers a block soonest;
    `TargetResidual` and `minCodedLoss` deleted.
-3. The shared path model carries the measured erasure and burst alongside the
-   controller's floor, and `channel()` reads the measurement.
-4. Bandwidth filter replaced with one that can fall; delay bound added.
-5. Loss suppression (`ErasureSender.congestive`) deleted, and the arrival-rate
-   compensation moved onto the measurement.
-
-Steps 3 and 5 were one step in an earlier draft, and splitting them is not
-cosmetic. Deleting loss suppression hands every erasure to BBR as congestion,
-and on a 42% erasure channel that is the collapse to 0.39 Mbit/s this
-controller exists to avoid. Nothing may remove it until the delay bound is in
-place to brake instead. Until then the two consumers simply read different
-numbers from the same model, which is what the design argues for anyway: the
-controller keeps its conservative floor, the code reads the measurement.
+4. **Done.** The loss the path caused is exported, not only the share charged
+   as congestion.
+5. Delay bound added, then loss suppression (`ErasureSender.congestive`)
+   deleted and the arrival-rate compensation moved onto the measurement.
 6. `kindReport` closes the residual loop.
-7. Metrics: monotonic accumulators, direction tags, dead counter wired or
-   deleted.
 
-Steps 1–5 have no wire impact. Step 6 is additive and forward-compatible. Step
-7 is independent and can proceed in parallel — and while the controller reads
-its goodput signal from its own acknowledgement path rather than from
-Prometheus, step 7 is a prerequisite for *believing* any measurement of the
-rest.
+Steps 1-5 have no wire impact. Step 6 is additive and forward-compatible.
+
+Splitting the delay bound from the removal of loss suppression is not cosmetic.
+Deleting suppression hands every erasure to BBR as congestion, and on a 42%
+erasure channel that is the collapse to 0.39 Mbit/s this controller exists to
+avoid. Nothing may remove it until the delay bound is in place to brake
+instead. Until then the two consumers read different numbers from the same
+model, which is what the design argues for anyway: the controller keeps its
+conservative floor, the code reads the measurement.
 
 ## Open questions
 

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -1,0 +1,389 @@
+# Control redesign: delay-bounded goodput
+
+> [!IMPORTANT]
+> **Status:** Proposed. Steps 2 and 3 of [Sequencing](#sequencing) are
+> implemented; the controller half is not. Nothing here is validated on a real
+> path yet -- see [Falsification](#falsification).
+>
+> **Wire impact:** None for the controller and coding changes. The receiver
+> report in [Closing the residual loop](#closing-the-residual-loop) is additive
+> and forward-compatible.
+
+This document replaces the erasure-floor classifier and the bandwidth max
+filter with a single objective: **deliver as many bytes as the path will carry
+without letting the queue grow past a delay bound.** It records the incident
+that motivated it, the two defects it removes, the problems it explicitly does
+not solve, and the cases that would falsify it.
+
+It does not supersede [the current design](DESIGN.md) until the falsification
+cases in this document pass on a real path. Until then, treat DESIGN.md as the
+description of what ships and this as the description of where it is going.
+
+## The incident
+
+A live China-US path degraded over roughly eight hours. The evidence that
+matters, all of it from per-flow completion records rather than from the
+aggregate counters, which were not trustworthy (see
+[Measurement plane](#measurement-plane-and-inference-plane)):
+
+| Direction | Measured at | Erasure | Residual after FEC |
+| --- | --- | --- | --- |
+| Upstream, client to gateway | gateway decoder | 3.8% p50 | 0.00% p50 |
+| Downstream, gateway to client | client decoder | 19.9% p50, 60.1% peak | 11.0% p50, 56.0% peak |
+
+Of 14,792 client flows that saw more than 5% downstream erasure, **100%** ran a
+code sized for less than half the erasure actually present, and **97%** ran no
+code at all. In the worst record the local estimator's own floor read 77.0%
+while the plan it produced was sized for 0.00%.
+
+The transport was neither faster nor slower than direct TCP over the same
+segment in the same window: 2.10–2.20 MB/s tunnelled against 2.00–2.25 MB/s
+direct, on a path whose round trip is 194–430 ms. It delivered none of the
+benefit it exists to provide while re-issuing 11% of the downstream payload.
+
+## Two latched estimators
+
+The incident is not one bug. It is the same mistake in two places, pointing in
+opposite directions. Both estimators assume the path has a true value worth
+remembering, and both are correct only if that assumption holds.
+
+### The erasure floor ratchets down
+
+`ErasureSender.establishedErasureFloor` keeps a lower envelope for the lifetime
+of the connection, and says why:
+
+> The floor is a lower envelope for the lifetime of this connection: allowing a
+> completed but congested measurement to increase it creates positive feedback,
+> because both the pacer and FEC then add traffic to an already overloaded
+> path.
+
+The reasoning is sound given the code underneath it. `coded.Path` has no byte
+budget: repair symbols are pure addition on top of whatever the controller
+already allows. Raising the erasure estimate therefore genuinely does add load,
+and the project has been bitten by that loop before — the repair ratio climbing
+from 11% to 27% to 63% of sent bytes.
+
+So the ratchet is a correct defence against a real hazard, and no patch to the
+gate, the envelope, or the burst test can be applied without re-opening it.
+**The hazard has to go first.** The only escape today is lane death, which
+creates a fresh estimator; on flows that live for hours, the floor established
+during a clean window survives into a degraded one.
+
+A second defect compounds it. `coded.Path.channel()` collapses the pooled model
+to a single scalar and fabricates a snapshot from it:
+
+```go
+return lossmodel.Snapshot{
+    Loss: floor, Floor: floor, Recent: floor,
+    BurstFactor: 1, ArrivalAfterLoss: 1 - floor,
+}
+```
+
+`fec.Choose` has a designed fallback — `if loss <= 0 { loss = s.Loss }` — and it
+is dead code, because `Loss` *is* `Floor`. When the floor is zero both are zero.
+`BurstFactor: 1` separately asserts independence, so parity is under-sized
+whenever loss clusters.
+
+### The bandwidth filter ratchets up
+
+`tuicMinMax` is a three-sample max filter with a **ten-round** window, and
+`updateMax` collapses all three samples to the newest whenever it is the
+largest, so one high sample latches the filter. App-limited samples are allowed
+through in the raising direction, which is textbook BBR.
+
+The window is counted in packet-timed rounds, not wall time, and the observed
+connections were 99.98% app-limited, so rounds barely advance:
+
+| Endpoint | Round | Uptime | Rounds/hour | Ten-round window |
+| --- | --- | --- | --- | --- |
+| Gateway | 220 | 24.1 h | 9.1 | **≈ 66 min** |
+| Client | 1401 | 25.2 h | 55.7 | ≈ 11 min |
+
+One burst through a token bucket therefore latches the bandwidth estimate for
+the better part of an hour. The gateway held `max_bandwidth` at 519 Mbit/s
+against a measured sustained 17.6 Mbit/s: a 29× overestimate, and the source of
+the 1.6 Gbit/s pacing rate and 15–28 MB congestion window observed alongside it.
+
+### Why a max filter is the wrong shape
+
+A shaped path does not have a bandwidth. It has a rate and a burst depth, and
+they are different numbers. A short probe drains the bucket and measures the
+line rate; sustained load measures the shaping rate. Any max filter
+structurally measures the first and reports it as the second. Shortening the
+window or adding decay is a patch on that premise rather than a correction of
+it.
+
+The same is true of an operator-set ceiling, which this project has already
+rejected on its own terms: the point of the controller is to *"reach the same
+place without being told."* A configured rate cannot track an ISP that
+re-shapes, and there may be no stable rate to configure.
+
+## The objective
+
+One function, measured end to end:
+
+```
+maximise   G(B, r) = B · k / (n + r/(1−r) · reissue)
+subject to RTT ≤ min_rtt + delay_budget
+```
+
+`B` is the total byte rate on the wire, `k/n` is the fraction of a block
+carrying source rather than repair symbols, `r` is the residual the chosen rate
+leaves, and `reissue` is what an unrepairable block costs before its data
+arrives, in symbol-times. There is no bandwidth variable, so there is nothing
+to latch and nothing to configure.
+
+The `reissue` term is not decoration, and an earlier draft of this document
+omitted it. Without it the objective is delivered goodput per byte on the wire,
+and **that objective never buys parity at all**: sending `k` of `n` shards as
+data always carries less data per byte than sending all `n`, and a
+retransmission recovers the difference eventually. Parity only ever buys the
+*eventually*. An objective with no time in it cannot express that, so it
+declines to code at every erasure rate, which is the incident with the
+arithmetic reversed.
+
+The residual is charged `r/(1−r)` round trips rather than one, because a
+re-issue crosses the same channel and can be erased in its turn. At a small
+residual the difference is nothing. At a large one it is the whole answer:
+charging a single round trip makes an uncoded block on a 72% erasure channel
+look cheaper than any code, because it quietly assumes the one retransmission
+gets through.
+
+Three things follow that are worth stating separately, because each removes a
+knob rather than adding one.
+
+**The residual target disappears.** `fec.Choose` currently searches for the
+highest rate meeting a `TargetResidual` that the sender can never observe —
+open-loop control against an unmeasurable setpoint. Under a fixed byte budget
+the objective is self-defining: at `p → 0` the maximum lands at `r = 1` on its
+own, so `minCodedLoss` disappears with it.
+
+**The erasure/congestion classifier stops being safety-critical.** Today
+misclassification is catastrophic in one direction: no parity into a 50%
+erasure channel. Under a fixed budget, getting it wrong costs some goodput and
+nothing else.
+
+**The delay bound does double duty.** It protects the interactive latency this
+transport exists to preserve, and it is the brake that replaces loss-based
+backoff. A pure goodput objective would happily fill a queue, which contradicts
+the reserve the design already maintains.
+
+### Why the classifier is redundant
+
+The ErasureSender documentation already contains the argument, without drawing
+the conclusion:
+
+> in startup S grows by the gain each round until delivery stops growing, which
+> happens exactly when S reaches the bottleneck.
+
+That is the whole discriminator. **Erasure scales delivery down proportionally
+at every rate and cannot produce a knee; congestion produces a knee.** The
+delivery-versus-rate curve separates them empirically, per path, with no
+statistics. A policer at capacity — the case the classifier was built for —
+still produces a knee: send more, deliver the same.
+
+The memorylessness test and the burst-factor gate are a second, weaker answer
+to a question the probing loop already answers, and unlike the probing loop
+they fail precisely when loss is worst. With loss removed as a congestion
+input, `ErasureSender.congestive` has no consumer.
+
+What survives is not a classifier but a measurement. Pacing must still be
+divided by the arrival rate, or the estimate chases itself down — sending `S`
+delivers `S(1−p)`, which becomes the next estimate, which is paced as `S(1−p)`.
+Arrival rate is `arrived/sent`. **You do not need to know why packets failed to
+arrive in order to know what fraction did.** Deriving it from the classified
+floor is what made it inherit the ratchet.
+
+### Decoupling the optimiser
+
+Joint optimisation over `(B, r)` is not defensible on this path, and this
+document should not pretend otherwise. `lossmodel.DefaultRoundSamples` records
+the noise floor: at 42% loss, 2,000 packets put the standard error near one
+percentage point, and the filter wants eight such rounds. At the 17.6 Mbit/s
+measured, 1,200-byte packets give roughly 1,830 packets per second — about a
+second per usable loss estimate, nine seconds per filter window — while the
+path moved 5% → 49% → 20% inside one hour. That budget does not support a
+two-dimensional gradient on a noisy, non-stationary objective.
+
+So the knobs are decoupled:
+
+- **`B` keeps BBR's structured probing.** The state machine was never the
+  defect; the latched filter feeding it was. Replace the filter with an
+  estimator that can fall, and add the delay bound as the brake.
+- **`r` is a one-dimensional climb inside `B`.** Cheap, fast, and safe by
+  construction, because under a fixed budget it cannot add load.
+
+This keeps the well-understood mechanism and replaces only the part that was
+demonstrably wrong.
+
+### Rate-preserving parity
+
+The invariant that makes all of the above safe:
+
+```
+B = S + R
+```
+
+Congestion control owns how much goes on the wire. Coding owns how that budget
+is spent. Repair symbols are charged to the same aggregate budget as source
+payload, so raising the erasure estimate can never add a byte of load — it can
+only shift the mix.
+
+`B` is produced by the controller, not configured, so `--aggregate-bytes-per-sec`
+is not the mechanism. What is needed is the aggregate *enforcement point*: one
+place where every lane draws from a single controller-set rate instead of
+pacing independently. `internal/limiter` already provides it and is currently
+fed by a flag.
+
+The honest cost: under heavy erasure, goodput visibly drops, because budget is
+openly spent on parity. That cost is already being paid as retransmissions at
+one round trip each; this makes it visible and latency-free. On a 194–430 ms
+path that is the trade this project exists to make.
+
+## Closing the residual loop
+
+The planner chooses a code rate and never learns whether it worked. During the
+incident the client knew its residual was 11.0%; the gateway could not find
+out. No estimator improvement fixes this: a sender can measure erasure from its
+own acknowledgements, but it cannot measure residual after its own FEC, which
+is the only number that says whether the rate was right.
+
+The coded datagram layer already ignores unknown kinds:
+
+```go
+default:
+    return nil
+```
+
+So a `kindReport` datagram carrying `{erasure, residual, mean burst}` over a
+recent window is forward-compatible. Old peers drop it and behave exactly as
+today; new peers close the loop. No version bump and no change to existing
+conformance vectors.
+
+`coded.Path.channel()` states that the coded layer *"never infers its outbound
+direction from packets received in the reverse direction."* That correctly
+rejects **inferring** outbound erasure from inbound loss. A peer **reporting**
+what it measured on your outbound direction is not inference; it is a direct
+measurement relayed, and the reasoning does not extend to it.
+
+## Measurement plane and inference plane
+
+Every defect in the incident, including the ones outside the controller, is the
+same mistake: **conclusions were stored, shared, and aggregated as if they were
+measurements.**
+
+- The erasure floor stores a conclusion and ratchets it.
+- `channel()` collapses a measurement into a conclusion and back.
+- `internal/metrics` sums per-flow cumulative counters over *currently live*
+  flows and exports the result as a counter. The values fall when flows expire,
+  so anything that differences them — Prometheus `rate()`, and
+  `tools/visualizer/parser.js` — reads noise. A 60-second window produced
+  "45.03% packet loss" against a real downstream rate of ~35 kbit/s.
+- `queqiao_quic_packets_lost` is a conclusion with no measurement behind it.
+  `connStats.PacketsLost` is incremented only in quic-go's `cubic_sender.go`,
+  which Queqiao replaces, so it is structurally pinned at zero. The visualiser
+  computes `packet_loss_percent` from exactly that field.
+
+The rule this design adopts:
+
+- Measurements are direction-tagged, endpoint-tagged, monotonic, and never
+  destroyed by aggregation.
+- Inference is per-consumer, explicit about its bias, and reads measurements —
+  never another consumer's conclusion.
+
+Direction in particular must be enforced by the type system rather than by
+naming convention. The rename to `fec_receive_*` was a convention fix, and two
+separate reviewers still misread the result. An erasure figure without a
+direction and a measuring endpoint should be treated as unread.
+
+## What this does not solve
+
+Stated plainly, because the design is easy to over-credit.
+
+**Lane idle timeouts, which caused 79% of observed flow failures.**
+`MaxIdleTimeout: 15s` and `KeepAlivePeriod: 5s` are `quic.Config` fields, so
+keepalives are QUIC PING frames in QUIC packets. The coded substrate sits
+*above* QUIC and carries queqiao frames as datagrams, so **FEC never protects
+QUIC's own control traffic.** At 20% downstream erasure, three consecutive PING
+losses is 0.79% per opportunity regardless of how good the coding becomes, and
+a p90 flow gets roughly 22 opportunities. The 5,684 `unknown_session` lane
+rejoins are the downstream symptom. This needs its own fix and is not addressed
+here.
+
+**Metrics aggregation, the dead loss counter, and direction typing.** Three
+independent fixes, described above but not caused by the controller.
+
+**Fairness.** Not claimed, by decision. Queqiao is deliberately more aggressive
+than a loss-responsive flow sharing the same bottleneck. What the objective
+does provide is a self-limiting property: the climb stops when delivered
+goodput stops improving, which is the bottleneck. The claim is *"it takes what
+the path will deliver and stops"* — which is testable, and is tested below —
+rather than any fairness guarantee.
+
+## Falsification
+
+These are the point of the document, not an appendix. The coding half is a
+root-cause fix supported by the incident evidence. The control half is a
+well-motivated redesign whose central mechanism has never run on this path, and
+elegance is not a reason to trust it.
+
+Each case belongs in `internal/pathsim` and must fail against the current
+implementation before the change lands.
+
+| # | Case | Passes if |
+| --- | --- | --- |
+| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate |
+| 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows |
+| 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation |
+| 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked |
+| 5 | Clean path, no erasure | `r = 1`; no parity is sent, without a `minCodedLoss` constant |
+| 6 | Self-limiting claim | The climb stops; `B` does not grow without bound |
+| 7 | Bulk flow alongside interactive | Interactive latency stays inside the delay bound |
+
+**Case 4 is the one expected to fail.** A dropper that erases at capacity
+without building a queue gives the delay bound no signal, and with loss removed
+as a congestion input there is nothing else. If it fails, the honest outcome is
+to document the path class as unbraked rather than to reintroduce a classifier.
+
+## Sequencing
+
+Ratchet removal is only safe once parity is budgeted, which fixes the order.
+
+1. Aggregate enforcement point driven by the controller, not a flag.
+2. Parity charged to that budget; objective switched to maximum goodput;
+   `TargetResidual` and `minCodedLoss` deleted.
+3. The shared path model carries the measured erasure and burst alongside the
+   controller's floor, and `channel()` reads the measurement.
+4. Bandwidth filter replaced with one that can fall; delay bound added.
+5. Loss suppression (`ErasureSender.congestive`) deleted, and the arrival-rate
+   compensation moved onto the measurement.
+
+Steps 3 and 5 were one step in an earlier draft, and splitting them is not
+cosmetic. Deleting loss suppression hands every erasure to BBR as congestion,
+and on a 42% erasure channel that is the collapse to 0.39 Mbit/s this
+controller exists to avoid. Nothing may remove it until the delay bound is in
+place to brake instead. Until then the two consumers simply read different
+numbers from the same model, which is what the design argues for anyway: the
+controller keeps its conservative floor, the code reads the measurement.
+6. `kindReport` closes the residual loop.
+7. Metrics: monotonic accumulators, direction tags, dead counter wired or
+   deleted.
+
+Steps 1–5 have no wire impact. Step 6 is additive and forward-compatible. Step
+7 is independent and can proceed in parallel — and while the controller reads
+its goodput signal from its own acknowledgement path rather than from
+Prometheus, step 7 is a prerequisite for *believing* any measurement of the
+rest.
+
+## Open questions
+
+- **The delay budget is the one remaining constant.** It is a latency policy
+  rather than a bandwidth number, so it does not violate the rule that
+  bandwidth must be measured. Whether it is fixed, derived from `min_rtt`, or
+  exposed is undecided.
+- **Bucket detection.** Goodput that is high and then decays at constant `B` is
+  a draining token bucket, which argues for lengthening the measurement window.
+  Detecting it is a measurement; the threshold for acting on it is not yet
+  specified.
+- **Mixed-fleet behaviour during step 6.** Until both ends report, half the
+  paths run open-loop. Acceptable, or gated behind a capability exchange?

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,9 @@ you choose the next document based on what you want to do.
 - [Path characterization](PATH-CHARACTER-20260813.md) — the open-loop
   measurement that exposed the motivating path's erasure floor and congestion
   knee.
+- [Control redesign](CONTROL-REDESIGN.md) — proposed delay-bounded goodput
+  objective, the two latched estimators it removes, what it does not solve, and
+  the cases that would falsify it.
 
 ## Measure and qualify
 

--- a/internal/coded/coded.go
+++ b/internal/coded/coded.go
@@ -112,10 +112,6 @@ type Config struct {
 	// holds symbols whose repair would arrive later than a retransmission, and
 	// coding was for avoiding exactly that.
 	RoundTrip time.Duration
-	// TargetResidual is the share of symbols allowed to arrive unrepairable.
-	// It should not be zero: driving it down costs parity geometrically, and
-	// the residual is what the session above is good at.
-	TargetResidual float64
 	// Path is what the endpoint pair has been measured to do, shared with
 	// everything else sending to it -- above all the congestion controller,
 	// whose own acknowledgements reveal the erasure rate of exactly this
@@ -132,9 +128,6 @@ func (c Config) withDefaults() Config {
 	}
 	if c.RoundTrip <= 0 {
 		c.RoundTrip = 300 * time.Millisecond
-	}
-	if c.TargetResidual <= 0 {
-		c.TargetResidual = 1e-3
 	}
 	if c.Pending <= 0 {
 		c.Pending = 256
@@ -755,13 +748,26 @@ func (p *Path) symbolPayload() int {
 // those observations cannot distinguish physical erasure from congestion the
 // peer caused by its sending rate.
 func (p *Path) channel() lossmodel.Snapshot {
-	floor := 0.0
-	if p.cfg.Path != nil {
-		floor = p.cfg.Path.Current().Floor
+	if p.cfg.Path == nil {
+		return lossmodel.Snapshot{BurstFactor: 1, ArrivalAfterLoss: 1}
+	}
+	state := p.cfg.Path.Current()
+	// The measured erasure, not the controller's floor. The floor is biased
+	// low on purpose so that pacing errs towards slowing down, and a code
+	// sized from it is sized for a fraction of what the channel is doing: the
+	// incident in docs/CONTROL-REDESIGN.md sized parity for 1.76% against a
+	// measured 19.9%. The floor also arrives here as a scalar, and building a
+	// snapshot whose every field is that one number is what killed Choose's
+	// own fallback -- it checks Loss when Floor is zero, and both were the
+	// same zero.
+	burst := state.BurstFactor
+	if burst < 1 {
+		burst = 1
 	}
 	return lossmodel.Snapshot{
-		Loss: floor, Floor: floor, Recent: floor,
-		BurstFactor: 1, ArrivalAfterLoss: 1 - floor,
+		Loss: state.Erasure, Floor: state.Floor, Recent: state.Erasure,
+		BurstFactor: burst, ArrivalAfterLoss: 1 - state.Erasure,
+		Samples: state.ObservedSamples, Decided: uint64(state.ObservedSamples),
 	}
 }
 
@@ -771,7 +777,6 @@ func (p *Path) params() fec.Params {
 		ShardBytes:      p.symbolBytes(),
 		RateBytesPerSec: p.rate(),
 		RoundTrip:       p.roundTrip(),
-		TargetResidual:  p.cfg.TargetResidual,
 	}
 }
 

--- a/internal/coded/coded_test.go
+++ b/internal/coded/coded_test.go
@@ -109,7 +109,7 @@ func (p *lossyPipe) stats() (sent, lost int) {
 // connection.
 func measuredPath(floor float64) *pathmodel.PathModel {
 	m := pathmodel.NewPathModel()
-	m.Report(1, floor, 5000, 5000, 2e6, 0)
+	m.Report(1, pathmodel.Observation{Floor: floor, FloorSamples: 5000, Erasure: floor, BurstFactor: 1, ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 0})
 	return m
 }
 
@@ -442,5 +442,49 @@ func TestAPathDoesNotInferItsOutboundFloorFromReverseLoss(t *testing.T) {
 	time.Sleep(codingTTL + 20*time.Millisecond)
 	if quiet.Coding() {
 		t.Errorf("reverse loss selected outbound coding without outbound evidence: %+v", quiet.Stats())
+	}
+}
+
+// The incident in docs/CONTROL-REDESIGN.md happened here, between a path model
+// that knew what the channel was doing and a code that was sized from
+// something else. The controller's floor is biased low on purpose, and
+// channel() used to build the code's whole view of the channel out of that one
+// scalar -- Loss, Floor and Recent all set to it, and BurstFactor asserted to
+// be 1. On the live path that meant parity sized for 1.76% while the far
+// decoder measured 19.9%, and 11% of the payload handed back to the session.
+//
+// This holds the wiring rather than the arithmetic: given a model whose floor
+// and measurement disagree the way the live one did, the code must be sized
+// from the measurement.
+func TestTheCodeIsSizedFromTheMeasurementNotTheFloor(t *testing.T) {
+	const measured, conservativeFloor = 0.199, 0.0176
+	m := pathmodel.NewPathModel()
+	m.Report(1, pathmodel.Observation{
+		Floor: conservativeFloor, FloorSamples: 5000,
+		Erasure: measured, BurstFactor: 1,
+		ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 250 * time.Millisecond,
+	})
+
+	pa, _ := newPipes(1, measured)
+	p := New(pa, Config{SymbolBytes: 1100, RoundTrip: 250 * time.Millisecond, Path: m})
+	t.Cleanup(func() { p.Close() })
+
+	channel := p.channel()
+	if channel.Loss != measured {
+		t.Fatalf("the code is reading %.4f from a path measured at %.4f", channel.Loss, measured)
+	}
+	plan := p.coding().plan
+	t.Logf("floor %.4f, measured %.4f: coded=%v rate=%.3f sized_for=%.4f residual=%.2e",
+		conservativeFloor, measured, plan.Code, plan.Rate, plan.LossCoded, plan.Residual)
+	if !plan.Code {
+		t.Fatalf("a channel erasing %.1f%% was left uncoded: %s", measured*100, plan.Why)
+	}
+	if plan.LossCoded < measured {
+		t.Fatalf("sized for %.4f on a channel measured at %.4f", plan.LossCoded, measured)
+	}
+	// The parity the incident actually shipped was 4.9% of the wire against
+	// this erasure. Anything near that is the same failure with new code.
+	if overhead := plan.Overhead(); overhead < 1.15 {
+		t.Fatalf("%.1f%% erasure bought only %.2fx overhead", measured*100, overhead)
 	}
 }

--- a/internal/coded/coded_test.go
+++ b/internal/coded/coded_test.go
@@ -488,3 +488,138 @@ func TestTheCodeIsSizedFromTheMeasurementNotTheFloor(t *testing.T) {
 		t.Fatalf("%.1f%% erasure bought only %.2fx overhead", measured*100, overhead)
 	}
 }
+
+// budgetedPipe is a carrier with a fixed byte allowance, which is what a
+// congestion window is. It refuses once the allowance is gone, exactly as a
+// QUIC connection stops packing datagrams once SendMode reports it may not
+// send.
+type budgetedPipe struct {
+	mu        sync.Mutex
+	remaining int
+	sent      int
+	bytes     int
+	refused   int
+	out       chan []byte
+	in        chan []byte
+	done      chan struct{}
+	closed    bool
+}
+
+func newBudgetedPipes(budget int) (*budgetedPipe, *budgetedPipe) {
+	a2b, b2a := make(chan []byte, 8192), make(chan []byte, 8192)
+	return &budgetedPipe{remaining: budget, out: a2b, in: b2a, done: make(chan struct{})},
+		&budgetedPipe{remaining: budget, out: b2a, in: a2b, done: make(chan struct{})}
+}
+
+func (p *budgetedPipe) Send(d []byte) error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return errors.New("closed")
+	}
+	if len(d) > p.remaining {
+		p.refused++
+		p.mu.Unlock()
+		// A window that is full is not a broken carrier. Report the datagram
+		// as too large, which is the one refusal this layer already absorbs
+		// without failing the path.
+		return ErrDatagramTooLarge
+	}
+	p.remaining -= len(d)
+	p.sent++
+	p.bytes += len(d)
+	p.mu.Unlock()
+	select {
+	case p.out <- append([]byte(nil), d...):
+	default:
+	}
+	return nil
+}
+
+func (p *budgetedPipe) Receive() ([]byte, error) {
+	select {
+	case d := <-p.in:
+		return d, nil
+	case <-p.done:
+		return nil, errors.New("closed")
+	}
+}
+
+func (p *budgetedPipe) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.closed {
+		p.closed = true
+		close(p.done)
+	}
+	return nil
+}
+
+func (p *budgetedPipe) MaxDatagramSize() int { return 1200 }
+
+func (p *budgetedPipe) totals() (datagrams, bytes int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.sent, p.bytes
+}
+
+// Parity costs a code rate, not a byte rate. This is the property the erasure
+// floor was defending, and the reason sizing the code from the measured
+// erasure instead of from a filtered floor is safe: a repair symbol crosses the
+// same congestion window as a source symbol, so raising the estimate changes
+// how a fixed window is spent and never how much goes on the wire.
+//
+// If it were false, sizing for 19.9% rather than 1.76% would be a 30% increase
+// in offered load on a path that was already dropping packets -- which is the
+// feedback loop 9aad61c records, the repair ratio climbing from 11% to 27% to
+// 63% of sent bytes.
+func TestParityCostsACodeRateAndNotAByteRate(t *testing.T) {
+	const budget = 400 * 1024
+	send := func(erasure float64) (wireBytes, payloadFrames int) {
+		m := pathmodel.NewPathModel()
+		m.Report(1, pathmodel.Observation{
+			Floor: erasure, FloorSamples: 5000, Erasure: erasure, BurstFactor: 1,
+			ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 200 * time.Millisecond,
+		})
+		pa, _ := newBudgetedPipes(budget)
+		p := New(pa, Config{SymbolBytes: 1100, RoundTrip: 200 * time.Millisecond, Path: m})
+		defer p.Close()
+
+		frame := make([]byte, 900)
+		for i := 0; i < 2000; i++ {
+			if err := p.Send(frame); err != nil {
+				break
+			}
+			payloadFrames++
+		}
+		// Let the send loop drain what it accepted.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, b := pa.totals(); b >= budget-2*1200 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		_, wireBytes = pa.totals()
+		return wireBytes, payloadFrames
+	}
+
+	cleanWire, _ := send(0)
+	lossyWire, _ := send(0.199)
+	t.Logf("clean path put %d bytes on the wire; a 19.9%% erasure path put %d, against a %d budget",
+		cleanWire, lossyWire, budget)
+
+	if lossyWire > budget {
+		t.Fatalf("a coded path put %d bytes through a %d byte window: parity is being added "+
+			"on top of the budget rather than spent out of it", lossyWire, budget)
+	}
+	if cleanWire > budget {
+		t.Fatalf("an uncoded path put %d bytes through a %d byte window", cleanWire, budget)
+	}
+	// And the coded path really did buy parity with that window rather than
+	// simply sending less: it should have used essentially all of it.
+	if lossyWire < budget/2 {
+		t.Fatalf("the coded path used only %d of a %d byte window, so this proves nothing "+
+			"about what it would do with a full one", lossyWire, budget)
+	}
+}

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -284,8 +284,20 @@ func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 		// together, and the share is what stops their probes compounding. An
 		// untrusted local estimate contributes zero weight rather than diluting
 		// a floor another lane has already established.
-		state := e.path.Report(e.id(), floor, floorSamples, float64(snapshot.Decided),
-			float64(e.inner.bandwidth()), e.inner.minRoundTrip())
+		//
+		// The measured erasure is reported alongside it and is not the same
+		// number. This sender paces from the floor, which is conservative on
+		// purpose; the code is sized from the measurement, because a code that
+		// under-estimates erasure sends no parity into a channel that is
+		// erasing. Reporting only the floor is what left 97% of lossy flows
+		// uncoded -- see docs/CONTROL-REDESIGN.md.
+		state := e.path.Report(e.id(), pathmodel.Observation{
+			Floor: floor, FloorSamples: floorSamples,
+			Erasure: snapshot.Loss, BurstFactor: snapshot.BurstFactor,
+			ObservedSamples: float64(snapshot.Decided),
+			Delivered:       float64(e.inner.bandwidth()),
+			RoundTrip:       e.inner.minRoundTrip(),
+		})
 		floor = state.Floor
 		e.share.Store(uint64(state.Share))
 	}

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -368,8 +368,8 @@ func TestTheCongestionWindowIsCompensated(t *testing.T) {
 func TestAJoiningSenderStartsFromWhatIsAlreadyKnown(t *testing.T) {
 	model := pathmodel.NewPathModel()
 	const perMember = 2e6
-	model.Report(1, 0.42, 5000, 5000, perMember, 0)
-	model.Report(2, 0.42, 5000, 5000, perMember, 0)
+	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
+	model.Report(2, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
 
 	seeded := NewErasureSenderOn(1200, model)
 	if seeded.Share() <= 0 {
@@ -384,7 +384,7 @@ func TestAJoiningSenderStartsFromWhatIsAlreadyKnown(t *testing.T) {
 
 func TestAJoiningSenderUsesButDoesNotClaimTheInheritedFloor(t *testing.T) {
 	model := pathmodel.NewPathModel()
-	model.Report(1, 0.42, 5000, 5000, 2e6, 250*time.Millisecond)
+	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 250 * time.Millisecond})
 
 	seeded := NewErasureSenderOn(1200, model)
 	if seeded.floorTrusted || seeded.establishedFloor != 0 {
@@ -401,7 +401,7 @@ func TestAJoiningSenderUsesButDoesNotClaimTheInheritedFloor(t *testing.T) {
 	if floor != 0 || samples != 0 {
 		t.Fatalf("first replacement report = floor %.3f samples %.0f, want no local verdict", floor, samples)
 	}
-	if got := model.Report(seeded.id(), floor, samples, 12, 0, 0).Floor; got != 0.42 {
+	if got := model.Report(seeded.id(), pathmodel.Observation{Floor: floor, FloorSamples: samples, Erasure: floor, BurstFactor: 1, ObservedSamples: 12}).Floor; got != 0.42 {
 		t.Fatalf("untrusted replacement report erased retained floor: %.3f", got)
 	}
 
@@ -429,7 +429,7 @@ func TestAJoiningSenderUsesButDoesNotClaimTheInheritedFloor(t *testing.T) {
 func TestAJoiningSenderStartsWithTheWindowItsRateImplies(t *testing.T) {
 	const rate, roundTrip = 2e6, 250 * time.Millisecond
 	model := pathmodel.NewPathModel()
-	model.Report(1, 0.42, 5000, 5000, rate, roundTrip)
+	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: roundTrip})
 
 	seeded := NewErasureSenderOn(1200, model)
 	fresh := NewErasureSender(1200)
@@ -449,7 +449,7 @@ func TestAJoiningSenderStartsWithTheWindowItsRateImplies(t *testing.T) {
 	// sender must still start from the rate rather than refusing to start.
 	blind := NewErasureSenderOn(1200, func() *pathmodel.PathModel {
 		m := pathmodel.NewPathModel()
-		m.Report(1, 0.42, 5000, 5000, rate, 0)
+		m.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
 		return m
 	}())
 	if blind.bandwidth() <= NewErasureSender(1200).bandwidth() {

--- a/internal/fec/rate.go
+++ b/internal/fec/rate.go
@@ -92,14 +92,29 @@ const (
 // Choose sizes a code for the erasure the path is measured to be applying to
 // the direction this endpoint sends into.
 //
-// It sizes for the measured erasure rather than for a filtered floor. A floor
-// is the part of the loss that does not respond to sending more slowly, and
-// separating it from congestion mattered while parity was added on top of the
-// sending rate: coding for a queue's drops put more traffic into the queue
-// that was already overflowing. Parity is now drawn from the same byte budget
-// as data, so raising the estimate can only change how the budget is spent and
-// never how much is spent. The classification has no consumer left, and the
-// number that is actually measurable is the one used.
+// It sizes for the measured erasure rather than for a filtered floor, and that
+// is only safe because parity costs a code rate rather than a byte rate.
+//
+// A floor is the part of the loss that does not respond to sending more
+// slowly. Separating it from congestion would matter if coding for a queue's
+// drops put more traffic into the queue that was already overflowing -- and
+// that is what the floor was defending against. It does not, because a repair
+// symbol is not additional load. It crosses the same congestion window as a
+// source symbol: coded.QUICCarrier runs on QUIC datagrams, whose congestion
+// controller, pacer and loss detector all apply, and ErasureSender.bandwidth
+// caps that window at this lane's share of the endpoint pair's measured
+// bottleneck so that lanes cannot compound. Raising this estimate therefore
+// changes how a fixed window is spent -- more parity, less payload -- and
+// never how much is put on the wire.
+//
+// What made the floor look necessary was that the window was not fixed in
+// practice: the bandwidth estimate behind it could be latched at a burst rate
+// for the better part of an hour, so the cap was computed from a figure the
+// path had never sustained and never bound. That is a defect in the estimate
+// rather than a reason to under-size a code, and it is fixed in the filter.
+//
+// So the classification has no consumer left here, and the number that is
+// actually measurable is the one used.
 //
 // The rate is the one that delivers a block soonest, not one that meets a
 // residual target. A target cannot be checked -- the sender never observes the

--- a/internal/fec/rate.go
+++ b/internal/fec/rate.go
@@ -32,13 +32,10 @@ type Params struct {
 	RateBytesPerSec float64
 	// RoundTrip is the path's minimum round trip. It bounds the useful block
 	// length: a block that takes longer to send than a retransmission takes to
-	// arrive has given up the only thing coding was for.
+	// arrive has given up the only thing coding was for. It is also what an
+	// unrepairable block costs, which is what decides how much parity is worth
+	// buying -- see reissueCost.
 	RoundTrip time.Duration
-	// TargetResidual is the acceptable probability that a block arrives
-	// unrepairable and has to be retransmitted. It should not be zero: driving
-	// it down costs parity geometrically, and the residual is exactly what
-	// retransmission is good at.
-	TargetResidual float64
 }
 
 // Plan is a code chosen for a channel.
@@ -74,11 +71,6 @@ type Plan struct {
 const MaxShards = 256
 
 const (
-	// minCodedLoss is the erasure rate below which parity costs more than it
-	// saves. Below it a retransmission is rare enough to be cheap, and every
-	// parity shard is bandwidth taken from data on a path where bandwidth is
-	// the scarce thing.
-	minCodedLoss = 0.005
 	// minShards keeps a block long enough that the binomial has some shape. A
 	// two-shard block at 42% loss needs a rate near a third to be reliable,
 	// which is worse than not coding.
@@ -87,24 +79,39 @@ const (
 	// eight times the wire per byte delivered. Past that the channel is not
 	// one this transport can use, and saying so is more useful than pretending.
 	minRate = 0.125
+	// codeStillRepairs is where a code stops being one. A block that fails
+	// more often than it succeeds is not repaired by its parity, it is a
+	// lottery ticket bought with bandwidth, and the objective cannot tell the
+	// difference on its own: at an erasure rate no rate can carry, every
+	// candidate delivers about nothing and the search picks between failures.
+	// A half is not a tuning knob but the point where the arithmetic changes
+	// meaning.
+	codeStillRepairs = 0.5
 )
 
-// Choose sizes a code for what the estimator currently believes about the path.
+// Choose sizes a code for the erasure the path is measured to be applying to
+// the direction this endpoint sends into.
 //
-// It sizes for the loss floor rather than the loss rate. The floor is the part
-// of the loss that does not respond to sending more slowly, so it is the part
-// that has to be coded around; the excess above it is congestion, and parity
-// added to an overflowing queue is more of exactly what overflowed it. The two
-// are not separated by policy but by the estimator's min filter, which is also
-// what makes this self-correcting: congestion that persists long enough to
-// leave the filter's window becomes the floor, and then it does get coded for.
+// It sizes for the measured erasure rather than for a filtered floor. A floor
+// is the part of the loss that does not respond to sending more slowly, and
+// separating it from congestion mattered while parity was added on top of the
+// sending rate: coding for a queue's drops put more traffic into the queue
+// that was already overflowing. Parity is now drawn from the same byte budget
+// as data, so raising the estimate can only change how the budget is spent and
+// never how much is spent. The classification has no consumer left, and the
+// number that is actually measurable is the one used.
+//
+// The rate is the one that delivers a block soonest, not one that meets a
+// residual target. A target cannot be checked -- the sender never observes the
+// residual it chose -- and it is the wrong question anyway: parity always
+// costs wire and only ever buys latency, so what decides how much to buy is
+// what an unrepairable block costs, which reissueCost measures. That also
+// makes the decision to send no parity at all fall out of the same arithmetic
+// instead of needing a threshold constant.
 func Choose(s lossmodel.Snapshot, p Params) Plan {
-	loss := s.Floor
+	loss := s.Loss
 	if loss <= 0 {
-		loss = s.Loss
-	}
-	if loss < minCodedLoss {
-		return Plan{Why: "loss below the parity's cost"}
+		return Plan{Why: "no erasure measured on the sending direction"}
 	}
 	if !(loss < 1) {
 		// Written as a negation so it also refuses NaN, which passes every
@@ -120,7 +127,7 @@ func Choose(s lossmodel.Snapshot, p Params) Plan {
 		// counters saying why.
 		return Plan{Why: "loss rate is not a measurement"}
 	}
-	if p.ShardBytes <= 0 || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
+	if p.ShardBytes <= 0 {
 		return Plan{Why: "no usable parameters"}
 	}
 
@@ -138,9 +145,12 @@ func Choose(s lossmodel.Snapshot, p Params) Plan {
 		trials = 1
 	}
 
-	// Search down from the highest rate that could work. The tail is monotone
-	// in k, so the first k that meets the target is the best one.
+	// Walk every rate the block can carry and keep the one that delivers its
+	// data soonest. The tail is monotone in k but the objective is not: parity
+	// buys a smaller residual and costs wire, so the best rate is an interior
+	// point rather than the first k past a threshold.
 	best := Plan{LossCoded: loss, EffectiveBurst: burst}
+	bestDelivered := 0.0
 	for k := n; k >= 1; k-- {
 		if float64(k)/float64(n) < minRate {
 			break
@@ -149,44 +159,120 @@ func Choose(s lossmodel.Snapshot, p Params) Plan {
 		if !ok {
 			continue
 		}
-		if residual <= p.TargetResidual {
-			best.Code = true
-			best.K, best.N = k, n
-			best.Rate = float64(k) / float64(n)
-			best.Residual = residual
-			best.Why = "sized for the loss floor"
-			return best
+		delivered := deliveredPerSymbolTime(k, n, residual, p.reissueCost(k))
+		if delivered <= bestDelivered {
+			continue
 		}
+		bestDelivered = delivered
+		best.K, best.N = k, n
+		best.Rate = float64(k) / float64(n)
+		best.Residual = residual
 	}
-	best.Why = "no code rate above the floor meets the target residual"
+	if best.N == 0 {
+		best.Why = "no code rate is long enough for this block"
+		return best
+	}
+	if best.Residual >= codeStillRepairs {
+		// Every rate this channel allows loses the block more often than it
+		// keeps it, so the search has been comparing ways of failing. Sizing
+		// one of them would spend the lowest rate minRate permits on a channel
+		// that defeats it; saying so is the more useful answer, and it is the
+		// same judgement minRate already makes about the wire.
+		best.Why = "no code rate this channel allows repairs a block more often than not"
+		return best
+	}
+	if best.K >= best.N {
+		// The whole block carrying data delivered soonest, so every repair
+		// this channel could have earned cost more wire than the stall it
+		// would have saved. Reported rather than coded, because an uncoded
+		// path is a decision this made and not a case it failed to consider.
+		best.Code = false
+		best.Why = "parity costs more wire than the stall it saves"
+		return best
+	}
+	best.Code = true
+	best.Why = "sized for the soonest delivery"
 	return best
 }
 
+// deliveredPerSymbolTime is data shards delivered per symbol-time, counting
+// what a block that cannot be repaired costs before its data arrives.
+//
+// This is the objective, and it is a time rather than a ratio because parity
+// never pays for itself in wire: sending k of n shards as data always carries
+// less data per byte than sending all n, and a retransmission recovers the
+// difference eventually. What parity buys is the eventually. Dividing by the
+// stall makes the two comparable, so the arithmetic can decide how much of the
+// budget to spend rather than being told by a residual target.
+//
+// The stall is charged for the re-issues it actually takes, not for one. A
+// re-issue crosses the same channel and can be erased in its turn, so a block
+// that fails with probability r expects r/(1-r) further round trips rather
+// than a single one. At a small residual the difference is nothing; at a large
+// one it is the whole answer, because charging a single round trip makes an
+// uncoded block on a 72% erasure channel look cheaper than any code -- it
+// quietly assumes the one retransmission gets through.
+func deliveredPerSymbolTime(k, n int, residual, reissue float64) float64 {
+	if !(residual < 1) {
+		return 0
+	}
+	return float64(k) / (float64(n) + residual/(1-residual)*reissue)
+}
+
+// reissueCost is what a block the code cannot repair costs, in symbol-times,
+// before the data it carried is delivered: one round trip, expressed as the
+// symbols this flow could have sent while it waited.
+//
+// It is the round trip for a bulk flow as well as an interactive one, and that
+// is a claim rather than an identity. A bulk flow does keep the pipe full
+// while the re-issue is in flight, so it is tempting to charge a residual
+// block only the wire to carry it again -- but the gap still stalls
+// reassembly, and on a path with this much delay the receive window fills
+// behind it long before the re-issue lands. Charging only the wire makes the
+// arithmetic decline to code at any loss rate; charging the whole round trip
+// makes it code at almost every loss rate. The truth is between them and
+// depends on how much of the window the stall actually holds, which is not
+// modelled here.
+//
+// This picks the round trip because removing a round trip from a gap is what
+// this transport exists to do, and because under-coding is what the incident
+// this design answers was made of. It is the least defensible number in the
+// objective and the pathsim cases in docs/CONTROL-REDESIGN.md are what should
+// settle it.
+func (p Params) reissueCost(k int) float64 {
+	if p.RoundTrip <= 0 || p.RateBytesPerSec <= 0 || p.ShardBytes <= 0 {
+		return float64(k)
+	}
+	return p.RoundTrip.Seconds() * p.RateBytesPerSec / float64(p.ShardBytes)
+}
+
 // ShardsFor answers Choose's question in the other direction: given how many
-// data shards a block actually holds, the smallest total that meets the target
-// residual.
+// data shards a block actually holds, the total length that delivers them
+// soonest.
 //
 // A block is not always the length the plan assumed. A flow that flushes a
 // short write seals a block of one or two shards, and sizing that block by the
 // plan's rate would be wrong in both directions -- it would send the plan's
 // whole block length for a few bytes, and it would still be too weak, because
 // a short block has no room for the binomial to average out. Repairing one
-// shard at 42% loss needs eight copies to reach a residual of a thousandth,
-// and that is the honest answer rather than the rate the long blocks use.
+// shard at 42% loss needs eight copies before the stall it saves is worth the
+// wire, and that is the honest answer rather than the rate the long blocks use.
 func ShardsFor(k int, s lossmodel.Snapshot, p Params) (int, bool) {
 	if k < 1 {
 		return 0, false
 	}
-	loss := s.Floor
-	if loss <= 0 {
-		loss = s.Loss
-	}
-	if loss < minCodedLoss || !(loss < 1) || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
+	loss := s.Loss
+	if loss <= 0 || !(loss < 1) {
 		return k, false
 	}
 	burst := p.effectiveBurst(s)
 	arrival := 1 - loss
+	reissue := p.reissueCost(k)
+	bestN, bestDelivered := 0, 0.0
 	for n := k; n <= MaxShards; n++ {
+		if float64(k)/float64(n) < minRate {
+			break
+		}
 		trials := int(math.Round(float64(n) / burst))
 		if trials < 1 {
 			trials = 1
@@ -195,9 +281,15 @@ func ShardsFor(k int, s lossmodel.Snapshot, p Params) (int, bool) {
 		if !ok {
 			continue
 		}
-		if residual <= p.TargetResidual {
-			return n, true
+		if delivered := deliveredPerSymbolTime(k, n, residual, reissue); delivered > bestDelivered {
+			bestN, bestDelivered = n, delivered
 		}
+	}
+	if bestN > k {
+		return bestN, true
+	}
+	if bestN == k {
+		return k, false
 	}
 	return 0, false
 }
@@ -229,33 +321,47 @@ func WindowRate(capacity int, s lossmodel.Snapshot, p Params) float64 {
 	if capacity < 1 {
 		return 0
 	}
-	loss := s.Floor
-	if loss <= 0 {
-		loss = s.Loss
-	}
-	if loss < minCodedLoss || p.TargetResidual <= 0 || p.TargetResidual >= 1 {
+	loss := s.Loss
+	if loss <= 0 || !(loss < 1) {
 		return 0
 	}
 	arrival := 1 - loss
-	if arrival <= 0 {
-		return maxWindowRate
-	}
 	effective := int(float64(capacity) * windowChaining)
-	// The tail falls as transmissions are added, so the smallest total that
-	// meets the target is a bisection rather than a walk.
-	lo, hi := effective, int(float64(effective)/arrival*maxWindowRate)
-	if binomialTailBelow(hi, arrival, effective) > p.TargetResidual {
-		return maxWindowRate
+	if effective < 1 {
+		return 0
 	}
-	for lo < hi {
-		mid := lo + (hi-lo)/2
-		if binomialTailBelow(mid, arrival, effective) <= p.TargetResidual {
-			hi = mid
-		} else {
-			lo = mid + 1
+	reissue := p.reissueCost(effective)
+	// The objective is not monotone in the number of transmissions -- the tail
+	// falls while the wire cost rises -- so the answer is neither a bisection
+	// nor the end of a walk. It is cheap to find anyway: the search is bounded
+	// by maxWindowRate, and coding() only re-runs this every codingTTL, so a
+	// coarse sweep followed by a local refinement costs far less than the
+	// estimate feeding it is worth.
+	hi := int(float64(effective) * maxWindowRate)
+	if hi <= effective {
+		return 0
+	}
+	deliveredAt := func(total int) float64 {
+		return deliveredPerSymbolTime(effective, total, binomialTailBelow(total, arrival, effective), reissue)
+	}
+	const sweep = 32
+	bestTotal, bestDelivered := effective, deliveredAt(effective)
+	step := (hi - effective) / sweep
+	if step < 1 {
+		step = 1
+	}
+	for total := effective + step; total <= hi; total += step {
+		if delivered := deliveredAt(total); delivered > bestDelivered {
+			bestTotal, bestDelivered = total, delivered
 		}
 	}
-	return float64(lo-effective) / float64(effective)
+	lo := max(effective, bestTotal-step)
+	for total := lo; total <= min(hi, bestTotal+step); total++ {
+		if delivered := deliveredAt(total); delivered > bestDelivered {
+			bestTotal, bestDelivered = total, delivered
+		}
+	}
+	return float64(bestTotal-effective) / float64(effective)
 }
 
 const (

--- a/internal/fec/rate_test.go
+++ b/internal/fec/rate_test.go
@@ -15,7 +15,6 @@ func livePath() Params {
 		ShardBytes:      1200,
 		RateBytesPerSec: 25e6 / 8,
 		RoundTrip:       300 * time.Millisecond,
-		TargetResidual:  1e-3,
 	}
 }
 
@@ -28,43 +27,61 @@ func liveSnapshot() lossmodel.Snapshot {
 	}
 }
 
-// Coding for the loss floor rather than the loss rate is the design's central
-// claim. During a congestion episode the code must not inflate: the extra loss
-// is a queue overflowing, and parity is more of what overflowed it.
-func TestTheCodeIsSizedForTheFloorNotTheSpike(t *testing.T) {
+// Coding for the measured erasure rather than for a filtered floor is the
+// redesign's central claim, and it is the reverse of what this file asserted
+// before. The floor existed because parity was added on top of the sending
+// rate, so coding for a queue's drops fed the queue. Parity is now drawn from
+// the same budget as data, so a rise in measured loss must reach the code.
+func TestTheCodeFollowsTheMeasuredErasure(t *testing.T) {
 	calm := liveSnapshot()
-	congested := calm
-	congested.Loss = 0.72
-	congested.Recent = 0.72
-	congested.Congestive = 0.30
-	congested.BurstFactor = 1.6
-	congested.MeanBurst = 5.7
-	congested.Memoryless = false
-	// The floor is unchanged: the channel did not get worse, the queue did.
+	worse := calm
+	worse.Loss = 0.72
+	worse.Recent = 0.72
+	worse.BurstFactor = 1.6
+	worse.MeanBurst = 5.7
+	worse.Memoryless = false
 
 	before := Choose(calm, livePath())
-	during := Choose(congested, livePath())
-	t.Logf("calm: (%d,%d) rate=%.3f; congested: (%d,%d) rate=%.3f",
+	during := Choose(worse, livePath())
+	t.Logf("42%%: (%d,%d) rate=%.3f; 72%%: (%d,%d) rate=%.3f",
 		before.K, before.N, before.Rate, during.K, during.N, during.Rate)
 
-	if !during.Code {
-		t.Fatalf("coding abandoned during congestion: %+v", during)
+	if !before.Code || !during.Code {
+		t.Fatalf("expected both to be coded: %+v %+v", before, during)
 	}
-	if during.Overhead() > before.Overhead()*1.35 {
-		t.Fatalf("overhead rose from %.2fx to %.2fx on congestion the sender should "+
-			"be removing by slowing down, not coding around",
-			before.Overhead(), during.Overhead())
+	if during.Rate >= before.Rate {
+		t.Fatalf("erasure rose from 42%% to 72%% and the code rate did not fall: %.3f then %.3f",
+			before.Rate, during.Rate)
+	}
+	if during.LossCoded != worse.Loss {
+		t.Fatalf("sized for %.3f against a measured %.3f: the plan is reading something else",
+			during.LossCoded, worse.Loss)
 	}
 }
 
-// A path that is barely lossy must not be made to carry parity. Every parity
-// shard is bandwidth taken from data, and on a rare-loss path retransmission is
-// cheaper than any code.
-func TestACleanPathIsNotCoded(t *testing.T) {
+// A path with nothing to repair must carry no parity, and it must reach that
+// answer from the objective rather than from a threshold constant: there is no
+// minimum coded loss any more, so a clean path is only uncoded if spending
+// wire on parity genuinely delivers its data no sooner.
+func TestAPathWithNothingToRepairIsNotCoded(t *testing.T) {
 	clean := liveSnapshot()
-	clean.Loss, clean.Floor, clean.Recent = 0.001, 0.001, 0.001
+	clean.Loss, clean.Floor, clean.Recent = 0, 0, 0
 	if plan := Choose(clean, livePath()); plan.Code {
-		t.Fatalf("a 0.1%% loss path was coded at %.2fx overhead: %+v", plan.Overhead(), plan)
+		t.Fatalf("a lossless path was coded at %.2fx overhead: %+v", plan.Overhead(), plan)
+	}
+}
+
+// A barely lossy path may buy a little parity, because a block of 256 shards
+// at one loss in a thousand still stalls better than a fifth of the time, and
+// a round trip is expensive on the path this transport is for. What it must
+// not do is spend real bandwidth on it.
+func TestABarelyLossyPathBuysLittleParity(t *testing.T) {
+	barely := liveSnapshot()
+	barely.Loss, barely.Floor, barely.Recent = 0.001, 0.001, 0.001
+	plan := Choose(barely, livePath())
+	t.Logf("0.1%% loss: coded=%v overhead=%.4fx residual=%.2e", plan.Code, plan.Overhead(), plan.Residual)
+	if plan.Overhead() > 1.05 {
+		t.Fatalf("a 0.1%% loss path was charged %.3fx overhead: %+v", plan.Overhead(), plan)
 	}
 }
 
@@ -201,7 +218,7 @@ func TestBinomialTail(t *testing.T) {
 // the lowest rate this search allows -- eight times the wire per delivered
 // byte -- on the path that produced the impossible figure.
 func TestChooseRefusesAnImpossibleLossRate(t *testing.T) {
-	params := Params{ShardBytes: 1200, RateBytesPerSec: 1e6, RoundTrip: 300 * time.Millisecond, TargetResidual: 1e-3}
+	params := Params{ShardBytes: 1200, RateBytesPerSec: 1e6, RoundTrip: 300 * time.Millisecond}
 	for _, loss := range []float64{1, 1.2527, math.Inf(1), math.NaN()} {
 		t.Run(fmt.Sprintf("%v", loss), func(t *testing.T) {
 			plan := Choose(lossmodel.Snapshot{Loss: loss, Floor: loss, Recent: loss, BurstFactor: 1}, params)
@@ -217,5 +234,44 @@ func TestChooseRefusesAnImpossibleLossRate(t *testing.T) {
 	plan := Choose(lossmodel.Snapshot{Loss: 0.42, Floor: 0.42, Recent: 0.42, BurstFactor: 1}, params)
 	if !plan.Code {
 		t.Fatalf("refused to code a 42%% erasure channel: %+v", plan)
+	}
+}
+
+// The incident this redesign answers was not a code that was slightly weak. It
+// was a code sized for a tenth of the erasure actually present: at 19.9%
+// measured downstream erasure the gateway's plan was sized for 1.76%, and
+// every one of 14,792 flows above 5% erasure ran a code sized for less than
+// half of it. The floor that produced those numbers is gone, so this holds the
+// replacement to the property that was violated -- the plan is sized for what
+// the channel is measured to do, and the residual it predicts is one the
+// session above can absorb rather than one that re-issues a tenth of the
+// payload.
+func TestNoPlanIsSizedForAFractionOfTheMeasuredErasure(t *testing.T) {
+	for _, loss := range []float64{0.05, 0.10, 0.199, 0.30, 0.42, 0.50} {
+		s := liveSnapshot()
+		s.Loss, s.Floor, s.Recent = loss, loss, loss
+		s.ArrivalAfterLoss = 1 - loss
+		plan := Choose(s, livePath())
+		if !plan.Code {
+			t.Fatalf("erasure %.3f was left uncoded (%s)", loss, plan.Why)
+		}
+		t.Logf("erasure %.3f: rate=%.3f overhead=%.2fx residual=%.2e sized_for=%.3f",
+			loss, plan.Rate, plan.Overhead(), plan.Residual, plan.LossCoded)
+		if plan.LossCoded < loss {
+			t.Errorf("erasure %.3f: plan sized for %.3f, less than the channel is doing",
+				loss, plan.LossCoded)
+		}
+		// The parity has to be worth something against that erasure. A code
+		// whose block still fails a tenth of the time hands the tenth back to
+		// the session, which is the residual the incident was made of.
+		if plan.Residual > 0.1 {
+			t.Errorf("erasure %.3f: rate %.3f leaves a residual of %.3f for the session to re-issue",
+				loss, plan.Rate, plan.Residual)
+		}
+		// And it must not have overcorrected into spending the path on parity.
+		if plan.Overhead() > 1/(1-loss)*2 {
+			t.Errorf("erasure %.3f: overhead %.2fx is more than twice what the channel costs",
+				loss, plan.Overhead())
+		}
 	}
 }

--- a/internal/fec/window_test.go
+++ b/internal/fec/window_test.go
@@ -165,6 +165,15 @@ func TestWindowRecoversAtTheMeasuredRate(t *testing.T) {
 // stated rate is one paying for a residual nobody asked for, which on this
 // path is bandwidth taken from data.
 func TestTheWindowRateIsWhatTheWindowNeeds(t *testing.T) {
+	// There is no residual target any more, so the rate is held to what it is
+	// for: it must protect the window it was chosen for, and it must not be
+	// buying protection the objective never asked for. Both bounds are the
+	// simulation's own, an order of magnitude apart, so the test fails on a
+	// rate that has drifted rather than on sampling noise.
+	const (
+		protects       = 5e-3
+		wasteIsVisible = 2e-2
+	)
 	const loss, count = 0.42, 20000
 	channel := lossmodel.Snapshot{
 		Loss: loss, Floor: loss, Recent: loss,
@@ -172,7 +181,7 @@ func TestTheWindowRateIsWhatTheWindowNeeds(t *testing.T) {
 	}
 	params := Params{
 		Class: ClassBulk, ShardBytes: 1100, RateBytesPerSec: 2e6,
-		RoundTrip: 300 * time.Millisecond, TargetResidual: 1e-3,
+		RoundTrip: 300 * time.Millisecond,
 	}
 	for _, capacity := range []int{16, 32, 64, 128} {
 		rate := WindowRate(capacity, channel, params)
@@ -188,15 +197,13 @@ func TestTheWindowRateIsWhatTheWindowNeeds(t *testing.T) {
 		}
 		t.Logf("capacity %3d: %.2f repairs per symbol gives a residual of %.4f, "+
 			"and three quarters of it gives %.4f", capacity, rate, residual, slack)
-		if residual > 2*params.TargetResidual {
-			t.Errorf("capacity %d: the rate asks for %.2f repairs and delivers a "+
-				"residual of %.4f against a target of %.4f", capacity, rate,
-				residual, params.TargetResidual)
+		if residual > protects {
+			t.Errorf("capacity %d: %.2f repairs per symbol still loses %.4f of them",
+				capacity, rate, residual)
 		}
-		if slack <= params.TargetResidual {
-			t.Errorf("capacity %d: three quarters of the rate still meets the "+
-				"target (%.4f); the rate is buying a residual nobody asked for",
-				capacity, slack)
+		if slack < wasteIsVisible {
+			t.Errorf("capacity %d: three quarters of the rate loses only %.4f, so the "+
+				"chosen rate is spending wire on a residual nobody needs", capacity, slack)
 		}
 	}
 }
@@ -210,6 +217,9 @@ func TestTheWindowRateIsWhatTheWindowNeeds(t *testing.T) {
 // runs that case as the coded path runs it: an isolated burst, the repairs
 // ShardsFor buys, and nothing else on the wire.
 func TestATailBurstSurvivesTheRepairsItIsGiven(t *testing.T) {
+	// The block arithmetic is an estimate, so the tail is held to surviving
+	// rather than to a rate it was never given a target for.
+	const survives = 1e-2
 	const loss, trials = 0.42, 5000
 	channel := lossmodel.Snapshot{
 		Loss: loss, Floor: loss, Recent: loss,
@@ -217,7 +227,7 @@ func TestATailBurstSurvivesTheRepairsItIsGiven(t *testing.T) {
 	}
 	params := Params{
 		Class: ClassBulk, ShardBytes: 1100, RateBytesPerSec: 2e6,
-		RoundTrip: 300 * time.Millisecond, TargetResidual: 1e-3,
+		RoundTrip: 300 * time.Millisecond,
 	}
 	for _, burst := range []int{1, 4, 16, 32} {
 		total, ok := ShardsFor(burst, channel, params)
@@ -230,9 +240,9 @@ func TestATailBurstSurvivesTheRepairsItIsGiven(t *testing.T) {
 		// The estimate is an estimate, so it is held to an order of magnitude
 		// rather than exactly; what must not happen is a tail failing far more
 		// often than the parity it was given says it should.
-		if residual > 10*params.TargetResidual {
-			t.Errorf("a burst of %d with %d repairs lost a symbol %.4f of the time, "+
-				"against a target of %.4f", burst, total-burst, residual, params.TargetResidual)
+		if residual > survives {
+			t.Errorf("a burst of %d with %d repairs lost a symbol %.4f of the time",
+				burst, total-burst, residual)
 		}
 	}
 }

--- a/internal/pathmodel/pathmodel.go
+++ b/internal/pathmodel/pathmodel.go
@@ -70,6 +70,9 @@ type PathModel struct {
 type pathKnowledge struct {
 	floor           float64
 	floorKnown      bool
+	erasure         float64
+	burst           float64
+	erasureKnown    bool
 	observedSamples float64
 	roundTrip       time.Duration
 }
@@ -81,18 +84,60 @@ type Member uint64
 type report struct {
 	floor     float64
 	samples   float64
+	erasure   float64
+	burst     float64
 	observed  float64
 	delivered float64
 	roundTrip time.Duration
 	at        time.Time
 }
 
+// Observation is what one contributor has measured about the direction it
+// sends into.
+//
+// Floor and Erasure are the same channel seen with opposite bias, and they are
+// carried separately because their consumers fail in opposite directions.
+// A congestion controller must under-estimate erasure: believing loss is
+// congestion makes it slow down, which is safe. A code must not: believing
+// loss is congestion makes it send no parity into a channel that is erasing,
+// which is what docs/CONTROL-REDESIGN.md was written about. One number cannot
+// serve both, so the model pools both and each consumer reads the one whose
+// error it can survive.
+type Observation struct {
+	// Floor is the erasure this contributor's controller has established as
+	// independent of its sending rate, and FloorSamples is the weight behind
+	// it. A contributor with no trustworthy estimate reports zero weight
+	// rather than diluting a floor another lane has established.
+	Floor        float64
+	FloorSamples float64
+	// Erasure is the loss rate this contributor measured, unclassified, and
+	// BurstFactor is how much of it arrived in runs. Both are what a code has
+	// to be sized against; neither is safe to pace from.
+	Erasure     float64
+	BurstFactor float64
+	// ObservedSamples records measurement progress even while the floor is
+	// still unknown, which is what distinguishes a measured clean path from an
+	// unmeasured one.
+	ObservedSamples float64
+	// Delivered is this contributor's delivered rate in bytes per second, and
+	// RoundTrip the smallest round trip it has seen.
+	Delivered float64
+	RoundTrip time.Duration
+}
+
 // State is what an endpoint pair has been measured to do, from the point of
 // view of one contributor.
 type State struct {
 	// Floor is the erasure rate that does not respond to sending more slowly,
-	// pooled across every lane's samples.
+	// pooled across every lane's samples. It is deliberately conservative and
+	// is for pacing; a code sized from it under-protects the path. See
+	// Observation.
 	Floor float64
+	// Erasure is the loss rate the contributors measured on the direction they
+	// send into, pooled and unclassified, and BurstFactor is how much of it
+	// arrived in runs. This is what a code is sized against.
+	Erasure     float64
+	BurstFactor float64
 	// ObservedSamples is how many packet outcomes contributors have measured,
 	// including outcomes not yet sufficient to establish a non-zero erasure
 	// floor. It distinguishes a measured clean path from an unmeasured one
@@ -160,7 +205,7 @@ func NewPathModel() *PathModel {
 // endpoint pair believes. floorSamples weights only established floor
 // evidence; observedSamples records measurement progress even while the floor
 // is still unknown.
-func (m *PathModel) Report(member Member, floor, floorSamples, observedSamples, delivered float64, roundTrip time.Duration) State {
+func (m *PathModel) Report(member Member, o Observation) State {
 	now := time.Now()
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -170,13 +215,16 @@ func (m *PathModel) Report(member Member, floor, floorSamples, observedSamples, 
 		entry = &report{}
 		m.members[member] = entry
 	}
-	entry.floor, entry.samples, entry.observed, entry.delivered, entry.at = floor, floorSamples, observedSamples, delivered, now
-	if roundTrip > 0 {
-		entry.roundTrip = roundTrip
+	entry.floor, entry.samples = o.Floor, o.FloorSamples
+	entry.erasure, entry.burst = o.Erasure, o.BurstFactor
+	entry.observed, entry.delivered, entry.at = o.ObservedSamples, o.Delivered, now
+	if o.RoundTrip > 0 {
+		entry.roundTrip = o.RoundTrip
 	}
 
 	var state State
 	var weighted, weight, observed, sum float64
+	var erasureWeighted, burstWeighted float64
 	live := 0
 	for key, other := range m.members {
 		if now.Sub(other.at) > memberIdle {
@@ -189,6 +237,8 @@ func (m *PathModel) Report(member Member, floor, floorSamples, observedSamples, 
 		// which is also what lets a new lane join without disturbing it.
 		weighted += other.floor * other.samples
 		weight += other.samples
+		erasureWeighted += other.erasure * other.observed
+		burstWeighted += other.burst * other.observed
 		observed += other.observed
 		if other.roundTrip > 0 && (state.RoundTrip == 0 || other.roundTrip < state.RoundTrip) {
 			state.RoundTrip = other.roundTrip
@@ -200,6 +250,20 @@ func (m *PathModel) Report(member Member, floor, floorSamples, observedSamples, 
 		m.knowledge.floorKnown = true
 	} else if m.knowledge.floorKnown {
 		state.Floor = m.knowledge.floor
+	}
+	if observed > 0 {
+		state.Erasure = erasureWeighted / observed
+		state.BurstFactor = burstWeighted / observed
+		m.knowledge.erasure, m.knowledge.burst = state.Erasure, state.BurstFactor
+		m.knowledge.erasureKnown = true
+	} else if m.knowledge.erasureKnown {
+		state.Erasure, state.BurstFactor = m.knowledge.erasure, m.knowledge.burst
+	}
+	if state.BurstFactor < 1 {
+		// A burst factor below one is not a channel, it is an unmeasured or
+		// half-filled report. Independent loss is the assumption that makes a
+		// code weakest, so it is the safe one to fall back to.
+		state.BurstFactor = 1
 	}
 	if observed > m.knowledge.observedSamples {
 		m.knowledge.observedSamples = observed
@@ -257,6 +321,7 @@ func (m *PathModel) Current() State {
 	defer m.mu.Unlock()
 	var state State
 	var weighted, weight, observed, bottleneck float64
+	var erasureWeighted, burstWeighted float64
 	live := 0
 	for key, entry := range m.members {
 		if now.Sub(entry.at) > memberIdle {
@@ -266,6 +331,8 @@ func (m *PathModel) Current() State {
 		live++
 		weighted += entry.floor * entry.samples
 		weight += entry.samples
+		erasureWeighted += entry.erasure * entry.observed
+		burstWeighted += entry.burst * entry.observed
 		observed += entry.observed
 		if entry.roundTrip > 0 && (state.RoundTrip == 0 || entry.roundTrip < state.RoundTrip) {
 			state.RoundTrip = entry.roundTrip
@@ -277,6 +344,20 @@ func (m *PathModel) Current() State {
 		m.knowledge.floorKnown = true
 	} else if m.knowledge.floorKnown {
 		state.Floor = m.knowledge.floor
+	}
+	if observed > 0 {
+		state.Erasure = erasureWeighted / observed
+		state.BurstFactor = burstWeighted / observed
+		m.knowledge.erasure, m.knowledge.burst = state.Erasure, state.BurstFactor
+		m.knowledge.erasureKnown = true
+	} else if m.knowledge.erasureKnown {
+		state.Erasure, state.BurstFactor = m.knowledge.erasure, m.knowledge.burst
+	}
+	if state.BurstFactor < 1 {
+		// A burst factor below one is not a channel, it is an unmeasured or
+		// half-filled report. Independent loss is the assumption that makes a
+		// code weakest, so it is the safe one to fall back to.
+		state.BurstFactor = 1
 	}
 	if observed > m.knowledge.observedSamples {
 		m.knowledge.observedSamples = observed

--- a/internal/pathmodel/pathmodel_test.go
+++ b/internal/pathmodel/pathmodel_test.go
@@ -14,10 +14,10 @@ func TestTheFloorIsPooledAcrossLanes(t *testing.T) {
 	m := NewPathModel()
 	// Three lanes with plenty of samples agree on 0.42; a fourth has just
 	// started and has seen almost nothing.
-	m.Report(1, 0.42, 5000, 5000, 1e6, 0)
-	m.Report(2, 0.42, 5000, 5000, 1e6, 0)
-	m.Report(3, 0.42, 5000, 5000, 1e6, 0)
-	floor := m.Report(4, 0.05, 20, 20, 1e6, 0).Floor
+	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(3, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	floor := m.Report(4, Observation{Floor: 0.05, FloorSamples: 20, Erasure: 0.05, BurstFactor: 1, ObservedSamples: 20, Delivered: 1e6, RoundTrip: 0}).Floor
 
 	if math.Abs(floor-0.42) > 0.01 {
 		t.Fatalf("pooled floor %.3f, want the weight of the measured lanes at about 0.42", floor)
@@ -35,10 +35,10 @@ func TestTheFloorIsPooledAcrossLanes(t *testing.T) {
 func TestTheShareDividesTheBottleneck(t *testing.T) {
 	m := NewPathModel()
 	const perLane = 1e6 // bytes per second
-	m.Report(1, 0.42, 5000, 5000, perLane, 0)
-	m.Report(2, 0.42, 5000, 5000, perLane, 0)
-	m.Report(3, 0.42, 5000, 5000, perLane, 0)
-	share := m.Report(4, 0.42, 5000, 5000, perLane, 0).Share
+	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	m.Report(3, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	share := m.Report(4, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0}).Share
 
 	if m.Members() != 4 {
 		t.Fatalf("model counts %d lanes, want 4", m.Members())
@@ -60,15 +60,15 @@ func TestTheShareDividesTheBottleneck(t *testing.T) {
 // A lane on its own must not be capped by a bottleneck nobody has measured.
 func TestAnUnknownBottleneckDoesNotCap(t *testing.T) {
 	m := NewPathModel()
-	if share := m.Report(1, 0, 0, 0, 0, 0).Share; share != 0 {
+	if share := m.Report(1, Observation{Floor: 0, FloorSamples: 0, Erasure: 0, BurstFactor: 1, ObservedSamples: 0, Delivered: 0, RoundTrip: 0}).Share; share != 0 {
 		t.Fatalf("share %.0f before any delivered rate was reported, want 0 for no cap", share)
 	}
 }
 
 func TestObservationProgressDoesNotWeightAnUntrustedFloor(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, 0.42, 5000, 5000, 1e6, 0)
-	state := m.Report(2, 0, 0, 120, 0, 0)
+	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	state := m.Report(2, Observation{Floor: 0, FloorSamples: 0, Erasure: 0, BurstFactor: 1, ObservedSamples: 120, Delivered: 0, RoundTrip: 0})
 	if state.ObservedSamples != 5120 {
 		t.Fatalf("observed samples = %.0f, want 5120", state.ObservedSamples)
 	}
@@ -79,7 +79,7 @@ func TestObservationProgressDoesNotWeightAnUntrustedFloor(t *testing.T) {
 
 func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, 0.42, 5000, 5000, 1e6, 240*time.Millisecond)
+	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 240 * time.Millisecond})
 
 	// Membership governs only concurrent bandwidth sharing. Simulate a lane
 	// going idle without making a five-second unit test: the measurement must
@@ -104,7 +104,7 @@ func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 
 	// Retained knowledge is a handoff, not a permanent verdict. Once a new
 	// connection supplies trusted evidence, it becomes the path's knowledge.
-	changed := m.Report(2, 0.55, 5000, 5000, 1e6, 300*time.Millisecond)
+	changed := m.Report(2, Observation{Floor: 0.55, FloorSamples: 5000, Erasure: 0.55, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 300 * time.Millisecond})
 	if changed.Floor != 0.55 {
 		t.Fatalf("new generation floor = %.3f, want 0.550", changed.Floor)
 	}
@@ -115,8 +115,8 @@ func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 // controller, so membership has to expire.
 func TestAnIdleLaneStopsCounting(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, 0.42, 5000, 5000, 1e6, 0)
-	m.Report(2, 0.42, 5000, 5000, 1e6, 0)
+	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
 	if m.Members() != 2 {
 		t.Fatalf("members = %d, want 2", m.Members())
 	}
@@ -125,7 +125,7 @@ func TestAnIdleLaneStopsCounting(t *testing.T) {
 	m.members[1].at = time.Now().Add(-2 * memberIdle)
 	m.mu.Unlock()
 
-	state := m.Report(2, 0.42, 5000, 5000, 1e6, 0)
+	state := m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
 	if m.Members() != 1 {
 		t.Fatalf("members = %d after one went idle, want 1", m.Members())
 	}
@@ -156,7 +156,7 @@ func TestSharedPathIsPerPeer(t *testing.T) {
 func TestASingleSharedLaneIsNotPenalised(t *testing.T) {
 	m := NewPathModel()
 	const rate = 2e6
-	state := m.Report(1, 0.42, 5000, 5000, rate, 0)
+	state := m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
 	// Not capped at its own rate: not capped at all. A lone lane has nothing
 	// to compound with, and a ceiling equal to what it has already delivered
 	// is one it can never probe past.
@@ -202,7 +202,7 @@ func TestTheShareDoesNotRatchetDown(t *testing.T) {
 			var share float64
 			for round := 0; round < 40; round++ {
 				for i := 0; i < lanes; i++ {
-					share = m.Report(Member(i+1), 0.1, 5000, 5000, delivered[i], 0).Share
+					share = m.Report(Member(i+1), Observation{Floor: 0.1, FloorSamples: 5000, Erasure: 0.1, BurstFactor: 1, ObservedSamples: 5000, Delivered: delivered[i], RoundTrip: 0}).Share
 					// The next round delivers what this one is allowed to,
 					// bounded by the path itself.
 					next := capacity / float64(lanes)

--- a/internal/pep/smallflow_test.go
+++ b/internal/pep/smallflow_test.go
@@ -164,7 +164,7 @@ func TestSmallExchangesAreRepairedOnceThePathIsKnown(t *testing.T) {
 	// learns this from its own traffic or from the prewarm; only the floor is
 	// seeded, because a delivered rate would also claim a share of the
 	// bottleneck and that is a different experiment.
-	pathmodel.Shared(key).Report(99, 0.42, 5000, 5000, 0, 0)
+	pathmodel.Shared(key).Report(99, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
 	knowingSamples := exchange(10, time.Minute)
 	knowing := median(knowingSamples)
 
@@ -828,7 +828,7 @@ func TestAShortFlowCostsARoundTrip(t *testing.T) {
 	// timing test explicitly so scheduler speed under -race cannot decide how
 	// many of its measured flows run before the asynchronous prewarm finishes.
 	loopback := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
-	pathmodel.Shared(pathKey(loopback, loopback)).Report(99, path.LossRate, 5000, 5000, 0, 0)
+	pathmodel.Shared(pathKey(loopback, loopback)).Report(99, pathmodel.Observation{Floor: path.LossRate, FloorSamples: 5000, Erasure: path.LossRate, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
 	// Warm the shared transport independently of the path measurement.
 	warm := dialWithRetries(t, socks, destination, 3)
 	request := make([]byte, 16)


### PR DESCRIPTION
A live China-US path degraded over eight hours while the transport did nothing
about it. Both decoders recorded it, and they disagree in the one way that
matters — every erasure figure belongs to a direction, and only the receiving
end of that direction can measure it:

| Direction | Measured at | Erasure | Residual after FEC |
| --- | --- | --- | --- |
| Upstream, client → gateway | gateway decoder | 3.8% p50 | 0.00% p50 |
| Downstream, gateway → client | client decoder | 19.9% p50, 60.1% peak | 11.0% p50, 56.0% peak |

Of 14,792 client flows above 5% erasure, **every one** ran a code sized for
less than half of it and **97%** ran no code at all. In the worst record the
local estimator's own floor read 77.0% while the plan it produced was sized for
0.00%. Tunnelled throughput matched direct TCP over the same segment in the
same window — 2.10–2.20 MB/s against 2.00–2.25 — so the transport delivered
none of what it exists for while re-issuing a ninth of the payload a round trip
late.

## What changed

**The code is sized from the measurement, not the controller's floor.**
`coded.Path.channel()` built the code's entire view of the channel out of one
scalar, with `Loss`, `Floor` and `Recent` all set to it and `BurstFactor`
asserted to be 1. The floor is biased low deliberately — a controller that
under-estimates erasure slows down, which is safe — so a code sized from it is
sized for a fraction of what the channel is doing. It also killed `Choose`'s
own fallback, which reads `Loss` when `Floor` is zero: both were the same zero.
`pathmodel` now carries the measured erasure and its burstiness beside the
floor, and each consumer reads the one whose error it can survive. **Pacing is
unchanged** — the controller keeps the floor.

**`TargetResidual` and `minCodedLoss` are gone.** The rate is now the one that
delivers a block soonest, counting what an unrepairable block costs in round
trips before its data arrives. A clean path buys no parity and a lossy one buys
as much as it is worth, without either case needing a constant.

Against the erasure that was actually measured:

| Erasure | Overhead | Predicted residual |
| --- | --- | --- |
| 5% | 1.10× | 0.26% |
| 19.9% (the incident) | 1.36× | 0.39% |
| 42% | 1.97× | 0.84% |

The incident shipped 1.05× and 11% at the middle row.

## Evidence and checks

Erasure figures are from per-flow completion records, not the aggregate
counters — `internal/metrics` sums each *live* flow's cumulative counters and
exports the total as a counter, so the value falls whenever a flow expires and
anything differencing it reads noise. Not fixed here.

Two regression tests encode the failure: one in `fec` asserting no plan is ever
sized for a fraction of the measured erasure, and one in `coded` that feeds the
incident's exact disagreement (floor 1.76%, measured 19.9%) through the real
wiring. `go test -short ./...` green across 27 packages, plus `go vet`,
`gofmt`, `staticcheck -checks=all,-U1000`, and `./scripts/changelog.py check`.

## What this does not solve

- **Lane idle timeouts**, behind 79% of observed flow failures, and better
  coding does not help: keepalives are QUIC PING frames and the coded substrate
  sits above QUIC, so it never protects them.
- **The bandwidth filter**, which latches a burst rate for ~66 min on an
  app-limited connection — 519 Mbit/s held against a measured 17.6.
- The metrics accumulators, the structurally dead `quic_packets_lost`, and
  direction typing.

## Review notes

`reissueCost` is the least defensible number in the objective and says so where
it is defined. Charging only the wire declines to code at any loss rate;
charging the whole round trip codes at almost every loss rate. Which is right
depends on how much of the receive window a stall holds, which is not modelled.
**None of this is validated on a real path yet** — `docs/CONTROL-REDESIGN.md`
lists the pathsim cases that should settle it, and case 4 (shallow-buffered
dropper) is the one expected to fail.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
