### PR TITLE
test: prove the code follows a channel that changes under a live flow

### DIFF
--- a/changelog.d/emulate-a-channel-that-changes.added.md
+++ b/changelog.d/emulate-a-channel-that-changes.added.md
@@ -1,0 +1,8 @@
+The path emulator can change what it erases while traffic is crossing it, in
+each direction independently, through Relay.SetLossRate and
+Bottleneck.SetLossRate. A path that only ever erases what it was constructed
+with cannot express the case a transport most needs to survive: a channel
+that moves under a live flow, which is what the motivating incident was. A
+negative rate leaves a direction alone so one can be changed without knowing
+the other, and a change clears any correlated-loss burst state rather than
+carrying the old regime across it.

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -358,8 +358,8 @@ implementation before the change lands.
 
 | # | Case | Passes if |
 | --- | --- | --- |
-| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing**; end-to-end needs a burst-depth knob in `internal/pathsim`, which has none |
-| 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Open** |
+| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing**; end-to-end still needs a burst-depth knob in `internal/pathsim`, which now has runtime loss control but no bucket |
+| 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Passing end to end** — `TestTheCodeFollowsAChannelThatGetsWorseMidFlow` steps an emulated path from 2% to 45% downstream under a live flow, and the measurement the code is sized from moves from 0.034 to 0.224 while the controller's floor stays at 0.031 |
 | 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation. **Filter-level test passing** |
 | 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked |
 | 5 | Clean path, no erasure | `r = 1`; no parity is sent, without a `minCodedLoss` constant |

--- a/internal/pathmodel/pathmodel.go
+++ b/internal/pathmodel/pathmodel.go
@@ -442,6 +442,23 @@ func Reset() {
 	clear(shared)
 }
 
+// Live reports the model for every endpoint pair this process is currently
+// measuring.
+//
+// It exists because the measured erasure is what a code is sized from and is
+// not exported as a metric, so a test that wants to know whether the stack
+// noticed a channel change has no other way to ask. Callers that know their
+// peer should use Shared; this is for the ones observing from outside.
+func Live() []*PathModel {
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+	models := make([]*PathModel, 0, len(shared))
+	for _, model := range shared {
+		models = append(models, model)
+	}
+	return models
+}
+
 // Shared returns the model for an endpoint pair, creating it on first use.
 // The key should identify the peer rather than the connection: lanes to the
 // same peer are exactly the ones that must share.

--- a/internal/pathsim/pathsim.go
+++ b/internal/pathsim/pathsim.go
@@ -512,6 +512,49 @@ func newRelay(listen, target string, cfg Config, shared *Bottleneck) (*Relay, er
 // LocalAddr is the address clients should use in place of the real server.
 func (r *Relay) LocalAddr() string { return r.local.LocalAddr().String() }
 
+// SetLossRate changes what the path erases, in each direction, while traffic
+// is already crossing it.
+//
+// A path that only ever erases what it was constructed with cannot express the
+// case a transport most needs to survive: one whose channel changes under a
+// live flow. The motivating incident was exactly that -- downstream erasure
+// moving from a few percent to sixty over a working afternoon -- and a
+// controller that reads a floor established during the clean window will size
+// its code for a channel that no longer exists. Emulating the step is the only
+// way to test that the estimate follows.
+//
+// A negative rate leaves that direction alone, so a caller may change one
+// without knowing the other.
+func (r *Relay) SetLossRate(upstream, downstream float64) {
+	r.upstream.setLossRate(upstream)
+	r.downstream.setLossRate(downstream)
+}
+
+// SetLossRate changes what a shared bottleneck erases, for every relay
+// attached to it.
+func (b *Bottleneck) SetLossRate(upstream, downstream float64) {
+	b.up.setLossRate(upstream)
+	b.down.setLossRate(downstream)
+}
+
+// setLossRate takes the same lock the drop decision is made under, so a change
+// lands between packets rather than during one.
+func (d *direction) setLossRate(rate float64) {
+	if rate < 0 {
+		return
+	}
+	if rate > 1 {
+		rate = 1
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.lossRate = rate
+	// A Gilbert chain mid-burst would otherwise carry the old regime's bad
+	// state across the change and erase everything until it happened to
+	// recover, which reads as the new rate arriving late.
+	d.inBurst = false
+}
+
 // Stats returns the upstream (client to server) and downstream counters.
 func (r *Relay) Stats() (up, down Stats) { return r.upstream.stats(), r.downstream.stats() }
 

--- a/internal/pathsim/pathsim_test.go
+++ b/internal/pathsim/pathsim_test.go
@@ -631,3 +631,81 @@ func TestPerFlowPolicerBucketFollowsItsOwnRate(t *testing.T) {
 		t.Fatalf("a source exceeding its own bucket was not policed: in=%d dropped=%d", up.PacketsIn, up.PacketsDropped)
 	}
 }
+
+// A path whose erasure never changes cannot express the case a transport most
+// needs to survive: a channel that moves under a live flow. The motivating
+// incident was exactly that, downstream erasure going from a few percent to
+// sixty over an afternoon, so the emulator has to be able to step it.
+func TestLossRateChangesUnderALiveFlow(t *testing.T) {
+	server := echoServer(t)
+	relay, err := New("127.0.0.1:0", server.LocalAddr().String(), Config{Seed: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+
+	client, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	target, err := net.ResolveUDPAddr("udp", relay.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	measure := func(packets int) float64 {
+		t.Helper()
+		before, _ := relay.Stats()
+		for range packets {
+			if _, err := client.WriteTo([]byte("x"), target); err != nil {
+				t.Fatal(err)
+			}
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if up, _ := relay.Stats(); up.PacketsIn >= before.PacketsIn+uint64(packets) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		after, _ := relay.Stats()
+		crossed := after.PacketsIn - before.PacketsIn
+		if crossed == 0 {
+			t.Fatal("no packets crossed the relay")
+		}
+		return float64(after.PacketsLost-before.PacketsLost) / float64(crossed)
+	}
+
+	if clean := measure(400); clean != 0 {
+		t.Fatalf("a path configured with no loss erased %.3f of its packets", clean)
+	}
+
+	relay.SetLossRate(0.5, 0)
+	if lossy := measure(1200); lossy < 0.35 || lossy > 0.65 {
+		t.Fatalf("after asking for 50%% upstream erasure the path erased %.3f", lossy)
+	}
+
+	relay.SetLossRate(0, 0)
+	if back := measure(600); back != 0 {
+		t.Fatalf("after returning to a clean path it still erased %.3f", back)
+	}
+
+	// A negative rate means "leave this direction alone", so one direction can
+	// be changed without the caller knowing the other.
+	relay.SetLossRate(0.5, -1)
+	if again := measure(1200); again < 0.35 {
+		t.Fatalf("a negative downstream rate disturbed the upstream change: %.3f", again)
+	}
+	relay.SetLossRate(-1, -1)
+	if held := measure(1200); held < 0.35 {
+		t.Fatalf("two negative rates changed the erasure: %.3f", held)
+	}
+
+	// Out-of-range rates are clamped rather than producing a probability above
+	// one, which the Gilbert chain would divide by.
+	relay.SetLossRate(2, -1)
+	if all := measure(400); all < 0.95 {
+		t.Fatalf("a rate above one erased only %.3f", all)
+	}
+}

--- a/internal/pep/codedlane_test.go
+++ b/internal/pep/codedlane_test.go
@@ -70,6 +70,7 @@ func codedPairWith(t *testing.T, pooled bool, path *pathsim.Config, serve func(n
 		}
 		t.Cleanup(func() { _ = relay.Close() })
 		remote = relay.LocalAddr()
+		lastRelay = relay
 	}
 
 	clientListener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -94,6 +95,10 @@ func codedPairWith(t *testing.T, pooled bool, path *pathsim.Config, serve func(n
 // lastClient is the client the most recent harness built, for tests that need
 // to call into it rather than through its SOCKS port.
 var lastClient *Client
+
+// lastRelay is the emulated path the most recent harness built, for tests that
+// change what it does while a flow is crossing it.
+var lastRelay *pathsim.Relay
 
 // clientServerAcross brings up a client and server across a path and returns
 // the client, for tests that drive it directly rather than through SOCKS.
@@ -374,4 +379,108 @@ func erasureChannelBudget(budget time.Duration) time.Duration {
 		return 4 * budget
 	}
 	return budget
+}
+
+// Falsification case 2 from the control redesign, end to end: the channel gets
+// materially worse under a live flow and the code has to follow it.
+//
+// This is the incident's own shape. Downstream erasure went from a few percent
+// to sixty over an afternoon, and the code stayed sized for the clean window
+// because the controller's floor was a lower envelope for the lifetime of the
+// connection and the coded layer built its whole view of the channel out of
+// that one scalar. Every unit test for the fix supplies the measurement
+// directly; this one makes the stack measure it.
+func TestTheCodeFollowsAChannelThatGetsWorseMidFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("brings up QUIC across an emulated 300 ms path")
+	}
+	requireStableImpairmentClock(t)
+	path := pathsim.Config{
+		OneWayDelay:         150 * time.Millisecond,
+		RateBytesPerSec:     uint64(25e6 / 8),
+		PolicerRefillPeriod: 8 * time.Millisecond,
+		LossRate:            0.02,
+		Seed:                23,
+	}
+	socks, destination := codedPair(t, true, &path)
+	relay := lastRelay
+	if relay == nil {
+		t.Fatal("the harness did not expose the emulated path")
+	}
+	conn := socksDial(t, socks, destination, erasureChannelBudget(180*time.Second))
+	defer conn.Close()
+
+	payload := make([]byte, 16*1024)
+	rand.New(rand.NewSource(9)).Read(payload)
+	echo := func(what string) {
+		t.Helper()
+		go func() { _, _ = conn.Write(payload) }()
+		got := make([]byte, len(payload))
+		if _, err := io.ReadFull(conn, got); err != nil {
+			t.Fatalf("%s: %v", what, err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("%s: the flow was corrupted", what)
+		}
+	}
+
+	// Enough traffic on the clean channel for the model to settle on it.
+	for i := 0; i < 3; i++ {
+		echo("clean channel")
+	}
+	cleanErasure := measuredErasure(t)
+	t.Logf("clean channel: measured erasure %.4f", cleanErasure)
+
+	// Now the channel gets much worse, without the flow being told.
+	relay.SetLossRate(-1, 0.45)
+	for i := 0; i < 6; i++ {
+		echo("degraded channel")
+	}
+	degradedErasure, degradedFloor := measuredErasureAndFloor(t)
+	t.Logf("degraded channel: measured erasure %.4f, controller floor %.4f",
+		degradedErasure, degradedFloor)
+
+	// The flow surviving is necessary but not the point: what the incident
+	// showed is a code that stayed sized for a channel that no longer existed.
+	// The measurement the code reads has to have followed the path.
+	if degradedErasure <= cleanErasure {
+		t.Fatalf("the channel went from 2%% to 45%% downstream erasure and the measurement "+
+			"the code is sized from went %.4f to %.4f", cleanErasure, degradedErasure)
+	}
+	if degradedErasure < 0.05 {
+		t.Fatalf("a 45%% erasure channel is being reported to the code as %.4f", degradedErasure)
+	}
+	// The floor is logged for contrast rather than asserted on. It is a lower
+	// envelope for the lifetime of the connection, so it keeps what the clean
+	// window established while the measurement moves -- on this path it
+	// typically reads around a seventh of the erasure, which is the same shape
+	// as the live incident's 1.76% against 19.9%. Sizing parity from it is
+	// sizing for a channel that no longer exists. But a later change that made
+	// the floor track honestly would be an improvement, and this test must not
+	// fail for it: what is under contract here is that the measurement follows.
+	t.Logf("the floor the code used to be sized from reads %.4f against a measured %.4f",
+		degradedFloor, degradedErasure)
+}
+
+// measuredErasure is the largest erasure any live endpoint pair in this process
+// has measured on the direction it sends into, which is what fec.Choose is
+// sized from.
+func measuredErasure(t *testing.T) float64 {
+	t.Helper()
+	erasure, _ := measuredErasureAndFloor(t)
+	return erasure
+}
+
+// measuredErasureAndFloor reports the measurement the code is sized from
+// alongside the controller's floor, which is what it used to be sized from.
+func measuredErasureAndFloor(t *testing.T) (erasure, floor float64) {
+	t.Helper()
+	for _, model := range pathmodel.Live() {
+		state := model.Current()
+		if state.Erasure > erasure {
+			erasure = state.Erasure
+			floor = state.Floor
+		}
+	}
+	return erasure, floor
 }


### PR DESCRIPTION
Every test for the erasure-sizing fix in #52 hands the measurement to the code
directly. None makes the stack measure it — which is the half that actually
failed on the live path.

## The gap

The controller's floor is a lower envelope for the lifetime of the connection,
so one established during a clean window survives into a degraded one, and the
coded layer built its whole view of the channel out of that scalar. The
emulator could not express that: its impairment is fixed at construction, so **a
channel that moves under a live flow had no representation** — and that is
precisely what the incident was.

## What this adds

`Relay.SetLossRate` and `Bottleneck.SetLossRate` change what a path erases, in
each direction independently, while traffic is crossing it.

- A negative rate leaves a direction alone, so one can be changed without the
  caller knowing the other.
- Out-of-range rates are clamped rather than handed to a Gilbert chain that
  would divide by them.
- A change clears any correlated-loss burst state, so the old regime is not
  carried across it and read as the new rate arriving late.

## The result

`TestTheCodeFollowsAChannelThatGetsWorseMidFlow` — falsification case 2 from
`docs/CONTROL-REDESIGN.md`, end to end. A coded lane comes up across an emulated
300 ms path at 2% erasure, the model settles, then the downstream goes to 45%
without the flow being told:

```
clean channel:    measured erasure 0.0340
degraded channel: measured erasure 0.2244, controller floor 0.0310
```

The measurement followed the path. **The floor stayed at a seventh of the
channel** — the same shape as the live incident's 1.76% against a measured
19.9%. Sizing parity from it is sizing for a channel that no longer exists,
which is what shipped.

The floor is logged rather than asserted on. A later change that made it track
honestly would be an improvement and this test must not fail for it; what is
under contract is that the measurement follows.

## Also

`pathmodel.Live` reports every endpoint pair the process is measuring. The
measured erasure is not exported as a metric, so a test observing from outside
the stack has no other way to ask what the code is being sized from — exporting
it per direction is the remaining half of that gap and is not in this PR.

## Falsification status after this

| # | Case | Status |
| --- | --- | --- |
| 1 | Token bucket | filter-level passing; end-to-end still needs a burst-depth knob in pathsim, which now has runtime loss control but no bucket |
| 2 | Step change mid-flow | **passing end to end** |
| 3 | Tightening throttle | filter-level passing |
| 4 | Shallow dropper, no queue | open — the one expected to fail |
| 5–7 | Clean path, self-limiting, interactive latency | open, need the delay bound |

## Checks

`go test -short ./...` green across 27 packages · full (non-short)
`internal/pep` 126 s and `internal/pathsim` 88 s, both green · `go vet` ·
`gofmt` · `staticcheck -checks=all,-U1000` · gosec baseline (134 reviewed
findings, no unreviewed) · `./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
