### PR TITLE
feat: publish the erasure the code is actually sized from

### DIFF
--- a/changelog.d/publish-the-erasure-the-code-is-sized-from.added.md
+++ b/changelog.d/publish-the-erasure-the-code-is-sized-from.added.md
@@ -1,0 +1,11 @@
+The erasure a path is measured to be applying is now published, labelled by
+the direction it was measured on: queqiao_erasure_ratio{direction="send"} in
+the metrics and queqiao_erasure_ratio_send in the performance snapshot. A
+gateway's send direction is its downstream, which is the direction that had
+no metric at all. The only erasure figure that used to leave the process was
+the congestion controller's floor, and a floor is not a smaller version of
+the measurement: it is biased low so that pacing errs towards slowing down,
+and it is a lower envelope for a connection's lifetime, so it keeps whatever
+a clean window established while the channel moves. On one live incident the
+two read 1.76% and 19.9%, and nothing on a dashboard could show which one
+the code was being sized for.

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -1001,6 +1001,7 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_quic_controller_bytes_lost", s.QUICControllerBytesLost),
 		slog.Uint64("queqiao_quic_controller_packets_lost", s.QUICControllerPacketsLost),
 		slog.Float64("queqiao_quic_controller_min_rtt_seconds", s.QUICControllerMinRTT.Seconds()),
+		slog.Float64("queqiao_erasure_ratio_send", s.QUICErasureSend),
 		slog.Float64("queqiao_quic_controller_erasure_floor_ratio", s.QUICControllerErasureFloor),
 		slog.Bool("queqiao_quic_controller_in_recovery", s.QUICControllerInRecovery),
 		// A refused lane join is a peer's flow about to fail. Flat names,

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -118,8 +118,17 @@ Prometheus `/metrics` names. They cover:
 - flow telemetry entries expired because nothing refreshed them, which is how
   a round-trip aggregate frozen at a stale constant announces itself;
 - lane joins refused and account flow opens refused, each split by reason; and
-- the controller's measured erasure floor, sampler diagnostics, and class
-  transitions.
+- the erasure the path is measured to be applying to the direction this
+  endpoint sends into, published as `queqiao_erasure_ratio{direction="send"}`
+  and as `queqiao_erasure_ratio_send` in the log. A gateway's send direction is
+  its downstream. This is what a code is sized from;
+- the controller's erasure floor, which is the pacing-side view of the same
+  channel and is not a smaller version of the figure above. It is biased low on
+  purpose so that pacing errs towards slowing down, and it is a lower envelope
+  for a connection's lifetime, so it keeps what a clean window established while
+  the measurement follows the path. On one live incident the two read 1.76% and
+  19.9%; and
+- sampler diagnostics and class transitions.
 
 Flow completion records also carry what the flow's lane replacements did:
 `lane_replacement_waits`, `lane_replacement_timeouts`, `lane_replacement_wait`,

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -77,6 +77,12 @@ type ErasureSender struct {
 	floorTrusted     bool
 	establishedFloor float64
 
+	// erasure is the pooled measured erasure of the direction this sender
+	// sends into, in parts per million. It is what the code is sized from, and
+	// it is published because a floor is not a substitute for it: on the live
+	// path the floor read a seventh of what the channel was doing.
+	erasure atomic.Uint64
+
 	// arrival is the last computed arrival rate, published for the pacer and
 	// the congestion window, which run outside the callback that computes it.
 	arrival atomic.Uint64 // arrival rate in parts per million
@@ -299,6 +305,7 @@ func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 			RoundTrip:       e.inner.minRoundTrip(),
 		})
 		floor = state.Floor
+		e.erasure.Store(uint64(state.Erasure * partsPerMillion))
 		e.share.Store(uint64(state.Share))
 	}
 	e.arrival.Store(uint64((1 - floor) * partsPerMillion))
@@ -460,6 +467,7 @@ func (e *ErasureSender) Telemetry() ControllerTelemetry {
 	suppressed := e.suppressed.Load()
 	t.PacketsLostSuppressed = suppressed
 	t.PacketsLostObserved = t.PacketsLost + suppressed
+	t.Erasure = float64(e.erasure.Load()) / partsPerMillion
 	arrival := e.arrivalRate()
 	t.ErasureFloor = 1 - arrival
 	t.PacingRate = uint64(float64(t.PacingRate) / arrival)

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -573,3 +573,34 @@ func TestControllersThatDoNotClassifyReportObservedEqualToCharged(t *testing.T) 
 		})
 	}
 }
+
+// The code is sized from the measured erasure and the pacer from the floor, and
+// the two are different numbers about the same channel. A trace that carries
+// only the floor cannot explain a code rate, which is what made the live
+// incident unreadable: the floor read 1.76% while the channel erased 19.9%.
+func TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom(t *testing.T) {
+	model := pathmodel.NewPathModel()
+	// A model whose floor and measurement disagree the way the live one did.
+	model.Report(2, pathmodel.Observation{
+		Floor: 0.0176, FloorSamples: 5000,
+		Erasure: 0.199, BurstFactor: 1,
+		ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 200 * time.Millisecond,
+	})
+	e := NewErasureSenderOn(1200, model)
+
+	// One congestion event is enough to make this sender a member and pull the
+	// pooled state through.
+	e.OnCongestionEventEx(0, monotime.Now(), []quiccongestion.AckedPacketInfo{
+		{PacketNumber: 1, BytesAcked: 1200},
+	}, nil)
+
+	got := e.Telemetry()
+	t.Logf("published erasure %.4f against floor %.4f", got.Erasure, got.ErasureFloor)
+	if got.Erasure < 0.1 {
+		t.Fatalf("the sender published %.4f on a path measured at 0.199", got.Erasure)
+	}
+	if got.Erasure <= got.ErasureFloor {
+		t.Fatalf("published erasure %.4f is not above the floor %.4f, so the two cannot be "+
+			"told apart in a trace", got.Erasure, got.ErasureFloor)
+	}
+}

--- a/internal/congestion/telemetry.go
+++ b/internal/congestion/telemetry.go
@@ -54,6 +54,16 @@ type ControllerTelemetry struct {
 	PacketsLostSuppressed uint64
 	MinRTT                time.Duration
 	InRecovery            bool
+	// Erasure is the share of packets the path is measured to be erasing on
+	// the direction this controller sends into, pooled across the lanes that
+	// share it. It is what a code is sized from.
+	//
+	// ErasureFloor below is not a substitute for it and is not a smaller
+	// version of it. The floor is biased low on purpose so that pacing errs
+	// towards slowing down, and it is a lower envelope for the lifetime of a
+	// connection, so it keeps what a clean window established while this
+	// follows the path. On the live incident the two read 1.76% and 19.9%.
+	Erasure float64
 	// ErasureFloor is the share of packets this path drops for reasons that
 	// have nothing to do with sending rate, as the controller currently
 	// believes it. Everything sized for the path is sized from this number --

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -293,7 +293,7 @@ type Snapshot struct {
 	QUICControllerCongestionWindow, QUICControllerBytesInFlight   uint64
 	QUICControllerBytesLost, QUICControllerPacketsLost            uint64
 	QUICControllerMinRTT                                          time.Duration
-	QUICControllerErasureFloor                                    float64
+	QUICErasureSend, QUICControllerErasureFloor                   float64
 	QUICControllerInRecovery                                      bool
 	// QUICObservationsExpired counts flow telemetry entries dropped because
 	// they stopped being refreshed. See quicObservationsExpired.
@@ -329,6 +329,7 @@ type QUICObservation struct {
 	ControllerCongestionWindow uint64
 	ControllerBytesInFlight    uint64
 	ControllerMinRTT           time.Duration
+	ControllerErasure          float64
 	ControllerErasureFloor     float64
 	ControllerInRecovery       bool
 }
@@ -649,7 +650,7 @@ func (r *Registry) Snapshot() Snapshot {
 	var controllerLatestAckRate, controllerLatestSendRate uint64
 	var controllerRound uint64
 	var controllerMinRTT time.Duration
-	var controllerErasureFloor float64
+	var controllerErasure, controllerErasureFloor float64
 	var controllerRecovery bool
 	for key, entry := range r.quicFlows {
 		// An entry nobody refreshes is not a measurement of anything. Because
@@ -705,6 +706,13 @@ func (r *Registry) Snapshot() Snapshot {
 			if o.ControllerMinRTT > controllerMinRTT {
 				controllerMinRTT = o.ControllerMinRTT
 			}
+			// Both are already pooled across the lanes of one endpoint pair,
+			// so a maximum here selects the worst pair this process is
+			// serving rather than the worst lane, which is what a maximum over
+			// per-lane estimates would have meant.
+			if o.ControllerErasure > controllerErasure {
+				controllerErasure = o.ControllerErasure
+			}
 			if o.ControllerErasureFloor > controllerErasureFloor {
 				controllerErasureFloor = o.ControllerErasureFloor
 			}
@@ -746,6 +754,7 @@ func (r *Registry) Snapshot() Snapshot {
 	s.QUICControllerBytesLost = counters.ControllerBytesLost
 	s.QUICControllerPacketsLost = counters.ControllerPacketsLost
 	s.QUICControllerMinRTT = controllerMinRTT
+	s.QUICErasureSend = controllerErasure
 	s.QUICControllerErasureFloor = controllerErasureFloor
 	s.QUICControllerInRecovery = controllerRecovery
 	return s
@@ -830,6 +839,15 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "queqiao_quic_controller_bytes_lost %d\n", s.QUICControllerBytesLost)
 	fmt.Fprintf(w, "queqiao_quic_controller_packets_lost %d\n", s.QUICControllerPacketsLost)
 	fmt.Fprintf(w, "queqiao_quic_controller_min_rtt_seconds %.9f\n", s.QUICControllerMinRTT.Seconds())
+	// The erasure the path is measured to be applying, labelled by the
+	// direction it was measured on. A gateway's send direction is its
+	// downstream, which is the direction that was invisible when the only
+	// erasure figure published was the floor below.
+	fmt.Fprintf(w, "queqiao_erasure_ratio{direction=\"send\"} %.9f\n", s.QUICErasureSend)
+	// The floor is the conservative, pacing-side view of the same channel:
+	// biased low on purpose, and a lower envelope for a connection's lifetime.
+	// It is not a smaller version of the figure above and a code sized from it
+	// is sized for a channel that may no longer exist.
 	fmt.Fprintf(w, "queqiao_quic_controller_erasure_floor_ratio %.9f\n", s.QUICControllerErasureFloor)
 	if s.QUICControllerInRecovery {
 		fmt.Fprintln(w, "queqiao_quic_controller_in_recovery 1")

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -462,3 +462,48 @@ func TestLossTotalsOnlyMoveForward(t *testing.T) {
 		t.Fatalf("suppressed total fell from %d to %d", before.QUICLossSuppressedPackets, after.QUICLossSuppressedPackets)
 	}
 }
+
+// An erasure figure without a direction cannot be read. The one that used to be
+// published was the controller's floor: biased low for pacing, a lower envelope
+// for a connection's lifetime, and the only erasure number that left the
+// process. On the live incident it read 1.76% while the channel erased 19.9%,
+// so nothing on a dashboard could show what the code was being sized for.
+func TestTheMeasuredErasureIsPublishedBesideTheFloorAndLabelledByDirection(t *testing.T) {
+	r := New()
+	r.ObserveQUIC(1, QUICObservation{
+		ControllerKind: "erasure", ControllerErasure: 0.199, ControllerErasureFloor: 0.0176,
+	})
+	s := r.Snapshot()
+	if s.QUICErasureSend != 0.199 {
+		t.Fatalf("measured send erasure = %v, want 0.199", s.QUICErasureSend)
+	}
+	if s.QUICControllerErasureFloor != 0.0176 {
+		t.Fatalf("floor = %v, want 0.0176", s.QUICControllerErasureFloor)
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		`queqiao_erasure_ratio{direction="send"} 0.199000000`,
+		"queqiao_quic_controller_erasure_floor_ratio 0.017600000",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exposition is missing %q", want)
+		}
+	}
+}
+
+// Both figures arrive already pooled across the lanes of one endpoint pair, so
+// folding several observations must select the worst pair rather than turning
+// into a maximum over lanes -- which is what made the floor read "the worst
+// single lane right now" and jump between 1.8% and 6.9% within minutes.
+func TestErasureFoldsAcrossEndpointPairsNotLanes(t *testing.T) {
+	r := New()
+	r.ObserveQUIC(1, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.05, ControllerErasureFloor: 0.01})
+	r.ObserveQUIC(2, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.30, ControllerErasureFloor: 0.02})
+	r.ObserveQUIC(3, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.10, ControllerErasureFloor: 0.03})
+	if s := r.Snapshot(); s.QUICErasureSend != 0.30 {
+		t.Fatalf("send erasure = %v across three pairs, want the worst at 0.30", s.QUICErasureSend)
+	}
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -693,6 +693,9 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 			if controller.MinRTT > observation.ControllerMinRTT {
 				observation.ControllerMinRTT = controller.MinRTT
 			}
+			if controller.Erasure > observation.ControllerErasure {
+				observation.ControllerErasure = controller.Erasure
+			}
 			if controller.ErasureFloor > observation.ControllerErasureFloor {
 				observation.ControllerErasureFloor = controller.ErasureFloor
 			}


### PR DESCRIPTION
The only erasure figure that left the process was the congestion controller's
floor — and **a floor is not a smaller version of the measurement.** It is
biased low so that pacing errs towards slowing down, and it is a lower envelope
for a connection's lifetime, so it keeps whatever a clean window established
while the channel moves.

On the live incident the two read **1.76% and 19.9%**. Nothing on a dashboard
could show which one the code was being sized for, which is why the
under-provisioning had to be found in per-flow completion records instead of on
a graph.

## What this adds

`queqiao_erasure_ratio{direction="send"}`, beside the floor, with
`queqiao_erasure_ratio_send` in the performance snapshot.

**A gateway's send direction is its downstream**, so this is exactly the figure
that was missing: the gateway's controller had been measuring the erasure that
mattered all along and had nowhere to put it.

The direction label is on the metric rather than in a comment because an
erasure figure without one cannot be read — an endpoint measures the direction
it *sends into*, so the same number means opposite things at the two ends of a
path. Two reviewers of this incident, myself included, read one wrongly.

## Folding

Both figures arrive already pooled across the lanes of an endpoint pair, so
folding several selects the worst **pair** rather than the worst **lane**. Not
academic: the floor's existing fold is over per-lane values and produced
readings of 1.8%, 3.5% and 6.9% within minutes on one gateway — the worst
single lane at each moment, rather than anything about the path.

## Tests

- `TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom` — a model whose floor
  and measurement disagree the way the live one did; the sender publishes
  `0.1990` against a floor of `0.0176`, and the two must be distinguishable.
- `TestTheMeasuredErasureIsPublishedBesideTheFloorAndLabelledByDirection` — both
  present in `/metrics`, with the direction label.
- `TestErasureFoldsAcrossEndpointPairsNotLanes` — three pairs fold to the worst
  pair.

## Not in this PR

The receive direction is still per-flow only. Aggregating the decoders' measured
erasure and residual into metrics — the 11% residual that was invisible during
the incident — needs the same monotonic treatment the connection counters got in
#51, so it is left out rather than half done.

## Checks

`go test -short ./...` green across 27 packages · `go vet` · `gofmt` ·
`staticcheck -checks=all,-U1000` · gosec baseline (134 reviewed, none
unreviewed) · `./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
