### PR TITLE
feat: hold the sender back when the path is carrying a queue

### DIFF
--- a/changelog.d/a-delay-bound-that-brakes-on-queue.added.md
+++ b/changelog.d/a-delay-bound-that-brakes-on-queue.added.md
@@ -1,0 +1,17 @@
+The sender is now held back when the path is carrying more than one
+bandwidth-delay product of queue. The bound is that the round trip may not
+exceed twice the path's own minimum, which is the same rule as the
+controller's 2.0 congestion-window gain expressed in the time domain, and it
+is a ratio rather than a duration on purpose: a duration would have to be
+chosen, and the choice would be a latency policy smuggled into a congestion
+controller.
+
+It matters because a deeply buffered bottleneck absorbs an overload instead
+of dropping it, so there is no loss to respond to and delay is the only
+evidence. It also catches something the window gain cannot: on an erasure
+path the window is divided by the arrival rate so that a full one arrives,
+which means what is sent can be several times the bottleneck's worth, and
+the queue is downstream of that division. The bound is therefore applied
+after the compensation rather than before it. queqiao_delay_brake_ratio
+publishes how much of the rate the bound is currently removing, so a path
+held back by its own queue can be told from one that simply measured less.

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -1002,6 +1002,7 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_quic_controller_packets_lost", s.QUICControllerPacketsLost),
 		slog.Float64("queqiao_quic_controller_min_rtt_seconds", s.QUICControllerMinRTT.Seconds()),
 		slog.Float64("queqiao_erasure_ratio_send", s.QUICErasureSend),
+		slog.Float64("queqiao_delay_brake_ratio", s.QUICDelayBrake),
 		slog.Uint64("queqiao_coded_symbols_arrived_total", s.QUICCodedSources),
 		slog.Uint64("queqiao_coded_symbols_recovered_total", s.QUICCodedRecovered),
 		slog.Uint64("queqiao_coded_symbols_lost_total", s.QUICCodedLost),

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -171,10 +171,29 @@ misclassification is catastrophic in one direction: no parity into a 50%
 erasure channel. Under a fixed budget, getting it wrong costs some goodput and
 nothing else.
 
-**The delay bound does double duty.** It protects the interactive latency this
-transport exists to preserve, and it is the brake that replaces loss-based
-backoff. A pure goodput objective would happily fill a queue, which contradicts
-the reserve the design already maintains.
+**The delay bound is the brake that replaces loss-based backoff.** A pure
+goodput objective would happily fill a queue.
+
+An earlier draft had it doing double duty, protecting interactive latency as
+well, and that was wrong in a way worth recording: it is the same mistake as
+the erasure floor serving both the pacer and the code. Interactive latency is
+an absolute quantity and is already protected by the aggregate budget's reserve
+and the lanes' priority queues. Once that job belongs elsewhere the bound has
+one job, and for that job the right frame is relative.
+
+So the bound is `RTT <= 2 x min_rtt`, which is the same statement as "the queue
+may hold at most one bandwidth-delay product" and the same rule as the
+controller's existing 2.0 congestion-window gain, in the time domain rather
+than the window domain. It is a ratio and not a duration on purpose: a duration
+would have to be chosen, and the choice would be a latency policy smuggled into
+a congestion controller.
+
+It is a measurement where the window gain is an estimate. The gain bounds the
+window using a bandwidth the sender believes in; on an erasure path that window
+is then divided by the arrival rate so a full one arrives, which means what is
+*sent* can be several times the bottleneck's worth. The queue is downstream of
+that division and does not care why the bytes were sent, so the bound is
+applied after the compensation.
 
 ### Why the classifier is redundant
 
@@ -386,10 +405,10 @@ implementation before the change lands.
 | 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing.** `internal/pathsim` now has the burst allowance (`PolicerBurstBytes`), but the end-to-end version also needs a runtime *rate* change, which it does not have — see [A limit found while trying to validate it](#a-limit-found-while-trying-to-validate-it) |
 | 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Passing end to end** — `TestTheCodeFollowsAChannelThatGetsWorseMidFlow` steps an emulated path from 2% to 45% downstream under a live flow, and the measurement the code is sized from moves from 0.034 to 0.224 while the controller's floor stays at 0.031 |
 | 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation. **Filter-level test passing** |
-| 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked |
+| 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked. **Still open, and still the one expected to fail** -- a dropper that erases at capacity without building a queue gives the bound no signal |
 | 5 | Clean path, no erasure | `r = 1`; no parity is sent, without a `minCodedLoss` constant |
 | 6 | Self-limiting claim | The climb stops; `B` does not grow without bound |
-| 7 | Bulk flow alongside interactive | Interactive latency stays inside the delay bound |
+| 7 | Bulk flow alongside interactive | Interactive latency stays inside the delay bound. **Partly covered**: `TestABulkTransferIsHeldBackByADeepQueue` shows the brake engaging on a deeply buffered bottleneck at 415 ms of queue against a 313 ms minimum, removing 24.7% of the rate. The interactive half is not covered |
 
 **Case 4 is the one expected to fail.** A dropper that erases at capacity
 without building a queue gives the delay bound no signal, and with loss removed
@@ -412,9 +431,11 @@ needed was an estimate that could fall.
    `TargetResidual` and `minCodedLoss` deleted.
 4. **Done.** The loss the path caused is exported, not only the share charged
    as congestion.
-5. Delay bound added, then loss suppression (`ErasureSender.congestive`)
-   deleted and the arrival-rate compensation moved onto the measurement.
-6. `kindReport` closes the residual loop.
+5. **Done.** Delay bound added: the round trip may not exceed twice the path's
+   own minimum.
+6. Loss suppression (`ErasureSender.congestive`) deleted and the arrival-rate
+   compensation moved onto the measurement, now that a brake exists.
+7. `kindReport` closes the residual loop.
 
 Steps 1-5 have no wire impact. Step 6 is additive and forward-compatible.
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -122,6 +122,10 @@ Prometheus `/metrics` names. They cover:
   endpoint sends into, published as `queqiao_erasure_ratio{direction="send"}`
   and as `queqiao_erasure_ratio_send` in the log. A gateway's send direction is
   its downstream. This is what a code is sized from;
+- how much of the sending rate the delay bound is removing, as
+  `queqiao_delay_brake_ratio`. It is non-zero only while the path is carrying
+  more than one bandwidth-delay product of queue, and it separates a rate held
+  back by the path's own queue from one that simply measured less;
 - the controller's erasure floor, which is the pacing-side view of the same
   channel and is not a smaller version of the figure above. It is biased low on
   purpose so that pacing errs towards slowing down, and it is a lower envelope

--- a/internal/congestion/delaybound_test.go
+++ b/internal/congestion/delaybound_test.go
@@ -1,0 +1,145 @@
+package congestion
+
+import (
+	"testing"
+	"time"
+
+	quiccongestion "github.com/apernet/quic-go/congestion"
+	"github.com/apernet/quic-go/monotime"
+)
+
+// fixedRTT is a round-trip provider a test can move under a live sender.
+type fixedRTT struct{ min, smoothed time.Duration }
+
+func (f *fixedRTT) MinRTT() time.Duration        { return f.min }
+func (f *fixedRTT) LatestRTT() time.Duration     { return f.smoothed }
+func (f *fixedRTT) SmoothedRTT() time.Duration   { return f.smoothed }
+func (f *fixedRTT) MeanDeviation() time.Duration { return 0 }
+func (f *fixedRTT) MaxAckDelay() time.Duration   { return 0 }
+func (f *fixedRTT) PTO(bool) time.Duration       { return f.smoothed }
+func (f *fixedRTT) UpdateRTT(_, _ time.Duration) {}
+func (f *fixedRTT) SetMaxAckDelay(time.Duration) {}
+func (f *fixedRTT) SetInitialRTT(time.Duration)  {}
+
+var _ quiccongestion.RTTStatsProvider = (*fixedRTT)(nil)
+
+// senderAtRTT builds a sender whose inner controller has established minRTT and
+// whose provider reports the given smoothed round trip.
+func senderAtRTT(t *testing.T, minRTT, smoothed time.Duration) *ErasureSender {
+	t.Helper()
+	e := NewErasureSender(1200)
+	e.inner.minRTT = minRTT
+	e.SetRTTStatsProvider(&fixedRTT{min: minRTT, smoothed: smoothed})
+	return e
+}
+
+// The bound is that the round trip may not exceed twice the path's own
+// minimum, which is the same statement as "the queue may hold at most one
+// bandwidth-delay product". Below that the sender is not touched at all: a
+// brake that engages before the bound would make the bound a target.
+func TestTheDelayBoundIsSilentBelowOneRoundTripOfQueue(t *testing.T) {
+	const minRTT = 200 * time.Millisecond
+	for _, smoothed := range []time.Duration{
+		minRTT,                        // no queue
+		minRTT + 50*time.Millisecond,  // a quarter
+		minRTT + 199*time.Millisecond, // just inside
+		2 * minRTT,                    // exactly at the bound
+	} {
+		e := senderAtRTT(t, minRTT, smoothed)
+		if got := e.delayBounded(1000); got != 1000 {
+			t.Errorf("smoothed %v (queue %v) scaled the rate to %.1f, want it untouched",
+				smoothed, smoothed-minRTT, got)
+		}
+		if brake := e.Telemetry().DelayBrake; brake != 0 {
+			t.Errorf("smoothed %v published a brake of %.4f with no queue past the bound", smoothed, brake)
+		}
+	}
+}
+
+// Past the bound the response is proportional to the overshoot rather than to
+// the fact of it: at one round trip of queue the factor is one, and it falls
+// continuously from there.
+func TestTheDelayBoundScalesWithTheOvershoot(t *testing.T) {
+	const minRTT = 200 * time.Millisecond
+	for _, test := range []struct {
+		queue time.Duration
+		want  float64
+	}{
+		{queue: 2 * minRTT, want: 500},  // twice the bound, half the rate
+		{queue: 4 * minRTT, want: 250},  // four times, a quarter
+		{queue: 10 * minRTT, want: 100}, // ten times, a tenth
+	} {
+		e := senderAtRTT(t, minRTT, minRTT+test.queue)
+		got := e.delayBounded(1000)
+		if got < test.want*0.99 || got > test.want*1.01 {
+			t.Errorf("queue %v scaled 1000 to %.1f, want about %.1f", test.queue, got, test.want)
+		}
+		brake := e.Telemetry().DelayBrake
+		if brake <= 0 || brake >= 1 {
+			t.Errorf("queue %v published a brake of %.4f, want a share in (0,1)", test.queue, brake)
+		}
+	}
+	// And it is monotone: more queue never means less braking.
+	previous := 1e9
+	for multiple := 1; multiple <= 8; multiple++ {
+		e := senderAtRTT(t, minRTT, minRTT+time.Duration(multiple)*minRTT)
+		got := e.delayBounded(1000)
+		if got > previous {
+			t.Fatalf("queue of %d round trips gave %.1f, more than the %.1f at one less",
+				multiple, got, previous)
+		}
+		previous = got
+	}
+}
+
+// A path nobody has measured has no bound to apply, and a sender with no
+// provider must behave exactly as it did before the bound existed.
+func TestTheDelayBoundNeedsAMeasuredPath(t *testing.T) {
+	e := NewErasureSender(1200)
+	if got := e.delayBounded(1000); got != 1000 {
+		t.Fatalf("a sender with no round-trip provider scaled the rate to %.1f", got)
+	}
+	e.inner.minRTT = 0
+	e.SetRTTStatsProvider(&fixedRTT{min: 0, smoothed: time.Second})
+	if got := e.delayBounded(1000); got != 1000 {
+		t.Fatalf("a sender with no established minimum scaled the rate to %.1f", got)
+	}
+}
+
+// The bound is applied after the erasure compensation, because the queue holds
+// what was sent rather than what arrived.
+//
+// This is the case the window gain cannot cover. On an erasure path the
+// compensation multiplies the window so that a full one *arrives*, which means
+// what is put on the wire is larger by the same factor -- and the bottleneck
+// queue is downstream of that multiplication and does not care why the bytes
+// were sent. Measuring the three points in order is what shows the bound
+// catching the compensation rather than being applied before it.
+func TestTheDelayBoundAppliesToWhatIsSentNotWhatArrives(t *testing.T) {
+	const minRTT = 200 * time.Millisecond
+	at := func(arrival float64, smoothed time.Duration) float64 {
+		e := senderAtRTT(t, minRTT, smoothed)
+		e.inner.estimator.maxFilter.updateMax(1, monotime.Now(), 1_000_000)
+		e.arrival.Store(uint64(arrival * partsPerMillion))
+		return float64(e.bandwidth())
+	}
+
+	clean := at(1, minRTT)
+	if clean <= 0 {
+		t.Fatal("a clean path with a measured bandwidth reported none")
+	}
+	// Half the packets arrive, so twice as many must be sent for a full window
+	// to land. That is the compensation, and it is deliberate.
+	compensated := at(0.5, minRTT)
+	if ratio := compensated / clean; ratio < 1.9 || ratio > 2.1 {
+		t.Fatalf("erasure compensation scaled the rate by %.2f, want about 2", ratio)
+	}
+	// Two round trips of queue halves it back. Had the bound been applied
+	// before the compensation, the compensation would have undone it and this
+	// would still read twice the clean rate.
+	braked := at(0.5, minRTT+2*minRTT)
+	if ratio := braked / clean; ratio < 0.9 || ratio > 1.1 {
+		t.Fatalf("with two round trips of queue the rate is %.2fx the clean one; the erasure "+
+			"compensation is escaping the delay bound", ratio)
+	}
+}

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -3,6 +3,7 @@ package congestion
 import (
 	"sort"
 	"sync/atomic"
+	"time"
 
 	quiccongestion "github.com/apernet/quic-go/congestion"
 	"github.com/apernet/quic-go/monotime"
@@ -82,6 +83,15 @@ type ErasureSender struct {
 	// it is published because a floor is not a substitute for it: on the live
 	// path the floor read a seventh of what the channel was doing.
 	erasure atomic.Uint64
+
+	// rttStats is the connection's round-trip measurements, kept here as well
+	// as on the inner controller because the delay bound is this sender's.
+	rttStats quiccongestion.RTTStatsProvider
+
+	// delayBrake is how much the delay bound is currently removing from the
+	// rate, in parts per million, so a trace can tell a path being held back
+	// by its own queue from one that simply measured less.
+	delayBrake atomic.Uint64
 
 	// arrival is the last computed arrival rate, published for the pacer and
 	// the congestion window, which run outside the callback that computes it.
@@ -204,7 +214,9 @@ func (e *ErasureSender) bandwidth() quiccongestion.ByteCount {
 	if share := float64(e.share.Load()); share > 0 && share < delivered {
 		delivered = share
 	}
-	return quiccongestion.ByteCount(delivered / e.arrivalRate())
+	// The delay bound is applied after the erasure compensation rather than
+	// before it, because the queue holds what was sent and not what arrived.
+	return quiccongestion.ByteCount(e.delayBounded(delivered / e.arrivalRate()))
 }
 
 func (e *ErasureSender) arrivalRate() float64 {
@@ -219,7 +231,62 @@ func (e *ErasureSender) arrivalRate() float64 {
 }
 
 func (e *ErasureSender) SetRTTStatsProvider(provider quiccongestion.RTTStatsProvider) {
+	e.rttStats = provider
 	e.inner.SetRTTStatsProvider(provider)
+}
+
+// queueDelay is how much delay the path is carrying beyond its own minimum,
+// which at the bottleneck rate is the data sitting in its queue.
+//
+// The smoothed round trip is used rather than the latest because a single
+// sample carries reordering and one ACK's scheduling; a brake that fires on
+// those would back off for a jittery path rather than a full one.
+func (e *ErasureSender) queueDelay() (queue, minRTT time.Duration) {
+	minRTT = e.inner.minRoundTrip()
+	if minRTT <= 0 || e.rttStats == nil {
+		return 0, minRTT
+	}
+	smoothed := e.rttStats.SmoothedRTT()
+	if smoothed <= minRTT {
+		return 0, minRTT
+	}
+	return smoothed - minRTT, minRTT
+}
+
+// delayBounded scales a rate down while the path is holding more than one
+// bandwidth-delay product of queue.
+//
+// The bound is that the round trip may not exceed twice the path's own
+// minimum, which is the same statement as "the queue may hold at most one
+// bandwidth-delay product" and the same rule as the controller's 2.0
+// congestion-window gain, in the time domain rather than the window domain.
+// It is a ratio rather than a duration on purpose: a duration would have to be
+// chosen, and any choice is a latency policy smuggled into a congestion
+// controller. Interactive latency is protected by the aggregate budget's
+// reserve and the lanes' priority queues, which is where an absolute guarantee
+// belongs; this bound exists only to stop the path being overdriven.
+//
+// The scaling is continuous rather than a step. At exactly one round trip of
+// queue the factor is one, so a sender that has just reached the bound is not
+// punished for arriving there; past it the factor falls as the queue grows,
+// which is what makes the response proportional to the overshoot rather than
+// to the fact of it.
+//
+// This is a measurement where the window gain is an estimate. The gain bounds
+// the window using a bandwidth this sender believes in, and on an erasure path
+// that window is divided by the arrival rate so that what arrives is a full
+// one -- which means what is *sent* can be several times the bottleneck's
+// worth. The queue is downstream of that division and does not care why the
+// bytes were sent.
+func (e *ErasureSender) delayBounded(rate float64) float64 {
+	queue, minRTT := e.queueDelay()
+	if queue <= minRTT || minRTT <= 0 {
+		e.delayBrake.Store(0)
+		return rate
+	}
+	factor := float64(minRTT) / float64(queue)
+	e.delayBrake.Store(uint64((1 - factor) * partsPerMillion))
+	return rate * factor
 }
 
 func (e *ErasureSender) TimeUntilSend(quiccongestion.ByteCount) monotime.Time {
@@ -468,6 +535,10 @@ func (e *ErasureSender) Telemetry() ControllerTelemetry {
 	t.PacketsLostSuppressed = suppressed
 	t.PacketsLostObserved = t.PacketsLost + suppressed
 	t.Erasure = float64(e.erasure.Load()) / partsPerMillion
+	// Recomputed rather than read from the cached value, so a trace taken while
+	// nothing is sending still reflects the path rather than the last send.
+	e.delayBounded(1)
+	t.DelayBrake = float64(e.delayBrake.Load()) / partsPerMillion
 	arrival := e.arrivalRate()
 	t.ErasureFloor = 1 - arrival
 	t.PacingRate = uint64(float64(t.PacingRate) / arrival)

--- a/internal/congestion/telemetry.go
+++ b/internal/congestion/telemetry.go
@@ -54,6 +54,14 @@ type ControllerTelemetry struct {
 	PacketsLostSuppressed uint64
 	MinRTT                time.Duration
 	InRecovery            bool
+	// DelayBrake is the share of the sending rate the delay bound is currently
+	// removing, in [0,1). It is non-zero only while the path is carrying more
+	// than one bandwidth-delay product of queue.
+	//
+	// It is published because a rate that has been held back by the path's own
+	// queue and a rate that simply measured less look identical otherwise, and
+	// the two call for opposite responses.
+	DelayBrake float64
 	// Erasure is the share of packets the path is measured to be erasing on
 	// the direction this controller sends into, pooled across the lanes that
 	// share it. It is what a code is sized from.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -304,6 +304,7 @@ type Snapshot struct {
 	QUICControllerBytesLost, QUICControllerPacketsLost            uint64
 	QUICControllerMinRTT                                          time.Duration
 	QUICErasureSend, QUICControllerErasureFloor                   float64
+	QUICDelayBrake                                                float64
 	QUICControllerInRecovery                                      bool
 	// QUICObservationsExpired counts flow telemetry entries dropped because
 	// they stopped being refreshed. See quicObservationsExpired.
@@ -340,6 +341,7 @@ type QUICObservation struct {
 	ControllerBytesInFlight    uint64
 	ControllerMinRTT           time.Duration
 	ControllerErasure          float64
+	ControllerDelayBrake       float64
 	ControllerErasureFloor     float64
 	ControllerInRecovery       bool
 }
@@ -678,7 +680,7 @@ func (r *Registry) Snapshot() Snapshot {
 	var controllerLatestAckRate, controllerLatestSendRate uint64
 	var controllerRound uint64
 	var controllerMinRTT time.Duration
-	var controllerErasure, controllerErasureFloor float64
+	var controllerErasure, controllerErasureFloor, controllerDelayBrake float64
 	var controllerRecovery bool
 	for key, entry := range r.quicFlows {
 		// An entry nobody refreshes is not a measurement of anything. Because
@@ -741,6 +743,9 @@ func (r *Registry) Snapshot() Snapshot {
 			if o.ControllerErasure > controllerErasure {
 				controllerErasure = o.ControllerErasure
 			}
+			if o.ControllerDelayBrake > controllerDelayBrake {
+				controllerDelayBrake = o.ControllerDelayBrake
+			}
 			if o.ControllerErasureFloor > controllerErasureFloor {
 				controllerErasureFloor = o.ControllerErasureFloor
 			}
@@ -786,6 +791,7 @@ func (r *Registry) Snapshot() Snapshot {
 	s.QUICControllerPacketsLost = counters.ControllerPacketsLost
 	s.QUICControllerMinRTT = controllerMinRTT
 	s.QUICErasureSend = controllerErasure
+	s.QUICDelayBrake = controllerDelayBrake
 	s.QUICControllerErasureFloor = controllerErasureFloor
 	s.QUICControllerInRecovery = controllerRecovery
 	return s
@@ -888,6 +894,11 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "queqiao_coded_symbols_total{outcome=\"lost\"} %d\n", s.QUICCodedLost)
 	fmt.Fprintf(w, "queqiao_erasure_ratio{direction=\"receive\"} %.9f\n", s.ReceiveErasure())
 	fmt.Fprintf(w, "queqiao_erasure_residual_ratio{direction=\"receive\"} %.9f\n", s.ReceiveResidual())
+	// How much of the sending rate the delay bound is removing. Non-zero means
+	// the path is carrying more than one bandwidth-delay product of queue and
+	// is being held back by it, which is a different condition from a path that
+	// simply measured less.
+	fmt.Fprintf(w, "queqiao_delay_brake_ratio %.9f\n", s.QUICDelayBrake)
 	// The floor is the conservative, pacing-side view of the same channel:
 	// biased low on purpose, and a lower envelope for a connection's lifetime.
 	// It is not a smaller version of the figure above and a code sized from it

--- a/internal/pep/codedlane_test.go
+++ b/internal/pep/codedlane_test.go
@@ -500,3 +500,75 @@ func measuredErasureAndFloor(t *testing.T) (erasure, floor float64) {
 	}
 	return erasure, floor
 }
+
+// The delay bound, against a real queue rather than a supplied round trip.
+//
+// A deeply buffered bottleneck is the case a loss-based controller cannot see
+// at all: the queue absorbs the overload instead of dropping it, so there is no
+// loss signal and the only evidence is the delay. The bound is that the round
+// trip may not exceed twice the path's own minimum, which is one
+// bandwidth-delay product of queue.
+func TestABulkTransferIsHeldBackByADeepQueue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("brings up QUIC across an emulated 300 ms path")
+	}
+	requireStableImpairmentClock(t)
+	path := pathsim.Config{
+		OneWayDelay:     150 * time.Millisecond,
+		RateBytesPerSec: 250_000,
+		// A bandwidth-delay product here is 75 KB. Ten times that is a router
+		// with far more buffer than it needs, which is the ordinary case and
+		// the one that produces delay instead of loss.
+		QueueBytes: 750_000,
+		Seed:       41,
+	}
+	socks, destination := codedPair(t, false, &path)
+	conn := socksDial(t, socks, destination, erasureChannelBudget(180*time.Second))
+	defer conn.Close()
+
+	// Enough bulk to fill the buffer and keep it full.
+	payload := make([]byte, 512*1024)
+	rand.New(rand.NewSource(17)).Read(payload)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 3; i++ {
+			if _, err := conn.Write(payload); err != nil {
+				return
+			}
+		}
+	}()
+	got := make([]byte, len(payload)*3)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("bulk across a deeply buffered path: %v", err)
+	}
+	<-done
+
+	s := lastClient.Metrics().Snapshot()
+	minRTT, smoothed := s.QUICControllerMinRTT, s.QUICSmoothedRTT
+	t.Logf("min_rtt=%v smoothed=%v queue=%v brake=%.4f",
+		minRTT.Round(time.Millisecond), smoothed.Round(time.Millisecond),
+		(smoothed - minRTT).Round(time.Millisecond), s.QUICDelayBrake)
+
+	if minRTT <= 0 {
+		t.Fatal("the path was never measured, so there was no bound to apply")
+	}
+	// The contract: past one round trip of queue the brake must be engaged.
+	// Below it the bound is silent by design, and a run that never filled the
+	// buffer has nothing to say -- but it must not be silent above it.
+	queue := smoothed - minRTT
+	if queue <= minRTT {
+		t.Skipf("the buffer never filled past the bound (queue %v against a %v minimum), "+
+			"so this run cannot test the brake", queue, minRTT)
+	}
+	if s.QUICDelayBrake == 0 {
+		t.Fatalf("the path is carrying %v of queue against a %v minimum and the brake reads "+
+			"zero, so nothing is holding the sender back", queue, minRTT)
+	}
+	// And the brake has to match the overshoot rather than being a flag.
+	want := 1 - float64(minRTT)/float64(queue)
+	if s.QUICDelayBrake < want*0.5 || s.QUICDelayBrake > want*1.5+0.05 {
+		t.Fatalf("brake reads %.4f against an overshoot implying about %.4f",
+			s.QUICDelayBrake, want)
+	}
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -696,6 +696,9 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 			if controller.Erasure > observation.ControllerErasure {
 				observation.ControllerErasure = controller.Erasure
 			}
+			if controller.DelayBrake > observation.ControllerDelayBrake {
+				observation.ControllerDelayBrake = controller.DelayBrake
+			}
 			if controller.ErasureFloor > observation.ControllerErasureFloor {
 				observation.ControllerErasureFloor = controller.ErasureFloor
 			}


### PR DESCRIPTION
Removing loss as a congestion signal needs something to brake with. This is it:
**the round trip may not exceed twice the path's own minimum.**

## Why a ratio and not a duration

`min_rtt + 50ms` needs the 50 defended, and it can't be — it would be picked
because it sounds like a latency people notice. `2 × min_rtt` is the same
statement as *"the queue may hold at most one bandwidth-delay product"*, which
is not a new constant at all: it is the controller's existing
`tuicCwndGain = 2.0`, in the time domain rather than the window domain.

An earlier draft of the design had this bound protecting interactive latency as
well as braking. That was the same mistake as the erasure floor serving both the
pacer and the code — **one mechanism carrying two jobs with different natural
frames.** Interactive latency is absolute and is already protected by the
aggregate budget's reserve and the lanes' priority queues. Once that job belongs
elsewhere, the bound has one job, and for that job relative is right.

## What the window gain cannot catch

The gain bounds the window from a bandwidth the sender *believes in*. On an
erasure path that window is then divided by the arrival rate so a full one
arrives — which means what is **sent** can be several times the bottleneck's
worth. The queue is downstream of that division and does not care why the bytes
were sent.

So the bound is applied **after** the compensation.
`TestTheDelayBoundAppliesToWhatIsSentNotWhatArrives` holds that ordering by
measuring three points — clean, compensated at half arrival, and compensated
with two round trips of queue — where the third must come back to the first.
Applied before the compensation, the compensation would simply undo it.

## Continuous, not a step

At exactly one round trip of queue the factor is 1, so a sender that has just
reached the bound is not punished for arriving there; past it the rate falls as
the queue grows. A step would make the bound a cliff and the sender oscillate
across it.

## End to end

On an emulated bottleneck with **ten times its bandwidth-delay product of
buffer** — the case that produces delay instead of loss, which a loss-based
controller cannot see at all:

```
min_rtt=312ms  smoothed=727ms  queue=415ms  brake=0.2474
```

Queue 415 ms against a 313 ms bound; the brake removes 24.7%, matching the
overshoot rather than being a flag.

## Verified by disabling it

With the factor forced to 1, the two behavioural unit tests and the end-to-end
one fail. The two that assert the bound is **silent below its threshold** still
pass — which is what they are for.

## Observability

`queqiao_delay_brake_ratio` publishes how much is being removed. A rate held
back by the path's own queue and a rate that simply measured less are
indistinguishable otherwise, and they call for opposite responses.

## Scope

This does **not** remove loss suppression. That is the next step and it depends
on this one existing — deleting `ErasureSender.congestive` hands every erasure
to BBR as congestion, which on a 42% channel is the collapse to 0.39 Mbit/s the
controller exists to avoid.

Falsification case 4 (shallow dropper, no queue) remains open and remains the
one expected to fail: a path that erases at capacity without building a queue
gives this bound no signal at all.

## Checks

`go test -short ./...` green across 27 packages · full `internal/pep` 136 s and
`internal/congestion` · `go test -race` on `internal/congestion` · `go vet` ·
`gofmt` · `staticcheck -checks=all,-U1000` · gosec baseline (134 reviewed, none
unreviewed) · `./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
