### PR TITLE
fix: detect same-address uplink reconnects

### DIFF
--- a/changelog.d/recover-stale-quic-udp-associations.fixed.md
+++ b/changelog.d/recover-stale-quic-udp-associations.fixed.md
@@ -1,3 +1,5 @@
 Recover UDP associations after a pooled QUIC stream stops making progress, and
 replace connections bound to a DHCP address which disappeared after a network
-change, instead of leaving either path stalled until the client restarts.
+change. An observed interface outage also starts a new path when the address
+after reconnect is unchanged, instead of leaving any of these paths stalled
+until the client restarts.

--- a/internal/netbind/netbind.go
+++ b/internal/netbind/netbind.go
@@ -35,6 +35,13 @@ type candidate struct {
 	address       netip.Addr
 }
 
+// IsDynamic reports whether resolving spec depends on live interface state.
+// Literal addresses are stable configuration; automatic and interface-bound
+// specifications can disappear and reappear as links change.
+func IsDynamic(spec string) bool {
+	return spec == "auto" || strings.HasPrefix(spec, "if:")
+}
+
 // Resolve returns the address selected by a literal IP, "if:NAME", or
 // "auto". Automatic and interface modes deliberately consider only IPv4
 // addresses on active, non-loopback, non-point-to-point interfaces. Excluding
@@ -44,7 +51,7 @@ func Resolve(spec string) (netip.Addr, error) {
 	if err := Validate(spec); err != nil {
 		return netip.Addr{}, err
 	}
-	if spec != "" && spec != "auto" && !strings.HasPrefix(spec, "if:") {
+	if spec != "" && !IsDynamic(spec) {
 		return netip.ParseAddr(spec)
 	}
 

--- a/internal/netbind/netbind_test.go
+++ b/internal/netbind/netbind_test.go
@@ -28,6 +28,19 @@ func TestResolveLiteral(t *testing.T) {
 	}
 }
 
+func TestIsDynamic(t *testing.T) {
+	for _, spec := range []string{"auto", "if:en0"} {
+		if !IsDynamic(spec) {
+			t.Errorf("IsDynamic(%q) = false", spec)
+		}
+	}
+	for _, spec := range []string{"", "192.0.2.10", "2001:db8::10"} {
+		if IsDynamic(spec) {
+			t.Errorf("IsDynamic(%q) = true", spec)
+		}
+	}
+}
+
 func TestResolveAutoReportsOperationalState(t *testing.T) {
 	// A CI host may have no physical IPv4 interface or more than one. Either
 	// result must be bounded and actionable; success must select IPv4.

--- a/internal/pep/uplink.go
+++ b/internal/pep/uplink.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/bojieli/queqiao/internal/netbind"
 	"github.com/bojieli/queqiao/internal/pathmodel"
 	"github.com/bojieli/queqiao/internal/protocol"
 )
@@ -50,23 +51,62 @@ const (
 // binds the socket and asks the routing table which source address this
 // destination gets.
 func (c *Client) currentUplink() string {
+	address, _ := c.currentUplinkState()
+	return address
+}
+
+// currentUplinkState distinguishes an observed loss of a configured dynamic
+// binding from an inconclusive route probe. That distinction matters when two
+// networks assign the same private address: the address before and after the
+// interruption is equal, but every connection and path measurement still
+// belongs to the network which disappeared.
+func (c *Client) currentUplinkState() (address string, unavailable bool) {
 	if c.cfg.LocalAddress != "" {
 		ip, err := resolveLocalAddress(c.cfg.LocalAddress)
 		if err != nil {
-			return ""
+			// A literal address is immutable, while if:NAME and auto are resolved
+			// from live interface state. Failure of the latter is positive
+			// evidence that the bound uplink is currently unavailable.
+			return "", netbind.IsDynamic(c.cfg.LocalAddress)
 		}
-		return ip.String()
+		return ip.String(), false
 	}
 	conn, err := (&net.Dialer{Control: c.cfg.SocketControl}).Dial("udp", c.cfg.RemoteAddr)
 	if err != nil {
-		return ""
+		// An unbound probe can fail for reasons unrelated to the local link
+		// (resolution, endpoint syntax, or policy), so it remains inconclusive.
+		return "", false
 	}
 	defer conn.Close()
-	return addressHost(conn.LocalAddr())
+	return addressHost(conn.LocalAddr()), false
+}
+
+type uplinkWatchState struct {
+	known       string
+	interrupted bool
+}
+
+// observe reports whether connections belonging to the previous path must be
+// discarded. A definite unavailable interval is itself a path boundary, even
+// if the address on the other side is textually identical. Inconclusive empty
+// observations stay harmless and do not churn a healthy pool.
+func (s *uplinkWatchState) observe(current string, unavailable bool) (from string, changed bool) {
+	if current == "" {
+		if unavailable {
+			s.interrupted = true
+		}
+		return s.known, false
+	}
+	from = s.known
+	changed = s.interrupted || current != s.known
+	s.known = current
+	s.interrupted = false
+	return from, changed
 }
 
 // watchUplink notices the machine changing how it reaches the server.
 func (c *Client) watchUplink(ctx context.Context, known string) {
+	state := uplinkWatchState{known: known}
 	ticker := time.NewTicker(uplinkPollInterval)
 	defer ticker.Stop()
 	for {
@@ -75,12 +115,12 @@ func (c *Client) watchUplink(ctx context.Context, known string) {
 			return
 		case <-ticker.C:
 		}
-		current := c.currentUplink()
-		if current == "" || current == known {
+		current, unavailable := c.currentUplinkState()
+		from, changed := state.observe(current, unavailable)
+		if !changed {
 			continue
 		}
-		c.cfg.Logger.Info("uplink changed", "from", known, "to", current)
-		known = current
+		c.cfg.Logger.Info("uplink changed", "from", from, "to", current)
 		c.onUplinkChanged(ctx)
 	}
 }

--- a/internal/pep/uplink_test.go
+++ b/internal/pep/uplink_test.go
@@ -1,0 +1,58 @@
+package pep
+
+import "testing"
+
+func TestUplinkReconnectWithTheSameAddressStartsANewPath(t *testing.T) {
+	state := uplinkWatchState{known: "192.0.2.10"}
+
+	if _, changed := state.observe("", true); changed {
+		t.Fatal("losing the address acted before a replacement path was usable")
+	}
+	from, changed := state.observe("192.0.2.10", false)
+	if !changed || from != "192.0.2.10" {
+		t.Fatalf("same-address reconnect = changed %v from %q, want a new path", changed, from)
+	}
+	if _, changed := state.observe("192.0.2.10", false); changed {
+		t.Fatal("stable address changed the path twice")
+	}
+}
+
+func TestUplinkAddressChangeStartsANewPath(t *testing.T) {
+	state := uplinkWatchState{known: "192.0.2.10"}
+	from, changed := state.observe("198.51.100.20", false)
+	if !changed || from != "192.0.2.10" || state.known != "198.51.100.20" {
+		t.Fatalf("address change = changed %v from %q known %q", changed, from, state.known)
+	}
+}
+
+func TestInconclusiveUplinkProbeDoesNotChurnAStablePath(t *testing.T) {
+	state := uplinkWatchState{known: "192.0.2.10"}
+	if _, changed := state.observe("", false); changed {
+		t.Fatal("inconclusive observation changed the path")
+	}
+	if _, changed := state.observe("192.0.2.10", false); changed {
+		t.Fatal("one inconclusive probe made the same address look new")
+	}
+}
+
+func TestInitiallyUnavailableUplinkWarmsWhenItAppears(t *testing.T) {
+	state := uplinkWatchState{}
+	if _, changed := state.observe("", true); changed {
+		t.Fatal("unavailable initial path changed before it became usable")
+	}
+	if _, changed := state.observe("192.0.2.10", false); !changed {
+		t.Fatal("first usable path was not detected")
+	}
+}
+
+func TestOnlyConfiguredDynamicBindingMakesAnEmptyProbeDefinitive(t *testing.T) {
+	dynamic := &Client{cfg: ClientConfig{LocalAddress: "if:queqiao-interface-that-does-not-exist"}}
+	if address, unavailable := dynamic.currentUplinkState(); address != "" || !unavailable {
+		t.Fatalf("missing configured interface = address %q unavailable %v", address, unavailable)
+	}
+
+	inconclusive := &Client{cfg: ClientConfig{RemoteAddr: "127.0.0.1:not-a-port"}}
+	if address, unavailable := inconclusive.currentUplinkState(); address != "" || unavailable {
+		t.Fatalf("failed unbound probe = address %q unavailable %v", address, unavailable)
+	}
+}


### PR DESCRIPTION
## Summary

Detect a network reconnect even when a configured dynamic interface receives the same local address it had before the interruption.

A confirmed interface outage is now treated as a path boundary. Once the interface becomes usable, the client retires the previous QUIC pool and prewarms a fresh generation whether or not the address string changed. Inconclusive failures from an unbound route probe remain ignored, so a resolver or endpoint error does not churn a healthy pool.

No wire format, configuration schema, background process, watchdog, or external script changes.

## Failure mechanism

The uplink watcher previously compared only the last and current local address. Empty observations were ignored. During a network switch, an interface can temporarily have no IPv4 address and then receive the same RFC1918 address from a different network. The watcher therefore saw the same string on both sides and kept connections, congestion state, and path measurements from the network which disappeared. Recovery happened only after an unrelated later timeout retired the stale generation.

## Invariant

A path is bounded by continuous availability, not only by its address text. A definite unavailable interval on `auto` or `if:NAME` ends the old path. The next usable observation starts a new one. An inconclusive probe failure is not evidence of a path boundary.

## Implementation

- Centralize whether a local-address specification is dynamic in `netbind.IsDynamic`.
- Return definite-unavailability evidence only for dynamic configured bindings.
- Track interrupted state in the uplink watcher.
- Reuse the existing pool retirement, UDP-health reset, singleflight rebuild, and prewarm paths after reconnect.

## Regression coverage

- same address after a definite outage starts exactly one new path;
- a genuinely changed address starts a new path;
- an inconclusive empty route probe followed by the same address does not churn the pool;
- a client started without an address detects and warms the first usable path;
- configured dynamic and unbound probe failures are classified separately.

## Checks

- full `internal/pep` suite: pass;
- affected state-machine tests repeated 20 times: pass;
- targeted race tests repeated 20 times: pass;
- vet and staticcheck: pass;
- changelog validation and staged secret scan: pass;
- Linux amd64 and Windows amd64 test cross-compilation: pass.

## Field validation

Darwin arm64 and Linux amd64 binaries built from this commit with Go 1.25.13 were deployed as a client/gateway pair. Direct Queqiao TCP returned HTTP 204, and a warmed persistent SOCKS5 UDP association completed 20/20 replies with zero flow failures, fallbacks, UDP-path-unavailable events, reconnect failures, or flow timeouts in the new client process.