### PR TITLE
fix: record what a flow's lane replacements actually did

### DIFF
--- a/changelog.d/lane-replacement-diagnostics.fixed.md
+++ b/changelog.d/lane-replacement-diagnostics.fixed.md
@@ -1,0 +1,11 @@
+Flow completion records now report what the flow's lane replacements did:
+`lane_replacement_waits`, `lane_replacement_timeouts`, `lane_replacement_wait`
+and `lanes_joined`, written by both the client and the gateway under the same
+names. A flow that fails with "lane replacement timeout" previously recorded
+only that it had given up, which was 94% of the failures observed on a live
+gateway over two hours and could not be diagnosed after the fact: the record
+did not say whether a replacement lane had ever been offered, how many graces
+the flow burned before failing, or how long it spent with no lane at all.
+Distinguishing a pool that will not rebuild from a path that will not carry a
+handshake needs all four, and none of them could be recovered from the logs as
+they stood.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -114,6 +114,14 @@ Prometheus `/metrics` names. They cover:
 - the controller's measured erasure floor, sampler diagnostics, and class
   transitions.
 
+Flow completion records also carry what the flow's lane replacements did:
+`lane_replacement_waits`, `lane_replacement_timeouts`, `lane_replacement_wait`,
+and `lanes_joined`. They are written on every flow record, not only on
+failures, because a replacement that succeeded is the control case for one that
+did not. A flow that never lost its last healthy lane reports zeroes. Both
+endpoints use the same names, so a client record and a gateway record about the
+same failure can be read side by side.
+
 The dashboard calculates interval packet loss from changes in sent and lost
 packet counters. QUIC can later recognize a packet previously declared lost,
 so its lost byte/packet counters are allowed to decrease; the dashboard skips

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -822,6 +822,7 @@ func (c *Client) handleLocal(ctx context.Context, inner net.Conn) {
 		"coded_substrate", codedSubstrateFields(substrate, hasCoded),
 		"class", classifier.Class(flowSession.class.Load())}
 	logFields = append(logFields, codedSubstrateLogFields(substrate, hasCoded)...)
+	logFields = append(logFields, flowSession.replacementLogFields()...)
 	if !flowComplete && err != nil && !errors.Is(err, context.Canceled) {
 		c.cfg.Logger.Warn("local flow ended with error", append(logFields, "error", err)...)
 		return

--- a/internal/pep/lanegrace_test.go
+++ b/internal/pep/lanegrace_test.go
@@ -91,3 +91,57 @@ func newGraceTestFlow(t *testing.T) *multipathFlow {
 	t.Cleanup(func() { _ = inner.Close(); _ = peer.Close() })
 	return newMultipathFlow(context.Background(), inner, [16]byte{2}, 3, defaultChunkSize, protocol.FlagAckUp, protocol.FlagAckDown, nil, nil)
 }
+
+// A flow that fails with "lane replacement timeout" used to say only that it
+// gave up. The live gateway produced 521 of those in two hours, all of them
+// ordinary small exchanges that had already moved a few kilobytes, and the
+// record could not say whether a replacement lane had ever been offered or how
+// many graces the flow burned before failing. That is the difference between a
+// pool that will not rebuild and a path that will not carry a handshake, and
+// neither the flow's own log nor the gateway's could distinguish them. See
+// issue #53.
+func TestAFlowRecordsWhatItsLaneReplacementsDid(t *testing.T) {
+	flow := newGraceTestFlow(t)
+
+	if waits, timeouts, joined, waited := flow.replacementDiagnostics(); waits != 0 || timeouts != 0 || joined != 0 || waited != 0 {
+		t.Fatalf("a flow that has not waited reports waits=%d timeouts=%d joined=%d waited=%s",
+			waits, timeouts, joined, waited)
+	}
+
+	// A grace that runs out is the case the incident was made of.
+	const grace = 200 * time.Millisecond
+	if err := flow.waitForHealthyLane(context.Background(), grace); err == nil {
+		t.Fatal("the wait succeeded with no healthy lane")
+	}
+	waits, timeouts, _, waited := flow.replacementDiagnostics()
+	if waits != 1 || timeouts != 1 {
+		t.Fatalf("one exhausted grace recorded waits=%d timeouts=%d, want 1 and 1", waits, timeouts)
+	}
+	if waited < grace {
+		t.Fatalf("the flow waited %s but recorded %s", grace, waited)
+	}
+
+	// A second grace has to be visible as a second grace: the observed
+	// durations clustered at roughly twice laneReplacementWait, and a counter
+	// that saturated at one could not have shown that.
+	if err := flow.waitForHealthyLane(context.Background(), grace); err == nil {
+		t.Fatal("the second wait succeeded with no healthy lane")
+	}
+	waits, timeouts, _, twice := flow.replacementDiagnostics()
+	if waits != 2 || timeouts != 2 {
+		t.Fatalf("two exhausted graces recorded waits=%d timeouts=%d, want 2 and 2", waits, timeouts)
+	}
+	if twice <= waited {
+		t.Fatalf("two graces recorded %s, no more than one grace's %s", twice, waited)
+	}
+
+	// And an exit that is not a timeout must not be counted as one, or the
+	// field cannot separate "nothing came" from "we stopped waiting".
+	flow.noteReplacementAbandoned()
+	if err := flow.waitForHealthyLane(context.Background(), grace); !errors.Is(err, errReplacementAbandoned) {
+		t.Fatalf("wait error = %v, want %v", err, errReplacementAbandoned)
+	}
+	if _, timeouts, _, _ := flow.replacementDiagnostics(); timeouts != 2 {
+		t.Fatalf("abandoning replacement counted as a timeout: timeouts=%d, want 2", timeouts)
+	}
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -240,6 +240,19 @@ type multipathFlow struct {
 	// replacements; the other end keeps waiting for a rescue that is still
 	// somebody's to send.
 	replacementAbandoned atomic.Bool
+
+	// Replacement diagnostics. A flow that fails with "lane replacement
+	// timeout" records only that it gave up, and the live gateway produced 521
+	// of those in two hours without the log saying whether a replacement lane
+	// was ever offered, how many graces were burned, or how long the flow
+	// spent with no lane at all. Distinguishing "nothing was opened" from
+	// "lanes were opened and never became ready" is the difference between a
+	// pool that will not rebuild and a path that will not carry a handshake,
+	// and it cannot be recovered after the fact. See issue #53.
+	replacementWaits     atomic.Uint64
+	replacementTimeouts  atomic.Uint64
+	replacementWaitNanos atomic.Int64
+	lanesJoined          atomic.Uint64
 	// controlLaneShared reports whether another flow is currently using the
 	// pooled control connection. Nil means "no", which is what a flow on a
 	// dedicated connection should answer.
@@ -414,6 +427,7 @@ func (f *multipathFlow) addLane(lane *mpLane) error {
 	}
 	lane.admitted = time.Now()
 	f.lanes[lane.id] = lane
+	f.lanesJoined.Add(1)
 	if lane.id >= f.nextJoinID {
 		f.nextJoinID = lane.id + 1
 	}
@@ -1643,6 +1657,32 @@ func (f *multipathFlow) tryEnqueueFrameClass(lane *mpLane, frame protocol.Frame,
 // longer cannot produce a lane nobody is going to open.
 func (f *multipathFlow) noteReplacementAbandoned() { f.replacementAbandoned.Store(true) }
 
+// replacementLogFields is what this flow's lane replacements did, named the
+// same way on both endpoints so a client record and a gateway record about the
+// same failure can be read side by side.
+//
+// They are emitted on every flow record rather than only on failures. A
+// replacement that succeeded is the control case for one that did not, and a
+// field that appears only when something went wrong cannot be compared against
+// the ordinary run of flows.
+func (f *multipathFlow) replacementLogFields() []any {
+	waits, timeouts, joined, waited := f.replacementDiagnostics()
+	return []any{
+		"lane_replacement_waits", waits,
+		"lane_replacement_timeouts", timeouts,
+		"lane_replacement_wait", waited,
+		"lanes_joined", joined,
+	}
+}
+
+// replacementDiagnostics reports what this flow's lane replacements did, for
+// the record written when a flow ends. Zero waits is the ordinary case and
+// says the flow never lost its last healthy lane.
+func (f *multipathFlow) replacementDiagnostics() (waits, timeouts, joined uint64, waited time.Duration) {
+	return f.replacementWaits.Load(), f.replacementTimeouts.Load(), f.lanesJoined.Load(),
+		time.Duration(f.replacementWaitNanos.Load())
+}
+
 func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Duration) error {
 	if len(f.healthyLanes()) > 0 {
 		return nil
@@ -1653,6 +1693,9 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 	if f.replacementAbandoned.Load() {
 		return errReplacementAbandoned
 	}
+	f.replacementWaits.Add(1)
+	waitStarted := time.Now()
+	defer func() { f.replacementWaitNanos.Add(int64(time.Since(waitStarted))) }()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	ticker := time.NewTicker(25 * time.Millisecond)
@@ -1684,6 +1727,7 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 				return errReplacementAbandoned
 			}
 		case <-timer.C:
+			f.replacementTimeouts.Add(1)
 			return errors.New("lane replacement timeout")
 		case <-f.done:
 			return errors.New("flow closed while waiting for lane replacement")

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -786,6 +786,7 @@ func (s *Server) handleSession(ctx context.Context, conn streamConn, principal i
 		"coded_substrate", codedSubstrateFields(substrate, hasCoded),
 		"class", classifier.Class(flow.class.Load())}
 	logFields = append(logFields, codedSubstrateLogFields(substrate, hasCoded)...)
+	logFields = append(logFields, flow.replacementLogFields()...)
 	if !flowComplete && err != nil && !errors.Is(err, context.Canceled) {
 		s.cfg.Logger.Warn("remote flow ended with error", append(logFields, "error", err)...)
 		return


### PR DESCRIPTION
First step on #53. **Diagnostics only — no behaviour changes.**

## Why not a fix

A live gateway failed 521 flows in two hours with `last lane failed (lane 0:
timeout: no recent network activity): lane replacement timeout` — 94% of its
failures in that window, against a cumulative flow failure rate of 8.2%
(1,952 / 23,706).

The record says the flow gave up and nothing else, and that cannot separate two
faults whose fixes are different:

- a client pool that will not rebuild, so **no replacement lane is ever opened**;
- a path that will not carry a handshake, so **lanes are opened and never become ready**.

The failing flows are otherwise ordinary — 2,961 bytes from the client and
5,101 to it at the median, against 1,948 and 3,906 for flows that succeeded —
and are distinguishable only by living 76–106 s, clustered tightly enough at
90.7 s to be a mechanism rather than a loss process. `laneReplacementWait` is
45 s, and two of those plus lane-death jitter lands in exactly that band, which
suggests the flows burn the grace twice. **That is a reading of durations, not
a measurement**, and it is the kind of thing this record should not have
required guessing about.

I deliberately did not touch the idle timeout. `internal/pep/transport.go` sets
`MaxIdleTimeout: 15s` so a black-holed lane is declared dead early enough for
TCP rescue to begin, and whether 15 s is too tight depends on whether these
lanes were really dead — which is the question these fields exist to answer.
Changing it now would be a guess dressed as a fix.

## What this adds

`lane_replacement_waits`, `lane_replacement_timeouts`, `lane_replacement_wait`
and `lanes_joined`, on flow completion records from **both** endpoints under the
same names, so a client record and a gateway record about one failure can be
read side by side.

Emitted on every flow record rather than only on failures: a replacement that
succeeded is the control case for one that did not, and a field that appears
only when something goes wrong cannot be compared against the ordinary run of
flows. A flow that never lost its last healthy lane reports zeroes.

Timeouts are counted separately from waits, so ending a wait early — which
`waitForHealthyLane` already does on `errResumeRefused` and
`errReplacementAbandoned` — is not recorded as the grace running out. The test
covers that case explicitly, along with a second grace being visible as a
second grace.

## A correction to the record

Review discussion on #52, **including my own**, asserted that three missed
keepalives kill a lane and computed `p³` from it. That is not how quic-go
behaves:

```go
if c.config.KeepAlivePeriod == 0 || c.keepAlivePingSent {
    return time.Time{}   // no keepalive scheduled
}
```

One PING is queued, `keepAlivePingSent` is set, and no further keepalive is
scheduled **until a packet is received**. Retries come from PTO probes, not the
keepalive timer. Any arithmetic based on `p³` should be discarded, mine
included. Separately, the earlier analysis pointed at
`internal/baseline/baseline.go` — that file is the TUIC reference used for
benchmark comparison and is not imported by the production path at all.

## Relationship to the other open PRs

- **#50** retires a stale pooled generation on stream timeout instead of handing
  the same dead one to the next flow. If the client is re-dialling into a dead
  generation, that is this bug's second half and #50 may resolve most of the
  94%. These fields would show it.
- **#52** does not touch this. Keepalives are QUIC PING frames and the coded
  substrate sits above QUIC, so FEC never protects QUIC's own control traffic.

No file overlap with either; `merge-tree` is clean against both.

## Checks

`go test -short ./...` green across 27 packages, `go vet`, `gofmt`, and
`./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
