### PR TITLE
feat: emulate a burst allowance, and record what it showed about the estimate

### DIFF
--- a/changelog.d/emulate-a-burst-allowance.added.md
+++ b/changelog.d/emulate-a-burst-allowance.added.md
@@ -1,0 +1,6 @@
+The path emulator can model a token bucket with a burst allowance, through
+Config.PolicerBurstBytes. A shaped path has two rates rather than one: a
+short probe drains the bucket and measures the line, while sustained load
+measures the shaping rate, and a path emulated with only the second is
+indistinguishable from a slower one. The existing shallow bucket, one refill
+quantum plus a packet, still models the live path and remains the default.

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -292,6 +292,31 @@ rejects **inferring** outbound erasure from inbound loss. A peer **reporting**
 what it measured on your outbound direction is not inference; it is a direct
 measurement relayed, and the reasoning does not extend to it.
 
+## A limit found while trying to validate it
+
+An attempt to check falsification case 1 end to end did not work, and why it
+did not is worth recording.
+
+**Expiry is driven by arriving samples, not by reading the estimate.** A sample
+that has outlived its window is replaced by the next one; `get` returns what is
+stored. A lane that carried a burst and then went silent keeps its figure until
+it sends again. For the lane that is harmless — its estimate only governs what
+it puts on the wire, and it is not putting anything there. For a trace it is
+not: `queqiao_quic_controller_max_bandwidth_bytes_per_second` folds the maximum
+across lanes, so **one idle lane can report a peak the path has not sustained
+for minutes.** Reading that metric as the path's bandwidth is the same mistake
+the filter was fixed for, one level up.
+
+The attempted test also showed that a shaped path is harder to hold in an
+emulator than it looks: a load modest enough to be "sustained" fits inside a
+bucket that refills between writes, so the path never shapes it and the
+estimate rises rather than settling. Expressing case 1 end to end needs a
+runtime change to the shaping *rate*, in the way `SetLossRate` changes erasure.
+`PolicerBurstBytes` is in place; the rate knob is not.
+
+The test was removed rather than kept, because it passed — on a comparison wide
+enough that it would have passed with the filter disabled too.
+
 ## Measurement plane and inference plane
 
 Every defect in the incident, including the ones outside the controller, is the
@@ -358,7 +383,7 @@ implementation before the change lands.
 
 | # | Case | Passes if |
 | --- | --- | --- |
-| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing**; end-to-end still needs a burst-depth knob in `internal/pathsim`, which now has runtime loss control but no bucket |
+| 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing.** `internal/pathsim` now has the burst allowance (`PolicerBurstBytes`), but the end-to-end version also needs a runtime *rate* change, which it does not have — see [A limit found while trying to validate it](#a-limit-found-while-trying-to-validate-it) |
 | 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Passing end to end** — `TestTheCodeFollowsAChannelThatGetsWorseMidFlow` steps an emulated path from 2% to 45% downstream under a live flow, and the measurement the code is sized from moves from 0.034 to 0.224 while the controller's floor stays at 0.031 |
 | 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation. **Filter-level test passing** |
 | 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked |

--- a/internal/congestion/bbr_tuic_minmax.go
+++ b/internal/congestion/bbr_tuic_minmax.go
@@ -27,6 +27,16 @@ import (
 // first. The two express the same intent -- a bandwidth estimate should not
 // outlive the window in which a path change ought to be believed -- and the
 // time bound is what keeps the round bound honest when rounds stall.
+//
+// Expiry is driven by arriving samples rather than by reading the estimate: a
+// sample that has outlived its window is replaced by the next one, and get
+// returns what is stored. A lane that carried a burst and then went silent
+// therefore keeps its figure until it sends again. That is harmless for the
+// lane, whose estimate only governs what it puts on the wire, but it is not
+// harmless for a trace: queqiao_quic_controller_max_bandwidth_bytes_per_second
+// folds the maximum across lanes, so one idle lane can report a peak the path
+// has not sustained for minutes. Reading the metric as the path's bandwidth is
+// the same mistake this filter was fixed for, one level up.
 type tuicMinMax struct {
 	window uint64
 	// timeWindow is how long a sample may stand in wall time. It is derived

--- a/internal/pathsim/pathsim.go
+++ b/internal/pathsim/pathsim.go
@@ -121,6 +121,17 @@ type Config struct {
 	// so a model that under-reports it would certify a code rate that fails on
 	// the real path.
 	PolicerRefillPeriod time.Duration
+	// PolicerBurstBytes is the token bucket's depth: how much a sender may put
+	// through after an idle period before the shaping rate shows through.
+	// Zero keeps the shallow bucket that models the live path, one refill
+	// quantum plus a packet.
+	//
+	// A deep bucket is what makes a shaped path something other than a slower
+	// one. A short probe drains the bucket and measures the line rate, while
+	// sustained load measures the shaping rate, so the path has two rates and
+	// no single bandwidth -- which is the case a max filter reports wrongly by
+	// construction, and the reason a bandwidth estimate has to be able to fall.
+	PolicerBurstBytes int
 	// Seed makes the loss pattern reproducible across runs.
 	Seed int64
 	// MTU bounds a single datagram. Zero selects 1500.
@@ -334,9 +345,14 @@ func (d *direction) policeLocked(now time.Time, size int, cfg Config) bool {
 	// passed two packets per period instead of two and a half, which measured
 	// as 19 Mbit/s out of a 25 Mbit/s limiter.
 	bucket := quantum + float64(cfg.MTU)
+	if burst := float64(cfg.PolicerBurstBytes); burst > bucket {
+		bucket = burst
+	}
 	if d.tokenAt.IsZero() {
 		d.tokenAt = now
-		d.tokens = quantum
+		// A bucket a sender has not touched yet is full, which is what gives
+		// the first burst its allowance.
+		d.tokens = bucket
 	}
 	// Bounded because an idle path can leave an arbitrary gap since the last
 	// packet, and the bucket saturates after two refills anyway.

--- a/internal/pathsim/pathsim_test.go
+++ b/internal/pathsim/pathsim_test.go
@@ -709,3 +709,127 @@ func TestLossRateChangesUnderALiveFlow(t *testing.T) {
 		t.Fatalf("a rate above one erased only %.3f", all)
 	}
 }
+
+// A shaped path has two rates, not one. A short probe drains the bucket and
+// measures the line rate; sustained load measures the shaping rate. Emulating
+// only the second makes a shaped path indistinguishable from a slower one, and
+// the case a bandwidth estimate gets wrong by construction is exactly the gap
+// between them.
+func TestADeepBucketPassesABurstThenShapes(t *testing.T) {
+	server := echoServer(t)
+	const (
+		shaped = 200_000 // bytes per second
+		burst  = 120_000
+		packet = 1200
+	)
+	relay, err := New("127.0.0.1:0", server.LocalAddr().String(), Config{
+		RateBytesPerSec: shaped, PolicerRefillPeriod: 8 * time.Millisecond,
+		PolicerBurstBytes: burst, Seed: 11,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+
+	client, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	target, err := net.ResolveUDPAddr("udp", relay.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := make([]byte, packet)
+	// One burst, sent as fast as the socket takes it. A bucket this deep must
+	// let most of it through: that is what a burst allowance is.
+	const burstPackets = burst / packet
+	for range burstPackets {
+		if _, err := client.WriteTo(payload, target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if up, _ := relay.Stats(); up.PacketsIn >= burstPackets {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	afterBurst, _ := relay.Stats()
+	if afterBurst.PacketsDropped > burstPackets/4 {
+		t.Fatalf("a %d byte bucket dropped %d of a %d packet burst; it is not a burst allowance",
+			burst, afterBurst.PacketsDropped, burstPackets)
+	}
+
+	// Now sustained load well above the shaping rate. The bucket is empty, so
+	// what gets through is the rate rather than the line.
+	const sustainedPackets = 2000
+	for range sustainedPackets {
+		if _, err := client.WriteTo(payload, target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if up, _ := relay.Stats(); up.PacketsIn >= afterBurst.PacketsIn+sustainedPackets {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	end, _ := relay.Stats()
+	sustainedDropped := end.PacketsDropped - afterBurst.PacketsDropped
+	if sustainedDropped == 0 {
+		t.Fatal("sustained load far above the shaping rate was not policed at all")
+	}
+	// The two regimes have to be visibly different, which is the whole point:
+	// a path with only one rate cannot express what a max filter gets wrong.
+	burstDropRate := float64(afterBurst.PacketsDropped) / float64(burstPackets)
+	sustainedDropRate := float64(sustainedDropped) / float64(sustainedPackets)
+	t.Logf("burst dropped %.3f, sustained dropped %.3f", burstDropRate, sustainedDropRate)
+	if sustainedDropRate <= burstDropRate {
+		t.Fatalf("the bucket shaped the burst as hard as the sustained load (%.3f vs %.3f), "+
+			"so there is no burst allowance to drain", burstDropRate, sustainedDropRate)
+	}
+}
+
+// A path that asks for no burst keeps the shallow bucket that models the live
+// policer, so existing campaigns are unaffected.
+func TestNoBurstAllowanceKeepsTheShallowBucket(t *testing.T) {
+	server := echoServer(t)
+	relay, err := New("127.0.0.1:0", server.LocalAddr().String(), Config{
+		RateBytesPerSec: 200_000, PolicerRefillPeriod: 8 * time.Millisecond, Seed: 11,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer relay.Close()
+	client, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	target, err := net.ResolveUDPAddr("udp", relay.LocalAddr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := make([]byte, 1200)
+	const packets = 100
+	for range packets {
+		if _, err := client.WriteTo(payload, target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if up, _ := relay.Stats(); up.PacketsIn >= packets {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	up, _ := relay.Stats()
+	if up.PacketsDropped == 0 {
+		t.Fatal("a shallow bucket passed a 100 packet burst without policing any of it")
+	}
+}


### PR DESCRIPTION
A shaped path has **two rates**, not one. A short probe drains the bucket and
measures the line; sustained load measures the shaping rate. The emulator could
express only the second — its bucket is one refill quantum plus a packet, which
models the live path's policer — so a shaped path was indistinguishable from a
slower one, and the case a max filter gets wrong by construction had no
representation.

`Config.PolicerBurstBytes` supplies the depth. The shallow bucket remains the
default, so existing campaigns are unaffected.

```
burst dropped 0.000, sustained dropped 0.999
```

## What trying to use it showed

I set out to build the end-to-end version of falsification case 1 and could
not. Why is worth more than the test would have been.

**Expiry in the bandwidth filter is sample-driven, not read-driven.** A sample
that has outlived its window is replaced by the *next* one; `get` returns what
is stored. A lane that carried a burst and then went silent keeps its figure
until it sends again.

For the lane that is harmless — its estimate governs only what it puts on the
wire, and it is putting nothing there. For a trace it is not:
`queqiao_quic_controller_max_bandwidth_bytes_per_second` folds the **maximum
across lanes**, so one idle lane can report a peak the path has not sustained
for minutes. That is the same mistake the filter was fixed for, one level up.
Documented in the filter and in `docs/CONTROL-REDESIGN.md`.

Second finding: a shaped path is harder to hold in an emulator than it looks. A
load modest enough to count as "sustained" fits inside a bucket that refills
between writes, so the path never shapes it and the estimate *rises* instead of
settling. Expressing case 1 end to end needs a runtime change to the shaping
**rate**, the way `SetLossRate` changes erasure. The burst allowance is in
place; that knob is not.

## Why the test is not in this PR

It passed. On a comparison wide enough that it would have passed with the filter
disabled as well — I checked. A test that cannot fail for the reason it was
written is worse than no test, so it was removed rather than kept as reassurance.

## Tests

- `TestADeepBucketPassesABurstThenShapes` — the two regimes must be visibly
  different, or there is no allowance to drain.
- `TestNoBurstAllowanceKeepsTheShallowBucket` — the default still polices a
  100-packet burst, so the live-path model is unchanged.

## Checks

`go test -short ./...` green across 27 packages · full `internal/pathsim` 88 s ·
`go vet` · `gofmt` · `staticcheck -checks=all,-U1000` · gosec baseline (134
reviewed, none unreviewed) · `./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
