### PR TITLE
fix: let the bandwidth estimate come down

### DIFF
--- a/changelog.d/a-bandwidth-estimate-that-can-fall.fixed.md
+++ b/changelog.d/a-bandwidth-estimate-that-can-fall.fixed.md
@@ -1,0 +1,18 @@
+The bandwidth estimate can now come down. Its max filter kept a sample for
+ten packet-timed rounds, which is the right clock only while rounds advance
+-- and a round advances when a packet sent in the previous round is
+acknowledged, so a connection with nothing to send advances none. Measured
+on a live gateway, 99.98% of samples were application limited and the round
+counter moved about nine times an hour, turning a ten-round memory into
+sixty-six minutes of wall time. One burst through a shaper therefore set the
+estimate for the rest of the hour: the gateway held 519 Mbit/s against a
+measured sustained 17.6 and paced and sized its congestion window from that.
+
+A sample now expires on rounds or on wall time, whichever comes first, with
+the wall-clock window derived from the measured minimum round trip rather
+than configured -- ten rounds and the time ten rounds takes are the same
+statement on a path whose rounds are advancing. An application-limited
+sample may also replace a standing estimate once that estimate has expired,
+which it previously could not; without that a connection which is
+application limited essentially always would have expired its estimate with
+nothing able to take its place.

--- a/internal/congestion/bandwidthdecay_test.go
+++ b/internal/congestion/bandwidthdecay_test.go
@@ -1,0 +1,314 @@
+package congestion
+
+import (
+	"testing"
+	"time"
+
+	quiccongestion "github.com/apernet/quic-go/congestion"
+	"github.com/apernet/quic-go/monotime"
+)
+
+// base is an arbitrary non-zero instant. The filter treats a zero time as "no
+// wall clock supplied", so a test that wants the time behaviour must not start
+// at zero.
+func base() monotime.Time { return monotime.Time(int64(time.Hour)) }
+
+// The defect this file exists for. The filter's clock was a packet-timed round
+// number, which is the right clock only while rounds advance. On the live
+// gateway 99.98% of samples were application limited and the round counter
+// moved nine times an hour, so a ten-round memory was sixty-six minutes of wall
+// time and one burst through a token bucket set the estimate for the rest of
+// the hour: 519 Mbit/s held against a measured sustained 17.6.
+func TestABurstDoesNotSetTheEstimateForAnHour(t *testing.T) {
+	m := newTUICMinMax()
+	m.setRoundTrip(226 * time.Millisecond)
+
+	now := base()
+	const burst, sustained = 64_000_000, 2_200_000
+	m.updateMax(1, now, burst)
+	if got := m.get(); got != burst {
+		t.Fatalf("the burst was not recorded: %d", got)
+	}
+
+	// Rounds barely advance, exactly as they did on the live path: two rounds
+	// over the next ten minutes, while sustained samples keep arriving.
+	for elapsed := time.Second; elapsed <= 10*time.Minute; elapsed += time.Second {
+		round := uint64(1)
+		if elapsed > 5*time.Minute {
+			round = 2
+		}
+		m.updateMax(round, now.Add(elapsed), sustained)
+	}
+
+	if got := m.get(); got != sustained {
+		t.Fatalf("after ten minutes of sustained samples the estimate is %d, want %d; "+
+			"the round clock alone would still be holding the burst", got, sustained)
+	}
+}
+
+// The estimate has to come down inside its own window, not merely eventually.
+func TestTheEstimateFallsWithinItsWindow(t *testing.T) {
+	const rtt = 200 * time.Millisecond
+	m := newTUICMinMax()
+	m.setRoundTrip(rtt)
+	window := m.timeWindow
+
+	now := base()
+	m.updateMax(1, now, 50_000_000)
+
+	// One round advances, so the round clock cannot expire anything: the
+	// ten-round window needs ten.
+	held := m.get()
+	m.updateMax(2, now.Add(window/2), 1_000_000)
+	if m.get() != held {
+		t.Fatalf("the estimate moved at half its window: %d, want it held at %d", m.get(), held)
+	}
+	m.updateMax(2, now.Add(window+time.Millisecond), 1_000_000)
+	if got := m.get(); got != 1_000_000 {
+		t.Fatalf("the estimate is %d one window after the peak, want it replaced by 1000000", got)
+	}
+}
+
+// The trap in this change. Application-limited samples may not lower a live
+// estimate -- a sender with nothing to send has learned nothing about what the
+// path could have carried -- so expiring the estimate on a connection that is
+// application limited essentially always could have left nothing able to
+// replace it, and an estimate of zero collapses the connection.
+func TestAnExpiredEstimateIsReplacedRatherThanEmptied(t *testing.T) {
+	e := newTUICBandwidthEstimator()
+	e.maxFilter.setRoundTrip(200 * time.Millisecond)
+	now := base()
+
+	e.maxFilter.updateMax(1, now, 50_000_000)
+	if !e.maxFilter.stale(now.Add(e.maxFilter.timeWindow + time.Millisecond)) {
+		t.Fatal("an estimate a window old does not report itself stale")
+	}
+	if e.maxFilter.stale(now.Add(e.maxFilter.timeWindow / 2)) {
+		t.Fatal("an estimate half a window old reports itself stale")
+	}
+
+	// The sampler's guard must let an application-limited sample through once
+	// the standing estimate has expired, and only then.
+	appLimitedAdmitted := func(at monotime.Time, sample uint64) bool {
+		return !(sample > e.maxFilter.get()) && e.maxFilter.stale(at)
+	}
+	if appLimitedAdmitted(now.Add(e.maxFilter.timeWindow/2), 1_000_000) {
+		t.Fatal("a lower application-limited sample was admitted against a live estimate")
+	}
+	if !appLimitedAdmitted(now.Add(e.maxFilter.timeWindow+time.Millisecond), 1_000_000) {
+		t.Fatal("a lower application-limited sample was refused against an expired estimate, " +
+			"which is how the filter would keep a value it has already decided not to trust")
+	}
+
+	e.maxFilter.updateMax(1, now.Add(e.maxFilter.timeWindow+time.Millisecond), 1_000_000)
+	if got := e.maxFilter.get(); got == 0 {
+		t.Fatal("the estimate emptied instead of being replaced")
+	} else if got != 1_000_000 {
+		t.Fatalf("estimate = %d, want the replacing sample 1000000", got)
+	}
+}
+
+// A shaped path does not have a bandwidth. It has a rate and a burst depth, and
+// a short probe measures the drain while sustained load measures the rate. The
+// filter must settle on the second.
+//
+// The end-to-end version of this needs a burst-depth knob in internal/pathsim,
+// which does not have one: its RateBytesPerSec is a serialization rate with no
+// bucket behind it. This holds the filter to the behaviour that matters.
+func TestATokenBucketSettlesOnTheShapingRateNotTheDrain(t *testing.T) {
+	const (
+		rtt      = 200 * time.Millisecond
+		drain    = 40_000_000
+		shaped   = 2_000_000
+		bucketMs = 300
+	)
+	m := newTUICMinMax()
+	m.setRoundTrip(rtt)
+
+	now := base()
+	round := uint64(1)
+	var last uint64
+	for elapsed := time.Duration(0); elapsed < 60*time.Second; elapsed += 100 * time.Millisecond {
+		sample := uint64(shaped)
+		if elapsed < bucketMs*time.Millisecond {
+			// The bucket has not drained yet, so the path delivers at line rate.
+			sample = drain
+		}
+		// The connection is application limited, so rounds crawl.
+		if elapsed%(10*time.Second) == 0 {
+			round++
+		}
+		m.updateMax(round, now.Add(elapsed), sample)
+		last = m.get()
+	}
+	if last != shaped {
+		t.Fatalf("the estimate settled on %d after a minute of shaping at %d; a drain rate "+
+			"held this long is what paced a gateway at 29x the path", last, shaped)
+	}
+}
+
+// A throttle that tightens under load must be believed, and the estimate must
+// settle rather than oscillate.
+func TestATighteningThrottleIsBelievedAndSettles(t *testing.T) {
+	const rtt = 200 * time.Millisecond
+	m := newTUICMinMax()
+	m.setRoundTrip(rtt)
+
+	now := base()
+	steps := []uint64{20_000_000, 10_000_000, 5_000_000, 2_500_000}
+	elapsed := time.Duration(0)
+	round := uint64(1)
+	for _, rate := range steps {
+		for i := 0; i < 200; i++ {
+			elapsed += 100 * time.Millisecond
+			if i%50 == 0 {
+				round++
+			}
+			m.updateMax(round, now.Add(elapsed), rate)
+		}
+		if got := m.get(); got != rate {
+			t.Fatalf("throttle moved to %d and the estimate reads %d", rate, got)
+		}
+	}
+	// Settled: another twenty seconds at the final rate does not move it.
+	settled := m.get()
+	for i := 0; i < 200; i++ {
+		elapsed += 100 * time.Millisecond
+		m.updateMax(round, now.Add(elapsed), steps[len(steps)-1])
+	}
+	if m.get() != settled {
+		t.Fatalf("the estimate moved from %d to %d with no change in the path", settled, m.get())
+	}
+}
+
+// The window is derived from the measured round trip rather than configured,
+// and bounded so that neither a spurious sub-millisecond sample nor a satellite
+// path can make the memory meaningless in either direction.
+func TestTheWindowIsDerivedFromTheMeasuredRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		rtt  time.Duration
+		want time.Duration
+	}{
+		{rtt: 226 * time.Millisecond, want: 2260 * time.Millisecond},
+		{rtt: 430 * time.Millisecond, want: 4300 * time.Millisecond},
+		{rtt: time.Millisecond, want: minBandwidthTimeWindow},
+		{rtt: 5 * time.Second, want: maxBandwidthTimeWindow},
+	} {
+		m := newTUICMinMax()
+		m.setRoundTrip(test.rtt)
+		if m.timeWindow != test.want {
+			t.Errorf("round trip %v gave a window of %v, want %v", test.rtt, m.timeWindow, test.want)
+		}
+	}
+	// An unmeasured path keeps whatever it had rather than collapsing to zero.
+	m := newTUICMinMax()
+	before := m.timeWindow
+	m.setRoundTrip(0)
+	m.setRoundTrip(-time.Second)
+	if m.timeWindow != before {
+		t.Fatalf("an unmeasured round trip changed the window from %v to %v", before, m.timeWindow)
+	}
+}
+
+// The ack-aggregation filter measures how much more than expected one round
+// delivered. That is a statement about rounds and means nothing between them,
+// so it keeps the original clock: supplying no time must leave the filter
+// behaving exactly as it did.
+func TestAFilterGivenNoTimeKeepsTheRoundClock(t *testing.T) {
+	timed, untimed := newTUICMinMax(), newTUICMinMax()
+	timed.setRoundTrip(200 * time.Millisecond)
+	now := base()
+
+	for round := uint64(1); round <= 30; round++ {
+		value := uint64(1000)
+		if round == 1 {
+			value = 9000
+		}
+		// Wall time races far ahead of the rounds for the timed filter.
+		timed.updateMax(round, now.Add(time.Duration(round)*time.Minute), value)
+		untimed.updateMax(round, monotime.Time(0), value)
+	}
+	if untimed.get() != 1000 {
+		t.Fatalf("the round clock alone gave %d after thirty rounds, want 1000", untimed.get())
+	}
+	// Both end up at the sustained value here; what matters is that the
+	// untimed one got there by rounds and never consulted a clock it was not
+	// given. A zero time must never be read as an ancient one.
+	m := newTUICMinMax()
+	m.setRoundTrip(200 * time.Millisecond)
+	m.updateMax(1, monotime.Time(0), 5000)
+	if m.stale(now.Add(time.Hour)) {
+		t.Fatal("a sample carrying no time was reported stale, so a zero was read as ancient")
+	}
+	if m.get() != 5000 {
+		t.Fatalf("untimed sample = %d, want 5000", m.get())
+	}
+}
+
+// Expiry must not be a way to lose a rising path. A sample above the standing
+// estimate is taken immediately, window or no window.
+func TestARisingPathIsTakenImmediately(t *testing.T) {
+	m := newTUICMinMax()
+	m.setRoundTrip(200 * time.Millisecond)
+	now := base()
+	m.updateMax(1, now, 1_000_000)
+	m.updateMax(1, now.Add(10*time.Millisecond), 8_000_000)
+	if got := m.get(); got != 8_000_000 {
+		t.Fatalf("estimate = %d, want the higher sample 8000000 taken at once", got)
+	}
+}
+
+// The filter change alone is not enough, and this is the test that proves the
+// sampler half is needed. Application-limited samples may not lower a live
+// estimate, so on a connection that is application limited essentially always
+// -- which is what the live gateway was, at 99.98% of samples -- expiring the
+// estimate without also relaxing that rule would leave nothing able to replace
+// it. This drives the real sampler rather than poking the filter.
+func TestASamplerThatIsAlwaysAppLimitedStillComesDown(t *testing.T) {
+	e := newTUICBandwidthEstimator()
+	start := base()
+	const rtt = 200 * time.Millisecond
+
+	// A first burst, not application limited: the path really did carry this.
+	var burstAcks []quiccongestion.AckedPacketInfo
+	for i := 0; i < 100; i++ {
+		pn := quiccongestion.PacketNumber(i)
+		e.onSentPacket(start.Add(time.Duration(i)*time.Microsecond*200), pn, 1200, uint64(i)*1200, true)
+		burstAcks = append(burstAcks, quiccongestion.AckedPacketInfo{PacketNumber: pn, BytesAcked: 1200})
+	}
+	e.onAckBatch(start.Add(rtt), burstAcks, 1)
+	peak := e.estimate()
+	if peak == 0 {
+		t.Fatal("the burst produced no estimate to decay from")
+	}
+	e.maxFilter.setRoundTrip(rtt)
+
+	// Now a long, slow, application-limited trickle: one packet per 50 ms,
+	// with the round barely advancing, which is the shape that latched the
+	// estimate for an hour.
+	number := quiccongestion.PacketNumber(1000)
+	elapsed := rtt
+	round := uint64(1)
+	for i := 0; i < 400; i++ {
+		elapsed += 50 * time.Millisecond
+		e.markAppLimited()
+		e.onSentPacket(start.Add(elapsed), number, 1200, 1200, true)
+		if i%100 == 0 {
+			round++
+		}
+		e.onAckBatch(start.Add(elapsed+rtt), []quiccongestion.AckedPacketInfo{
+			{PacketNumber: number, BytesAcked: 1200},
+		}, round)
+		number++
+	}
+
+	settled := e.estimate()
+	t.Logf("peak=%d settled=%d after %v of application-limited trickle", peak, settled, elapsed)
+	if settled == 0 {
+		t.Fatal("the estimate emptied: an application-limited connection collapsed its own bandwidth model")
+	}
+	if settled >= peak {
+		t.Fatalf("estimate held at %d against a peak of %d; the sampler never let a lower "+
+			"application-limited sample replace an expired estimate", settled, peak)
+	}
+}

--- a/internal/congestion/bbr_tuic.go
+++ b/internal/congestion/bbr_tuic.go
@@ -257,7 +257,13 @@ func (b *TUICBBRSender) seedBandwidth(rate uint64, roundTrip time.Duration) {
 	if rate > tuicMaxRate {
 		rate = tuicMaxRate
 	}
-	b.estimator.maxFilter.updateMax(b.round, rate)
+	// The seed is stamped with the current time like any other sample, so a
+	// lane that inherits a rate and then goes quiet lets it expire rather than
+	// pacing from another lane's peak indefinitely.
+	if roundTrip > 0 {
+		b.estimator.maxFilter.setRoundTrip(roundTrip)
+	}
+	b.estimator.maxFilter.updateMax(b.round, monotime.Now(), rate)
 	if pacing := uint64(float64(rate) * b.highGain); pacing > b.pacingRate {
 		b.pacingRate = minUint64(pacing, tuicMaxRate)
 	}
@@ -986,6 +992,10 @@ func (a *tuicAckAggregation) update(newlyAcked uint64, now monotime.Time, round,
 	}
 	a.epochBytes = satAddUint64(a.epochBytes, newlyAcked)
 	diff := a.epochBytes - expected
-	a.maxAckHeight.updateMax(round, diff)
+	// The ack-aggregation filter keeps the original round-only clock: it
+	// measures how much more than expected one round delivered, which is a
+	// statement about rounds and means nothing between them. A zero time
+	// leaves it exactly as it was.
+	a.maxAckHeight.updateMax(round, monotime.Time(0), diff)
 	return diff
 }

--- a/internal/congestion/bbr_tuic_bw.go
+++ b/internal/congestion/bbr_tuic_bw.go
@@ -270,8 +270,21 @@ func (e *tuicBandwidthEstimator) onAckBatch(eventTime monotime.Time, acked []qui
 	}
 	// App-limited samples cannot lower the model, but an app-limited event
 	// above the current best is still proof of higher deliverable bandwidth.
-	if result.maxBandwidth > 0 && (!result.sampleAppLimited || result.maxBandwidth > e.maxFilter.get()) {
-		e.maxFilter.updateMax(round, result.maxBandwidth)
+	//
+	// The exception is a standing estimate that has outlived its window. That
+	// rule protects a live estimate from a sender that had nothing to send and
+	// therefore learned nothing; once the estimate has expired there is
+	// nothing left to protect, and refusing the only samples on offer is how
+	// the filter would keep a value it has already decided not to trust. On a
+	// connection that is application limited essentially always -- 99.98% of
+	// samples on the path this was measured against -- that exception is the
+	// only way the estimate ever comes down.
+	if result.maxBandwidth > 0 &&
+		(!result.sampleAppLimited || result.maxBandwidth > e.maxFilter.get() || e.maxFilter.stale(eventTime)) {
+		if result.minRTT > 0 {
+			e.maxFilter.setRoundTrip(result.minRTT)
+		}
+		e.maxFilter.updateMax(round, eventTime, result.maxBandwidth)
 	}
 	return result
 }
@@ -300,7 +313,10 @@ func (e *tuicBandwidthEstimator) onAck(now monotime.Time, bytes, round uint64, a
 	sendRate := rateFromDelta(e.totalSent-e.legacyPrevSent, e.legacySentTime.Sub(e.legacyPrevSentTime))
 	ackRate := rateFromDelta(e.totalAcked-e.legacyPrevAcked, e.legacyAckedTime.Sub(e.legacyPrevAckTime))
 	if !appLimited && sendRate > 0 && ackRate > 0 {
-		e.maxFilter.updateMax(round, minUint64(sendRate, ackRate))
+		// The aggregate helpers are for deterministic tests and callers with no
+		// packet numbers, and carry no event time; a zero leaves the sample on
+		// the round clock alone.
+		e.maxFilter.updateMax(round, monotime.Time(0), minUint64(sendRate, ackRate))
 	}
 }
 

--- a/internal/congestion/bbr_tuic_minmax.go
+++ b/internal/congestion/bbr_tuic_minmax.go
@@ -44,6 +44,10 @@ type tuicMinMaxSample struct {
 }
 
 const (
+	// tuicMinMaxWindow is the filter's memory in rounds. It is untyped so that
+	// deriving a duration from it needs no conversion from the uint64 the
+	// round arithmetic uses.
+	tuicMinMaxWindow = 10
 	// minBandwidthTimeWindow keeps a spuriously small round-trip sample from
 	// collapsing the filter's memory to nothing. Below this the round window
 	// binds first in any case, because samples cannot arrive faster than the
@@ -57,7 +61,7 @@ const (
 )
 
 func newTUICMinMax() tuicMinMax {
-	return tuicMinMax{window: 10, timeWindow: maxBandwidthTimeWindow}
+	return tuicMinMax{window: tuicMinMaxWindow, timeWindow: maxBandwidthTimeWindow}
 }
 
 func (m *tuicMinMax) get() uint64 { return m.samples[0].value }
@@ -79,12 +83,17 @@ func (m *tuicMinMax) setRoundTrip(rtt time.Duration) {
 	if rtt <= 0 {
 		return
 	}
-	window := time.Duration(m.window) * rtt
+	// Clamp before multiplying rather than after. The round trip is a
+	// measurement, and a large enough one overflows the product before either
+	// bound could be applied to it -- which would set the memory from a sign
+	// bit instead of from the path.
+	if rtt >= maxBandwidthTimeWindow/tuicMinMaxWindow {
+		m.timeWindow = maxBandwidthTimeWindow
+		return
+	}
+	window := tuicMinMaxWindow * rtt
 	if window < minBandwidthTimeWindow {
 		window = minBandwidthTimeWindow
-	}
-	if window > maxBandwidthTimeWindow {
-		window = maxBandwidthTimeWindow
 	}
 	m.timeWindow = window
 }

--- a/internal/congestion/bbr_tuic_minmax.go
+++ b/internal/congestion/bbr_tuic_minmax.go
@@ -1,21 +1,63 @@
 package congestion
 
+import (
+	"time"
+
+	"github.com/apernet/quic-go/monotime"
+)
+
 // tuicMinMax is the constant-space, three-sample max filter used by TUIC's
-// quinn-congestions BBR implementation. The clock is a packet-timed round
-// number rather than wall time. Keeping the filter round based makes it
-// insensitive to ACK coalescing and gives it a bounded ten-round memory.
+// quinn-congestions BBR implementation, with one correction.
+//
+// The original clock is a packet-timed round number rather than wall time,
+// which makes the filter insensitive to ACK coalescing and gives it a bounded
+// ten-round memory. That is the right clock while rounds advance. It stops
+// being a clock when they do not.
+//
+// A round advances when a packet sent in the previous round is acknowledged,
+// so a connection with nothing to send advances no rounds. Measured on a live
+// gateway, 99.98% of samples were application limited and the round counter
+// moved 220 times in 24 hours -- about nine an hour, which turns a ten-round
+// memory into sixty-six minutes of wall time. One burst through a token bucket
+// therefore latched the bandwidth estimate for the better part of an hour: the
+// gateway held 519 Mbit/s against a measured sustained 17.6, and paced and
+// sized its congestion window from that.
+//
+// The filter now expires a sample on rounds or on wall time, whichever comes
+// first. The two express the same intent -- a bandwidth estimate should not
+// outlive the window in which a path change ought to be believed -- and the
+// time bound is what keeps the round bound honest when rounds stall.
 type tuicMinMax struct {
-	window  uint64
-	samples [3]tuicMinMaxSample
+	window uint64
+	// timeWindow is how long a sample may stand in wall time. It is derived
+	// from the measured round trip rather than configured, because "ten
+	// rounds" and "the time ten rounds takes" are the same statement on a path
+	// whose rounds are advancing; see setRoundTrip.
+	timeWindow time.Duration
+	samples    [3]tuicMinMaxSample
 }
 
 type tuicMinMaxSample struct {
 	round uint64
+	at    monotime.Time
 	value uint64
 }
 
+const (
+	// minBandwidthTimeWindow keeps a spuriously small round-trip sample from
+	// collapsing the filter's memory to nothing. Below this the round window
+	// binds first in any case, because samples cannot arrive faster than the
+	// path returns them.
+	minBandwidthTimeWindow = time.Second
+	// maxBandwidthTimeWindow bounds the worst case on a very long path. It is
+	// the same figure, and the same reasoning, as pathmodel's bottleneck
+	// window: long enough to survive a probe cycle, short enough that a path
+	// which genuinely narrowed is believed within a few seconds.
+	maxBandwidthTimeWindow = 10 * time.Second
+)
+
 func newTUICMinMax() tuicMinMax {
-	return tuicMinMax{window: 10}
+	return tuicMinMax{window: 10, timeWindow: maxBandwidthTimeWindow}
 }
 
 func (m *tuicMinMax) get() uint64 { return m.samples[0].value }
@@ -24,16 +66,66 @@ func (m *tuicMinMax) reset() {
 	m.samples = [3]tuicMinMaxSample{}
 }
 
-func (m *tuicMinMax) updateMax(round, value uint64) {
+// setRoundTrip derives the wall-clock memory from the path's measured minimum
+// round trip: the time the filter's own round window would take to pass if
+// rounds were advancing normally.
+//
+// Deriving it rather than configuring it is what keeps the correction honest
+// on paths nobody has measured yet. A 226 ms path gets 2.3 seconds, a
+// millisecond LAN gets the one-second floor and never notices because its
+// rounds advance far faster than that, and a satellite path is held to the ten
+// second ceiling rather than being allowed to remember a burst for a minute.
+func (m *tuicMinMax) setRoundTrip(rtt time.Duration) {
+	if rtt <= 0 {
+		return
+	}
+	window := time.Duration(m.window) * rtt
+	if window < minBandwidthTimeWindow {
+		window = minBandwidthTimeWindow
+	}
+	if window > maxBandwidthTimeWindow {
+		window = maxBandwidthTimeWindow
+	}
+	m.timeWindow = window
+}
+
+// stale reports whether the standing estimate has outlived its wall-clock
+// window.
+//
+// The bandwidth sampler asks before deciding whether an application-limited
+// sample may be recorded. Ordinarily it may not lower the estimate -- a sender
+// that had nothing to send has learned nothing about what the path could have
+// carried -- but that rule assumes there is a live estimate to protect. Once
+// the standing one has expired there is nothing to protect, and refusing the
+// only samples on offer would leave the filter holding a value it has already
+// decided not to trust, or empty it and collapse the connection.
+func (m *tuicMinMax) stale(now monotime.Time) bool {
+	if m.samples[0].value == 0 {
+		return false
+	}
+	return m.expired(m.samples[0], now)
+}
+
+func (m *tuicMinMax) expired(sample tuicMinMaxSample, now monotime.Time) bool {
+	if sample.at.IsZero() || now.IsZero() || m.timeWindow <= 0 {
+		return false
+	}
+	return now.Sub(sample.at) > m.timeWindow
+}
+
+func (m *tuicMinMax) updateMax(round uint64, now monotime.Time, value uint64) {
 	if value == 0 {
 		return
 	}
-	current := tuicMinMaxSample{round: round, value: value}
-	oldest := m.samples[2].round
+	current := tuicMinMaxSample{round: round, at: now, value: value}
+	oldest := m.samples[2]
 	// A round counter is monotonic in normal operation. The explicit round
 	// comparison also makes the filter safe if a test or a timeout resets it.
-	windowExpired := round >= oldest && round-oldest > m.window
-	if m.samples[0].value == 0 || value >= m.samples[0].value || windowExpired {
+	windowExpired := round >= oldest.round && round-oldest.round > m.window
+	// The wall-clock test is against the standing estimate rather than the
+	// oldest sample: it is the estimate that is being trusted, and it is the
+	// one that outlived its window on the live path.
+	if m.samples[0].value == 0 || value >= m.samples[0].value || windowExpired || m.expired(m.samples[0], now) {
 		m.samples = [3]tuicMinMaxSample{current, current, current}
 		return
 	}

--- a/internal/congestion/bbr_tuic_test.go
+++ b/internal/congestion/bbr_tuic_test.go
@@ -18,15 +18,15 @@ func sendTUICPacket(sender *TUICBBRSender, sentTime monotime.Time, preSend quicc
 
 func TestTUICMinMaxRetainsPeakForTenRounds(t *testing.T) {
 	m := newTUICMinMax()
-	m.updateMax(1, 100)
-	m.updateMax(3, 120)
-	m.updateMax(5, 160)
-	m.updateMax(7, 100)
-	m.updateMax(10, 100)
+	m.updateMax(1, monotime.Time(0), 100)
+	m.updateMax(3, monotime.Time(0), 120)
+	m.updateMax(5, monotime.Time(0), 160)
+	m.updateMax(7, monotime.Time(0), 100)
+	m.updateMax(10, monotime.Time(0), 100)
 	if got := m.get(); got != 160 {
 		t.Fatalf("peak was lost inside filter window: %d", got)
 	}
-	m.updateMax(16, 100)
+	m.updateMax(16, monotime.Time(0), 100)
 	if got := m.get(); got != 100 {
 		t.Fatalf("expired peak remained in filter: %d", got)
 	}
@@ -34,15 +34,15 @@ func TestTUICMinMaxRetainsPeakForTenRounds(t *testing.T) {
 
 func TestTUICMinMaxHalfWindowStartsAtThirdSample(t *testing.T) {
 	m := newTUICMinMax()
-	m.updateMax(0, 100)
+	m.updateMax(0, monotime.Time(0), 100)
 	// The quarter-window refresh records the second and third samples at round
 	// three. The half-window clock must start there, not at the original best.
-	m.updateMax(3, 90)
-	m.updateMax(6, 80)
+	m.updateMax(3, monotime.Time(0), 90)
+	m.updateMax(6, monotime.Time(0), 80)
 	if got := m.samples[2]; got.round != 3 || got.value != 90 {
 		t.Fatalf("third sample advanced before its half-window elapsed: %+v", got)
 	}
-	m.updateMax(9, 80)
+	m.updateMax(9, monotime.Time(0), 80)
 	if got := m.samples[2]; got.round != 9 || got.value != 80 {
 		t.Fatalf("third sample did not advance after its half-window: %+v", got)
 	}
@@ -177,7 +177,7 @@ func TestTUICAppLimitedMarkerIsPacketScoped(t *testing.T) {
 
 func TestTUICAppLimitedSampleCanRaiseBandwidth(t *testing.T) {
 	e := newTUICBandwidthEstimator()
-	e.maxFilter.updateMax(1, 100)
+	e.maxFilter.updateMax(1, monotime.Time(0), 100)
 	start := monotime.Now()
 	e.markAppLimited()
 	e.onSentPacket(start, 0, 1200, 0, true)
@@ -561,7 +561,7 @@ func TestTUICStartupDoesNotExitOnOnePostModelLoss(t *testing.T) {
 	sender.recovery = tuicConservation
 	sender.roundsNoGain = 0
 	sender.bwAtLastRound = 1
-	sender.estimator.maxFilter.updateMax(1, 1)
+	sender.estimator.maxFilter.updateMax(1, monotime.Time(0), 1)
 	sender.checkFullBandwidth(tuicSendState{valid: true})
 	if sender.fullBandwidth {
 		t.Fatal("one recovery event prematurely exited startup")
@@ -584,7 +584,7 @@ func TestTUICProbeBWLowGainDoesNotStickAboveTarget(t *testing.T) {
 	sender.mode = tuicBbrProbeBW
 	sender.pacingGain = tuicPacingGains[1]
 	sender.cycleOffset = 1
-	sender.estimator.maxFilter.updateMax(1, 1024*1024)
+	sender.estimator.maxFilter.updateMax(1, monotime.Time(0), 1024*1024)
 	start := monotime.Now()
 	sender.lastCycle = start
 	inFlight := sender.targetCwnd(1) + sender.maxDatagramSize
@@ -599,7 +599,7 @@ func TestTUICProbeRTTPreservesModelAndExitsAfterPriorRound(t *testing.T) {
 	sender.fullBandwidth = true
 	sender.mode = tuicBbrProbeBW
 	sender.cwnd = 512 * 1024
-	sender.estimator.maxFilter.updateMax(1, 2*1024*1024)
+	sender.estimator.maxFilter.updateMax(1, monotime.Time(0), 2*1024*1024)
 	start := monotime.Now()
 	sender.maybeProbeRTT(start, false, 0, true)
 	if sender.mode != tuicBbrProbeRTT || sender.GetCongestionWindow() != sender.minCwnd || !sender.estimator.appLimited {
@@ -627,8 +627,8 @@ func TestTUICTargetWindowUsesStartupGainWithoutBandwidth(t *testing.T) {
 
 func TestTUICStartupGrowthPreservesAckHeight(t *testing.T) {
 	sender := NewTUICBBRSender(1200)
-	sender.ackAgg.maxAckHeight.updateMax(1, 24*1200)
-	sender.estimator.maxFilter.updateMax(1, 1024*1024)
+	sender.ackAgg.maxAckHeight.updateMax(1, monotime.Time(0), 24*1200)
+	sender.estimator.maxFilter.updateMax(1, monotime.Time(0), 1024*1024)
 	sender.checkFullBandwidth(tuicSendState{valid: true})
 	if got := sender.ackAgg.maxAckHeight.get(); got != 24*1200 {
 		t.Fatalf("startup bandwidth growth discarded ACK height: %d", got)

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -475,7 +475,7 @@ func TestAnEmptiedPipeKeepsWhatItMeasured(t *testing.T) {
 	sender.seedBandwidth(peak, sender.minRTT)
 	sender.peakBandwidth = peak
 	sender.estimator.maxFilter.reset()
-	sender.estimator.maxFilter.updateMax(sender.round, peak/32)
+	sender.estimator.maxFilter.updateMax(sender.round, monotime.Time(0), peak/32)
 	if before := sender.estimator.estimate(); before >= peak {
 		t.Fatalf("the filter still holds %d; this test is not testing decay", before)
 	}


### PR DESCRIPTION
The max filter behind the bandwidth estimate keeps a sample for ten
**packet-timed rounds**. That is the right clock while rounds advance, and it
is what makes the filter insensitive to ACK coalescing. It stops being a clock
when rounds stall.

A round advances when a packet sent in the previous round is acknowledged, so a
connection with nothing to send advances none:

| Endpoint | Round | Uptime | Rounds/hour | Ten-round window |
| --- | --- | --- | --- | --- |
| Gateway | 220 | 24.1 h | 9.1 | **≈ 66 min** |
| Client | 1401 | 25.2 h | 55.7 | ≈ 11 min |

99.98% of samples were application limited (`app_limited 966429` vs
`non_app_limited 216`). One burst through a shaper therefore set the estimate
for the rest of the hour: the gateway held `max_bandwidth` at **519 Mbit/s
against a sustained 17.6 measured over the same path**, and paced at
199–413 MB/s with a 15–28 MB congestion window from that figure.

Shortening the round window would not have helped, because the rounds are what
stopped. A shaped path also has no bandwidth to remember in the first place —
it has a rate and a burst depth, and a short probe measures the drain while
sustained load measures the rate. Any max filter structurally measures the
first and reports it as the second.

## The fix

A sample now expires on rounds **or** on wall time, whichever comes first. The
wall-clock window is derived from the measured minimum round trip rather than
configured: ten rounds and the time ten rounds takes are the same statement on
a path whose rounds are advancing, so the time bound keeps the round bound
honest rather than being a second policy. Floored at 1 s so a spurious
sub-millisecond sample cannot collapse the memory, capped at 10 s — which is
`pathmodel`'s bottleneck window, and the same reasoning.

**The filter change alone would have been a bug.** An application-limited
sample may not lower a live estimate, because a sender that had nothing to send
has learned nothing about what the path could have carried. On a connection
that is application limited essentially always, expiring the estimate would
have left nothing able to replace it — and an estimate of zero collapses the
connection. That rule now has an exception for an estimate that has *already
expired*: there is nothing left to protect, and refusing the only samples on
offer is how the filter would keep a value it has itself decided not to trust.

The ack-aggregation filter shares the type and keeps the original round-only
clock. It measures how much more than expected one round delivered, which means
nothing between rounds, so it is given no time — and a zero is never read as an
ancient one.

## Tests, and proof they bite

Nine new tests. Both halves of the fix were verified load-bearing by
neutralising them:

- **Neutralising the wall-clock expiry** fails 5: the hour-long latch, falling
  within the window, replace-rather-than-empty, the token bucket, and the
  tightening throttle.
- **Removing the sampler's exception** fails the sampler-level test with
  `estimate held at 600000 against a peak of 600000`.

The sampler test drives the real `tuicBandwidthEstimator` — burst, then an
application-limited trickle with rounds crawling — and watches the estimate fall
from 600000 to 24000 rather than holding.

The two tests that assert *unchanged* behaviour (round-clock-only when given no
time; a rising path taken immediately) pass in both configurations, which is
what they are for.

## Scope

This is the estimate only. It does not add the delay bound, and it does not
make parity rate-preserving — but it is the dependency for #52, because a
budget that never binds is not a budget. With the ceiling real, parity displaces
source bytes instead of adding to them.

Two falsification cases from #52's design notes are covered here at the filter
level (token bucket; tightening throttle). Their end-to-end versions need a
burst-depth knob in `internal/pathsim`, which has none — `RateBytesPerSec` is a
serialization rate with no bucket behind it. Noted in the test rather than
silently skipped.

## Checks

`go test -short ./...` green across 27 packages · `go test -race` on
`internal/congestion` and `internal/pathsim` · `go vet` · `gofmt` ·
`staticcheck -checks=all,-U1000` · `./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
