### PR TITLE
fix: enforce bulk isolation connection budget

### DIFF
--- a/changelog.d/bound-bulk-isolation.fixed.md
+++ b/changelog.d/bound-bulk-isolation.fixed.md
@@ -1,0 +1,2 @@
+Keep concurrent bulk isolation within its configured connection budget instead
+of bypassing a full pool with dedicated QUIC dials.

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -1498,6 +1498,20 @@ type laneJoinResult struct {
 // this endpoint is the ordinary way to reach it.
 var errLaneJoinRejected = errors.New("lane join rejected")
 
+// errBulkConnectionLimit is a scheduling answer, not a transport failure.
+// The caller keeps the flow on its pooled control connection when every
+// isolation slot is occupied. Falling back to a dedicated connection here
+// would silently bypass the descriptor and handshake budget this limit exists
+// to enforce.
+var errBulkConnectionLimit = errors.New("bulk lane connection limit reached")
+
+func dedicatedBulkFallbackAllowed(err error) bool {
+	return err != nil &&
+		!errors.Is(err, errBulkConnectionLimit) &&
+		!errors.Is(err, context.Canceled) &&
+		!errors.Is(err, context.DeadlineExceeded)
+}
+
 func (c *Client) openJoinLane(ctx context.Context, kind TransportKind, sessionID [16]byte, flowID, laneID uint64) (*mpLane, error) {
 	if kind != TransportQUIC && kind != TransportTCP {
 		return nil, fmt.Errorf("unsupported join transport %q", kind)
@@ -1505,6 +1519,8 @@ func (c *Client) openJoinLane(ctx context.Context, kind TransportKind, sessionID
 	if kind == TransportQUIC && c.cfg.EnableQUICPool {
 		if lane, poolErr := c.openPooledJoinLane(ctx, sessionID, flowID, laneID); poolErr == nil {
 			return lane, nil
+		} else if !dedicatedBulkFallbackAllowed(poolErr) {
+			return nil, poolErr
 		} else {
 			c.cfg.Logger.Debug("pooled lane join unavailable; using dedicated lane", "error", poolErr)
 		}
@@ -1638,7 +1654,7 @@ func (c *Client) reserveBulkConn(ctx context.Context) (*bulkConn, error) {
 	}
 	if len(c.bulkConns) >= c.maxBulkConns() {
 		c.bulkMu.Unlock()
-		return nil, errors.New("bulk lane connection limit reached")
+		return nil, errBulkConnectionLimit
 	}
 	c.bulkMu.Unlock()
 
@@ -1652,7 +1668,7 @@ func (c *Client) reserveBulkConn(ctx context.Context) (*bulkConn, error) {
 	if len(c.bulkConns) >= c.maxBulkConns() {
 		c.bulkMu.Unlock()
 		entry.close("queqiao bulk pool limit reached")
-		return nil, errors.New("bulk lane connection limit reached")
+		return nil, errBulkConnectionLimit
 	}
 	entry.busy = true
 	c.bulkConns = append(c.bulkConns, entry)
@@ -1881,7 +1897,11 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 							c.cfg.Logger.Debug("peer refused lane join; flow stays on the shared connection", "lane", result.id, "error", result.err)
 							break
 						}
-						c.cfg.Logger.Warn("bulk isolation lane unavailable", "lane", result.id, "error", result.err)
+						if errors.Is(result.err, errBulkConnectionLimit) {
+							c.cfg.Logger.Debug("bulk isolation capacity occupied; flow stays on the shared connection", "lane", result.id)
+						} else {
+							c.cfg.Logger.Warn("bulk isolation lane unavailable", "lane", result.id, "error", result.err)
+						}
 						if isolationBackoff == 0 {
 							isolationBackoff = minLaneProbeBackoff
 						} else if isolationBackoff < maxLaneProbeBackoff {

--- a/internal/pep/laneisolation_test.go
+++ b/internal/pep/laneisolation_test.go
@@ -3,9 +3,15 @@ package pep
 import (
 	"context"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -304,6 +310,100 @@ func TestPooledFlowCountTracksOpenAndClose(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("server shutdown timeout")
+	}
+}
+
+func TestBulkIsolationCapacityCannotEscapeIntoDedicatedConnections(t *testing.T) {
+	certificate, roots := testCertificate(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	packetConn, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := NewServer(ServerConfig{
+		ListenAddr: packetConn.LocalAddr().String(), Credentials: certificate,
+		DestinationPolicy: DestinationPolicy{AllowPrivate: true}, EnableQUIC: true,
+		Logger: logger, HandshakeTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- server.ServePacketConn(ctx, packetConn) }()
+
+	var sockets atomic.Int64
+	client, err := NewClient(ClientConfig{
+		ListenAddr: "127.0.0.1:0", RemoteAddr: packetConn.LocalAddr().String(),
+		LocalAddress: "127.0.0.1", Credentials: roots,
+		Transport: TransportQUIC, EnableQUICPool: true,
+		DialTimeout: 2 * time.Second, HandshakeTimeout: 2 * time.Second,
+		Logger: logger,
+		SocketControl: func(network, _ string, _ syscall.RawConn) error {
+			if strings.HasPrefix(network, "udp") {
+				sockets.Add(1)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.memoryLimits.maxBulkConnections = 1
+
+	occupied, err := client.reserveBulkConn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer occupied.close("test complete")
+
+	const waiters = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, waiters)
+	for i := 0; i < waiters; i++ {
+		wg.Add(1)
+		go func(laneID uint64) {
+			defer wg.Done()
+			_, laneErr := client.openJoinLane(ctx, TransportQUIC, [16]byte{1}, 1, laneID)
+			errs <- laneErr
+		}(uint64(i + 1))
+	}
+	wg.Wait()
+	close(errs)
+	for laneErr := range errs {
+		if !errors.Is(laneErr, errBulkConnectionLimit) {
+			t.Fatalf("over-budget lane = %v, want capacity decision", laneErr)
+		}
+	}
+	if got := sockets.Load(); got != 1 {
+		t.Fatalf("over-budget isolation opened %d UDP sockets, want the one admitted connection", got)
+	}
+
+	client.closeQUICPool()
+	cancel()
+	select {
+	case serveErr := <-serverErr:
+		if serveErr != nil && !errors.Is(serveErr, net.ErrClosed) {
+			t.Fatalf("server shutdown: %v", serveErr)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("server shutdown timeout")
+	}
+}
+
+func TestDedicatedBulkFallbackIsReservedForRecoverablePoolFailures(t *testing.T) {
+	if dedicatedBulkFallbackAllowed(errBulkConnectionLimit) {
+		t.Fatal("capacity decision was treated as a pool failure")
+	}
+	if dedicatedBulkFallbackAllowed(fmt.Errorf("wrapped: %w", errBulkConnectionLimit)) {
+		t.Fatal("wrapped capacity decision was treated as a pool failure")
+	}
+	if dedicatedBulkFallbackAllowed(context.Canceled) || dedicatedBulkFallbackAllowed(context.DeadlineExceeded) {
+		t.Fatal("expired caller started a dedicated fallback")
+	}
+	if !dedicatedBulkFallbackAllowed(errors.New("pooled stream unavailable")) {
+		t.Fatal("recoverable pool failure did not retain dedicated fallback")
 	}
 }
 


### PR DESCRIPTION
## Summary

- treat a full bulk-isolation pool as a scheduling decision instead of a transport failure
- keep excess flows on the shared control connection rather than escaping the configured limit through dedicated QUIC dials
- retain dedicated fallback for genuine pool failures and keep capacity retries at debug level with the existing bounded backoff

## Why

`reserveBulkConn` correctly rejected new entries at the configured budget, but `openJoinLane` interpreted that answer like any other pooled-lane failure and immediately opened a dedicated QUIC connection. Concurrent bulk flows could therefore exceed the intended socket, handshake, and memory ceiling.

## Verification

- new real-QUIC regression: 16 simultaneous over-budget joins create no sockets beyond the one admitted connection
- held-out policy regression: wrapped capacity errors and canceled contexts do not fall back; unrelated pool failures still do
- `go test ./internal/pep -run 'Test(BulkIsolationCapacityCannotEscapeIntoDedicatedConnections|DedicatedBulkFallbackIsReservedForRecoverablePoolFailures)$' -count=20`\n- `go test ./internal/pep -count=1`\n- `go vet ./...`\n- full repository tests, race-focused tests, and Linux/Windows amd64 cross-builds passed on the combined development branch\n\n## Local A/B\n\nWith 16 concurrent rate-limited bulk downloads over the same Mac-to-VPS path, the deployed pre-fix client opened 17 outer UDP sockets and reached about 187 MB RSS; this branch stayed at 9 sockets (one control plus eight budgeted bulk connections) and about 113 MB RSS. Five foreground 204 probes during load averaged about 373 ms before and 354 ms after. CPU did not improve in that short run, so this change is intentionally scoped to enforcing the configured resource budget and protecting latency under concurrency.