### PR TITLE
change: stop reading loss as congestion

### DIFF
--- a/changelog.d/loss-is-no-longer-a-congestion-signal.changed.md
+++ b/changelog.d/loss-is-no-longer-a-congestion-signal.changed.md
@@ -1,0 +1,22 @@
+Loss is no longer a congestion signal. The controller previously separated
+erasure from congestion statistically and forwarded only the share the
+channel could not explain, so that a path erasing packets independently of
+the sending rate would not be read as an overloaded one. That separation is
+gone: it was a statistical answer to a question the delivery-versus-rate
+curve answers directly, and it was least reliable exactly when loss was
+worst, because heavy erasure is bursty and the burst test then refused to
+call it erasure at all. The brake is the delay bound instead.
+
+Every loss now reaches the congestion controller, which matters for a reason
+unrelated to congestion: its in-flight accounting is what was sent less what
+was acknowledged and what was lost, so a controller told about only a
+fraction of the losses believes the pipe is fuller than it is. The erasure
+compensation rides on the measured erasure rather than on a floor biased low
+for pacing, and waits for a measured round trip before engaging, because
+that is when the delay bound can bound it.
+
+queqiao_quic_controller_erasure_floor_ratio and
+queqiao_quic_loss_suppressed_packets_total are removed. There is no floor
+any more, and nothing is withheld from the controller, so neither figure can
+be produced. queqiao_erasure_ratio{direction="send"} is the measurement that
+replaced the first.

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -981,7 +981,6 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_quic_packets_sent", s.QUICPacketsSent),
 		slog.Uint64("queqiao_quic_packets_received", s.QUICPacketsReceived),
 		slog.Uint64("queqiao_quic_loss_observed_packets_total", s.QUICLossObservedPackets),
-		slog.Uint64("queqiao_quic_loss_suppressed_packets_total", s.QUICLossSuppressedPackets),
 		slog.Uint64("queqiao_quic_observations_expired_total", s.QUICObservationsExpired),
 		slog.String("queqiao_quic_controller_kind", s.QUICControllerKind),
 		slog.Uint64("queqiao_quic_controller_mode", uint64(s.QUICControllerMode)),
@@ -1008,7 +1007,6 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_coded_symbols_lost_total", s.QUICCodedLost),
 		slog.Float64("queqiao_erasure_ratio_receive", s.ReceiveErasure()),
 		slog.Float64("queqiao_erasure_residual_ratio_receive", s.ReceiveResidual()),
-		slog.Float64("queqiao_quic_controller_erasure_floor_ratio", s.QUICControllerErasureFloor),
 		slog.Bool("queqiao_quic_controller_in_recovery", s.QUICControllerInRecovery),
 		// A refused lane join is a peer's flow about to fail. Flat names,
 		// one per reason, matching the labelled /metrics series.

--- a/cmd/queqiaod/main_test.go
+++ b/cmd/queqiaod/main_test.go
@@ -172,7 +172,7 @@ func TestPerformanceSnapshotIsMachineReadable(t *testing.T) {
 	registry.FlowStarted()
 	registry.ObserveQUIC(1, metrics.QUICObservation{
 		Lanes: 1, SmoothedRTT: 210 * time.Millisecond, ControllerKind: "bbr-tuic",
-		ControllerPacingRate: 9999, ControllerErasureFloor: 0.025,
+		ControllerPacingRate: 9999,
 	})
 	registry.AddQUICConnectionCounters(metrics.QUICConnectionCounters{
 		BytesSent: 1234, BytesReceived: 5678,
@@ -189,7 +189,6 @@ func TestPerformanceSnapshotIsMachineReadable(t *testing.T) {
 		"queqiao_quic_smoothed_rtt_seconds": 0.21, "queqiao_quic_bytes_received": float64(5678),
 		"queqiao_quic_packets_sent": float64(123), "queqiao_quic_packets_received": float64(119),
 		"queqiao_quic_controller_kind": "bbr-tuic", "queqiao_quic_controller_pacing_rate_bytes_per_second": float64(9999),
-		"queqiao_quic_controller_erasure_floor_ratio": 0.025,
 	} {
 		if record[key] != want {
 			t.Fatalf("%s = %#v, want %#v in %#v", key, record[key], want, record)

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -1,8 +1,9 @@
 # Control redesign: delay-bounded goodput
 
 > [!IMPORTANT]
-> **Status:** Partly implemented. The coding half and the bandwidth estimate
-> have landed; the delay bound and the receiver report have not. Nothing here
+> **Status:** Implemented except for the receiver report. The classifier is
+> gone, the estimate can fall, the code is sized from the measurement, and the
+> delay bound is the brake. Nothing here
 > is validated on a real path yet -- see [Falsification](#falsification).
 >
 > **Wire impact:** None for the controller and coding changes. The receiver
@@ -311,6 +312,31 @@ rejects **inferring** outbound erasure from inbound loss. A peer **reporting**
 what it measured on your outbound direction is not inference; it is a direct
 measurement relayed, and the reasoning does not extend to it.
 
+## What removing the classifier actually cost
+
+The classifier was protecting one thing that the delay bound does not, and the
+existing test suite caught it rather than a review.
+
+A first flight can overrun a clean path's queue before the controller has found
+its bottleneck. Those drops arrive in runs and are congestion, not erasure.
+With the compensation riding on the raw measurement, the sender compensates for
+its own queue drops and sends twice as fast into a queue that is already
+overflowing — the exact positive feedback the classifier existed to prevent.
+
+The delay bound would stop it, except that at that moment there is no minimum
+round trip to bound against, so the brake is inert. The two safeguards did not
+overlap the way the sequencing assumed.
+
+The resolution is a coupling rather than a restored classifier: **compensation
+waits for a measured minimum round trip**, which is exactly when the brake can
+act. It makes no judgement about what kind of loss it is seeing. Before that
+point the sender is plain BBR that ignores loss — it neither compensates nor
+collapses.
+
+`TestClusteredStartupLossDoesNotBecomeAnErasureFloor` predates this work and now
+holds the new arrangement unchanged, which is the strongest evidence available
+that the property survived the mechanism.
+
 ## A limit found while trying to validate it
 
 An attempt to check falsification case 1 end to end did not work, and why it
@@ -433,8 +459,9 @@ needed was an estimate that could fall.
    as congestion.
 5. **Done.** Delay bound added: the round trip may not exceed twice the path's
    own minimum.
-6. Loss suppression (`ErasureSender.congestive`) deleted and the arrival-rate
-   compensation moved onto the measurement, now that a brake exists.
+6. **Done.** Loss suppression deleted and the arrival-rate compensation moved
+   onto the measurement, gated on a measured round trip so it cannot run ahead
+   of the brake that bounds it.
 7. `kindReport` closes the residual loop.
 
 Steps 1-5 have no wire impact. Step 6 is additive and forward-compatible.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -103,14 +103,13 @@ Prometheus `/metrics` names. They cover:
 
 - active/started/completed/failed flows and transferred bytes;
 - latest, smoothed, and controller-minimum RTT;
-- QUIC sent and received bytes and packets, and three loss counters that must
-  be read together: `queqiao_quic_loss_observed_packets_total` is every loss
-  the sender detected, `queqiao_quic_loss_suppressed_packets_total` is the part
-  withheld from the congestion controller as erasure, and
-  `queqiao_quic_controller_packets_lost` is the part charged as congestion.
-  Observed is the sum of the other two, and it is the one to divide by
-  `queqiao_quic_packets_sent` for a loss rate -- on an erasure path the charged
-  figure alone understates the channel by most of its loss;
+- QUIC sent and received bytes and packets, and two loss counters that are now
+  the same number derived two ways: `queqiao_quic_loss_observed_packets_total`
+  is every loss the sender detected, and `queqiao_quic_controller_packets_lost`
+  is what the congestion controller was charged. Nothing is withheld from the
+  controller any more, so they agree; they are both kept so that a divergence
+  is visible rather than silent. Divide either by `queqiao_quic_packets_sent`
+  for a loss rate;
 - delivery, ACK, send, pacing, and maximum-bandwidth estimates;
 - congestion window, bytes in flight, controller round/mode/recovery;
 - lanes, failures, replacements, reinjections, fallbacks, and timeouts;
@@ -126,12 +125,6 @@ Prometheus `/metrics` names. They cover:
   `queqiao_delay_brake_ratio`. It is non-zero only while the path is carrying
   more than one bandwidth-delay product of queue, and it separates a rate held
   back by the path's own queue from one that simply measured less;
-- the controller's erasure floor, which is the pacing-side view of the same
-  channel and is not a smaller version of the figure above. It is biased low on
-  purpose so that pacing errs towards slowing down, and it is a lower envelope
-  for a connection's lifetime, so it keeps what a clean window established while
-  the measurement follows the path. On one live incident the two read 1.76% and
-  19.9%; and
 - the receive direction, measured by this endpoint's decoders rather than
   inferred from acknowledgements: `queqiao_coded_symbols_total` split by
   outcome (`arrived`, `recovered`, `lost`), with

--- a/internal/coded/coded.go
+++ b/internal/coded/coded.go
@@ -752,20 +752,16 @@ func (p *Path) channel() lossmodel.Snapshot {
 		return lossmodel.Snapshot{BurstFactor: 1, ArrivalAfterLoss: 1}
 	}
 	state := p.cfg.Path.Current()
-	// The measured erasure, not the controller's floor. The floor is biased
-	// low on purpose so that pacing errs towards slowing down, and a code
-	// sized from it is sized for a fraction of what the channel is doing: the
-	// incident in docs/CONTROL-REDESIGN.md sized parity for 1.76% against a
-	// measured 19.9%. The floor also arrives here as a scalar, and building a
-	// snapshot whose every field is that one number is what killed Choose's
-	// own fallback -- it checks Loss when Floor is zero, and both were the
-	// same zero.
+	// The measured erasure. There is no longer a separate floor to choose
+	// wrongly between: the classifier that produced one is gone, and this is
+	// what the path is doing. Floor is set to the same figure because the
+	// snapshot type still carries the field for the estimator's own use.
 	burst := state.BurstFactor
 	if burst < 1 {
 		burst = 1
 	}
 	return lossmodel.Snapshot{
-		Loss: state.Erasure, Floor: state.Floor, Recent: state.Erasure,
+		Loss: state.Erasure, Floor: state.Erasure, Recent: state.Erasure,
 		BurstFactor: burst, ArrivalAfterLoss: 1 - state.Erasure,
 		Samples: state.ObservedSamples, Decided: uint64(state.ObservedSamples),
 	}

--- a/internal/coded/coded_test.go
+++ b/internal/coded/coded_test.go
@@ -109,7 +109,7 @@ func (p *lossyPipe) stats() (sent, lost int) {
 // connection.
 func measuredPath(floor float64) *pathmodel.PathModel {
 	m := pathmodel.NewPathModel()
-	m.Report(1, pathmodel.Observation{Floor: floor, FloorSamples: 5000, Erasure: floor, BurstFactor: 1, ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 0})
+	m.Report(1, pathmodel.Observation{Erasure: floor, BurstFactor: 1, ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 0})
 	return m
 }
 
@@ -460,7 +460,6 @@ func TestTheCodeIsSizedFromTheMeasurementNotTheFloor(t *testing.T) {
 	const measured, conservativeFloor = 0.199, 0.0176
 	m := pathmodel.NewPathModel()
 	m.Report(1, pathmodel.Observation{
-		Floor: conservativeFloor, FloorSamples: 5000,
 		Erasure: measured, BurstFactor: 1,
 		ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 250 * time.Millisecond,
 	})
@@ -578,7 +577,7 @@ func TestParityCostsACodeRateAndNotAByteRate(t *testing.T) {
 	send := func(erasure float64) (wireBytes, payloadFrames int) {
 		m := pathmodel.NewPathModel()
 		m.Report(1, pathmodel.Observation{
-			Floor: erasure, FloorSamples: 5000, Erasure: erasure, BurstFactor: 1,
+			Erasure: erasure, BurstFactor: 1,
 			ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 200 * time.Millisecond,
 		})
 		pa, _ := newBudgetedPipes(budget)

--- a/internal/congestion/bbr_tuic.go
+++ b/internal/congestion/bbr_tuic.go
@@ -19,9 +19,21 @@ import (
 // per packet. ACK receive timestamps are used when the QUIC fork supplies them
 // and the congestion-event time otherwise.
 type TUICBBRSender struct {
-	rttStats        quiccongestion.RTTStatsProvider
-	maxDatagramSize quiccongestion.ByteCount
-	pacer           *pacer
+	rttStats quiccongestion.RTTStatsProvider
+	// lossIsCongestion decides whether a loss may put this sender into
+	// recovery. It is true for a sender used on its own, which is TUIC's
+	// behaviour and what the benchmark reference must keep. ErasureSender
+	// clears it: on a path that erases packets for reasons unrelated to the
+	// sending rate, a controller that reads every loss as congestion gives the
+	// path away, and the brake is the delay bound instead.
+	//
+	// Losses still reach this method either way. They have to: bytesInFlight
+	// below is priorInFlight less what was acknowledged and what was lost, so
+	// a sender that is not told about a loss believes the pipe is fuller than
+	// it is and throttles itself for a packet that is already gone.
+	lossIsCongestion bool
+	maxDatagramSize  quiccongestion.ByteCount
+	pacer            *pacer
 
 	mode                 tuicBbrMode
 	pacingGain           float64
@@ -143,16 +155,19 @@ func NewTUICBBRSender(initialPacketSize quiccongestion.ByteCount) *TUICBBRSender
 		// TUIC uses a 2.0 congestion-window gain in STARTUP.  The pacing gain
 		// remains highGain; applying that factor to cwnd as well overfills the
 		// initial flight before a delivery model exists.
-		cwndGain:      tuicCwndGain,
-		highCwndGain:  tuicCwndGain,
-		maxAckedPN:    quiccongestion.PacketNumber(-1),
-		maxSentPN:     quiccongestion.PacketNumber(-1),
-		endRecoveryPN: quiccongestion.PacketNumber(-1),
-		roundEndPN:    quiccongestion.PacketNumber(-1),
-		estimator:     newTUICBandwidthEstimator(),
-		ackAgg:        tuicAckAggregation{maxAckHeight: newTUICMinMax()},
-		randomState:   uint64(monotime.Now()) ^ uint64(initialPacketSize)<<17,
-		telemetry:     newTelemetryState("bbr-tuic"),
+		cwndGain:     tuicCwndGain,
+		highCwndGain: tuicCwndGain,
+		// A sender used on its own keeps TUIC's behaviour, which is what the
+		// benchmark reference and every non-erasure path expect.
+		lossIsCongestion: true,
+		maxAckedPN:       quiccongestion.PacketNumber(-1),
+		maxSentPN:        quiccongestion.PacketNumber(-1),
+		endRecoveryPN:    quiccongestion.PacketNumber(-1),
+		roundEndPN:       quiccongestion.PacketNumber(-1),
+		estimator:        newTUICBandwidthEstimator(),
+		ackAgg:           tuicAckAggregation{maxAckHeight: newTUICMinMax()},
+		randomState:      uint64(monotime.Now()) ^ uint64(initialPacketSize)<<17,
+		telemetry:        newTelemetryState("bbr-tuic"),
 	}
 	b.pacer = newTUICPacer(b.bandwidth)
 	b.publishTelemetry()
@@ -437,7 +452,7 @@ func (b *TUICBBRSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 	// updates sampler/loss accounting, but waits for an ACK-clocked event before
 	// entering or advancing packet conservation.
 	if len(acked) != 0 {
-		b.updateRecoveryState(largestAck, hasLosses, isRoundStart)
+		b.updateRecoveryState(largestAck, hasLosses && b.lossIsCongestion, isRoundStart)
 	}
 	// Process the complete ACK batch as one sample. quic-go gives every packet
 	// in this callback the same receive/event time; updating the estimator once

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -63,20 +63,7 @@ type ErasureSender struct {
 	// packet number within each congestion event for the burst statistic.
 	estimator *lossmodel.Estimator
 
-	// forward carries the fractional part of how many losses to pass through,
-	// so a congestive share of a third forwards one loss in three rather than
-	// rounding to none.
-	forward  float64
 	outcomes []packetOutcome
-
-	// floorTrusted remembers that this lane has seen evidence of an
-	// independent channel. establishedFloor is the lowest such estimate seen
-	// by this connection. A physical erasure floor is a lower envelope: queue
-	// loss may raise an observation, but it cannot raise the channel floor.
-	// A replacement connection gets a fresh estimator and can establish a
-	// genuinely different floor after a path change.
-	floorTrusted     bool
-	establishedFloor float64
 
 	// erasure is the pooled measured erasure of the direction this sender
 	// sends into, in parts per million. It is what the code is sized from, and
@@ -97,8 +84,11 @@ type ErasureSender struct {
 	// the congestion window, which run outside the callback that computes it.
 	arrival atomic.Uint64 // arrival rate in parts per million
 
-	suppressed atomic.Uint64
-	passed     atomic.Uint64
+	// passed counts the losses handed to the inner controller, which is now
+	// all of them. It stays because the telemetry below is an assertion as
+	// much as a measurement: what this sender saw and what the controller was
+	// charged must agree, and a counter is how that is checked from outside.
+	passed atomic.Uint64
 
 	// path is shared with every other lane to the same endpoint pair, or nil
 	// for a lane that is on its own. share is this lane's allowance of the
@@ -119,17 +109,7 @@ const (
 	// delivered; below that the path is not one to push harder into, and an
 	// unbounded divisor would turn a measurement error into a flood.
 	erasureMinArrival = 0.15
-	// erasureMinSamples is how many packet fates must be decided before the
-	// early independence checks may establish a floor. Until then every loss
-	// is passed through, so an unmeasured path behaves exactly like BBR.
-	erasureMinSamples = 100
-	// erasureEarlyMaxFloor bounds only the pre-verdict bootstrap. Acting on a
-	// tiny sample that says more than two thirds of the path vanished would
-	// multiply the send rate by more than three, which is precisely the unsafe
-	// response to a full startup queue. A formally established floor may be
-	// higher and is still bounded by erasureMinArrival.
-	erasureEarlyMaxFloor = 0.65
-	partsPerMillion      = 1e6
+	partsPerMillion   = 1e6
 )
 
 // NewErasureSender returns a controller for a path whose loss is mostly not
@@ -166,17 +146,16 @@ func NewErasureSenderOn(initialPacketSize quiccongestion.ByteCount, path *pathmo
 		// seed only. Sharing one number for the two used to mean that the
 		// only lane on a path capped itself at whatever the last one managed.
 		state := path.Current()
-		// The floor is path knowledge too, so use it for the replacement's first
-		// pacing decision. Do not call it this connection's own established
-		// evidence, though: a fresh connection is also the safe point at which a
-		// changed physical path may establish a higher floor. The shared model
-		// retains the inherited value while this sender reports zero weight, then
-		// replaces it once this connection has trustworthy evidence of its own.
-		if state.Floor > 0 {
-			e.arrival.Store(uint64((1 - state.Floor) * partsPerMillion))
+		// The measured erasure is path knowledge, so a replacement lane paces
+		// from it rather than rediscovering it. On a channel that erases 42% of
+		// packets that rediscovery is expensive -- it is the same ramp that
+		// costs a loss-based controller the path in the first place -- and a
+		// lane opened because its predecessor died would pay it every time.
+		if state.Erasure > 0 {
+			e.arrival.Store(uint64((1 - state.Erasure) * partsPerMillion))
+			e.erasure.Store(uint64(state.Erasure * partsPerMillion))
 		}
 		if state.Seed > 0 {
-			e.arrival.Store(uint64((1 - state.Floor) * partsPerMillion))
 			if state.Share > 0 {
 				e.share.Store(uint64(state.Share))
 			}
@@ -187,8 +166,14 @@ func NewErasureSenderOn(initialPacketSize quiccongestion.ByteCount, path *pathmo
 }
 
 func newErasureSender(initialPacketSize quiccongestion.ByteCount) *ErasureSender {
+	inner := NewTUICBBRSender(initialPacketSize)
+	// Loss is not this path's congestion signal. Erasure scales delivery down
+	// proportionally at every rate and cannot produce a knee; congestion
+	// produces one, and the delivery-versus-rate curve is what separates them.
+	// The brake is the delay bound.
+	inner.lossIsCongestion = false
 	e := &ErasureSender{
-		inner:  NewTUICBBRSender(initialPacketSize),
+		inner:  inner,
 		member: pathmodel.Member(nextErasureMemberID.Add(1)),
 		// A reorder tolerance wide enough for QUIC's acknowledgement
 		// aggregation: packets are acked in batches, and a batch boundary must
@@ -323,9 +308,26 @@ func (e *ErasureSender) OnCongestionEvent(number quiccongestion.PacketNumber, lo
 	e.inner.OnCongestionEvent(number, lostBytes, priorInFlight)
 }
 
-// OnCongestionEventEx is where the two regimes are separated. Everything that
-// arrived updates the estimate of the channel; only the share of the losses
-// that the channel does not explain is passed to BBR.
+// OnCongestionEventEx measures the channel and passes every fate through.
+//
+// It used to be where the two regimes were separated: only the share of the
+// losses the channel did not explain reached BBR, so that erasure would not be
+// read as congestion. That separation is gone. It was a statistical answer to a
+// question the delivery-versus-rate curve answers directly -- erasure scales
+// delivery down proportionally at every rate and cannot produce a knee, while
+// congestion produces one -- and it was least reliable exactly when loss was
+// worst, because heavy erasure is bursty and the burst test then refused to
+// call it erasure at all.
+//
+// What replaced it is not a better classifier but a different signal. The inner
+// controller no longer enters recovery on loss, and the brake is the delay
+// bound: the round trip may not exceed twice the path's own minimum.
+//
+// Every loss is still handed to the inner controller, which matters for a
+// reason unrelated to congestion. Its bytesInFlight is priorInFlight less what
+// was acknowledged and what was lost, so a sender told about only a fraction of
+// the losses believes the pipe is fuller than it is and throttles itself for
+// packets that are already gone.
 func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCount, eventTime monotime.Time, acked []quiccongestion.AckedPacketInfo, lost []quiccongestion.LostPacketInfo) {
 	// QUIC has a separate packet-number space for Initial, Handshake and
 	// 1-RTT packets, but this public callback omits the space. Inferring losses
@@ -351,164 +353,44 @@ func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 		e.estimator.ObserveOutcome(outcome.arrived)
 	}
 	snapshot := e.estimator.Snapshot()
-	floor, floorSamples := e.establishedErasureFloor(snapshot)
+	erasure := snapshot.Loss
 	if e.path != nil {
-		// Pool with the other lanes: the floor converges on all their samples
-		// together, and the share is what stops their probes compounding. An
-		// untrusted local estimate contributes zero weight rather than diluting
-		// a floor another lane has already established.
-		//
-		// The measured erasure is reported alongside it and is not the same
-		// number. This sender paces from the floor, which is conservative on
-		// purpose; the code is sized from the measurement, because a code that
-		// under-estimates erasure sends no parity into a channel that is
-		// erasing. Reporting only the floor is what left 97% of lossy flows
-		// uncoded -- see docs/CONTROL-REDESIGN.md.
+		// Pool with the other lanes: the estimate converges on all their
+		// samples together, and the share is what stops their probes
+		// compounding.
 		state := e.path.Report(e.id(), pathmodel.Observation{
-			Floor: floor, FloorSamples: floorSamples,
 			Erasure: snapshot.Loss, BurstFactor: snapshot.BurstFactor,
 			ObservedSamples: float64(snapshot.Decided),
 			Delivered:       float64(e.inner.bandwidth()),
 			RoundTrip:       e.inner.minRoundTrip(),
 		})
-		floor = state.Floor
+		erasure = state.Erasure
 		e.erasure.Store(uint64(state.Erasure * partsPerMillion))
 		e.share.Store(uint64(state.Share))
 	}
-	e.arrival.Store(uint64((1 - floor) * partsPerMillion))
-
-	// The pooled, established floor governs both compensation and which losses are
-	// forwarded. Using the raw local floor here would still suppress startup
-	// queue drops even though pacing correctly declined to compensate for them.
-	snapshot.Floor = floor
-	e.inner.OnCongestionEventEx(priorInFlight, eventTime, acked, e.congestive(snapshot, lost))
-}
-
-// establishedErasureFloor turns the stateless early discriminator into a
-// stable measurement. Once an independent floor has been seen, a later burst
-// of congestion must not make it vanish or raise it. The floor is a lower
-// envelope for the lifetime of this connection: allowing a completed but
-// congested measurement to increase it creates positive feedback, because
-// both the pacer and FEC then add traffic to an already overloaded path.
-//
-// A lower independent measurement may refine the floor downward. If the
-// physical path really changes to a higher erasure rate, lane recovery creates
-// a new connection and therefore a new estimator; guessing upward inside a
-// congested connection is the unsafe direction.
-func (e *ErasureSender) establishedErasureFloor(snapshot lossmodel.Snapshot) (floor, samples float64) {
-	candidate, _ := conservativeErasureFloor(snapshot)
-	if candidate > 0 {
-		// Before the first round, the conditional is the measurement that
-		// passed the independence check; the partial-round loss rate can
-		// already include a queue burst. Once the formal verdict is present,
-		// its windowed floor is the stronger evidence.
-		measured := candidate
-		if snapshot.Memoryless {
-			measured = snapshot.Floor
-		}
-		if measured <= 0 {
-			measured = snapshot.Floor
-		}
-		if measured > 0 && (!e.floorTrusted || measured < e.establishedFloor) {
-			e.establishedFloor = measured
-		}
-		e.floorTrusted = true
-	}
-	if !e.floorTrusted {
-		return 0, 0
-	}
-	return e.establishedFloor, snapshot.Samples
-}
-
-// conservativeErasureFloor separates evidence of an independent channel from
-// the first clustered queue drops of STARTUP.
-//
-// Waiting for the whole process to be declared memoryless is too late on the
-// 42% channel this controller exists for: plain BBR has already backed away
-// before that verdict and takes most of a short transfer to recover. The
-// useful early statistic is P(loss | previous packet arrived). Congestion
-// drops in runs, so this conditional is near zero even while a partial round's
-// raw loss rate is large; an independent channel keeps it near the floor.
-//
-// Before the formal memoryless verdict, require that conditional to agree
-// with the overall loss rate and require the observed burst length to agree as
-// well. The conditional itself is then the conservative bootstrap. Once the
-// verdict is available, the estimator's windowed minimum is authoritative.
-func conservativeErasureFloor(snapshot lossmodel.Snapshot) (floor, samples float64) {
-	if snapshot.Decided < erasureMinSamples || snapshot.Samples <= 0 {
-		return 0, 0
-	}
-	// Even the formal transition test can briefly call an overflowing queue
-	// memoryless when almost every packet in a small sample is lost. Do not
-	// turn that extreme result into a three-to-sevenfold send-rate increase
-	// until two complete floor rounds have given BBR time to drain and supply
-	// a lower observation. Ordinary erasure floors use the early path below.
-	if snapshot.Floor > erasureEarlyMaxFloor && snapshot.Decided < 2*lossmodel.DefaultRoundSamples {
-		return 0, 0
-	}
-	if snapshot.Memoryless {
-		return snapshot.Floor, snapshot.Samples
-	}
-	p := snapshot.LossAfterArrival
-	if p <= 0 {
-		return 0, 0
-	}
-	if snapshot.Loss > erasureEarlyMaxFloor || p > erasureEarlyMaxFloor {
-		return 0, 0
-	}
-	// A conditional below the overall loss rate is evidence that losses are
-	// clustered. Do not compensate until the two are close enough that the
-	// early sample is consistent with independence. The formal verdict below
-	// deliberately waits longer; this narrower bootstrap exists only to keep
-	// BBR from yielding a real erasure channel before that verdict arrives.
-	if p < 0.9*snapshot.Loss {
-		return 0, 0
-	}
-	// The second, independent view of the same question is the length of loss
-	// runs. A queue can briefly make the conditional probabilities look close
-	// in a small sample; its longer bursts still distinguish it from a
-	// memoryless channel.
-	if snapshot.BurstFactor > 1.1 {
-		return 0, 0
-	}
-	return p, snapshot.Samples
-}
-
-// congestive returns the share of these losses that the channel does not
-// explain, in whole packets.
-//
-// The share is a fraction, and a fraction of a loss cannot be reported, so the
-// remainder is carried rather than rounded away. Rounding down would suppress
-// every loss whenever the congestive share stayed below a half, which is
-// exactly the mild persistent congestion a controller most needs to see.
-func (e *ErasureSender) congestive(snapshot lossmodel.Snapshot, lost []quiccongestion.LostPacketInfo) []quiccongestion.LostPacketInfo {
-	if len(lost) == 0 {
-		return lost
-	}
-	if snapshot.Decided < erasureMinSamples || snapshot.Recent <= 0 {
-		e.passed.Add(uint64(len(lost)))
-		return lost
-	}
-	share := 1.0
-	if snapshot.Recent > snapshot.Floor {
-		share = (snapshot.Recent - snapshot.Floor) / snapshot.Recent
-	} else {
-		share = 0
+	// The compensation rides on the measurement rather than on a floor biased
+	// low for pacing. Under-compensating is not the safe direction it looks
+	// like: pacing a delivered-rate estimate makes the sending rate its own
+	// input, and the loop walks down to nothing rather than converging on the
+	// bottleneck.
+	//
+	// But it waits for the delay bound to be able to act. A first flight can
+	// overrun a clean path's queue before the controller has found its
+	// bottleneck, and compensating for those drops means sending twice as fast
+	// into a queue that is already overflowing -- the exact positive feedback
+	// the removed classifier was there to prevent. The bound would stop it,
+	// except that at that moment there is no minimum round trip to bound
+	// against, so the brake is inert.
+	//
+	// Gating on the minimum being measured is not a classifier returning. It
+	// makes no judgement about what kind of loss this is; it says only that
+	// compensation may not run ahead of the brake that bounds it.
+	if _, minRTT := e.queueDelay(); minRTT > 0 {
+		e.arrival.Store(uint64((1 - erasure) * partsPerMillion))
 	}
 
-	e.forward += share * float64(len(lost))
-	pass := int(e.forward)
-	if pass > len(lost) {
-		pass = len(lost)
-	}
-	e.forward -= float64(pass)
-
-	e.passed.Add(uint64(pass))
-	e.suppressed.Add(uint64(len(lost) - pass))
-	if pass == 0 {
-		return nil
-	}
-	return lost[:pass]
+	e.passed.Add(uint64(len(lost)))
+	e.inner.OnCongestionEventEx(priorInFlight, eventTime, acked, lost)
 }
 
 func (e *ErasureSender) OnRetransmissionTimeout(retransmitted bool) {
@@ -531,16 +413,17 @@ func (e *ErasureSender) Telemetry() ControllerTelemetry {
 	// The inner controller was charged only the congestive share, so its own
 	// figure cannot answer what the path did. Both halves are reported: what
 	// this sender saw, and what it withheld as erasure.
-	suppressed := e.suppressed.Load()
-	t.PacketsLostSuppressed = suppressed
-	t.PacketsLostObserved = t.PacketsLost + suppressed
+	// Every loss now reaches the inner controller, so what this sender saw and
+	// what the controller was charged are the same number. Publishing it from
+	// this sender's own counter rather than copying the controller's keeps the
+	// two independently derived, which is what lets a test assert they agree.
+	t.PacketsLostObserved = e.passed.Load()
 	t.Erasure = float64(e.erasure.Load()) / partsPerMillion
 	// Recomputed rather than read from the cached value, so a trace taken while
 	// nothing is sending still reflects the path rather than the last send.
 	e.delayBounded(1)
 	t.DelayBrake = float64(e.delayBrake.Load()) / partsPerMillion
 	arrival := e.arrivalRate()
-	t.ErasureFloor = 1 - arrival
 	t.PacingRate = uint64(float64(t.PacingRate) / arrival)
 	t.CongestionWindow = uint64(float64(t.CongestionWindow) / arrival)
 	return t
@@ -555,8 +438,8 @@ func (e *ErasureSender) id() pathmodel.Member { return e.member }
 // known.
 func (e *ErasureSender) Share() float64 { return float64(e.share.Load()) }
 
-// Channel reports what the controller believes about the path and how much
-// loss it has declined to treat as congestion.
-func (e *ErasureSender) Channel() (lossmodel.Snapshot, uint64, uint64) {
-	return e.estimator.Snapshot(), e.suppressed.Load(), e.passed.Load()
+// Channel reports what this sender has measured about the path and how many
+// losses it has handed to the controller.
+func (e *ErasureSender) Channel() (lossmodel.Snapshot, uint64) {
+	return e.estimator.Snapshot(), e.passed.Load()
 }

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -9,7 +9,6 @@ import (
 
 	quiccongestion "github.com/apernet/quic-go/congestion"
 
-	"github.com/bojieli/queqiao/internal/lossmodel"
 	"github.com/bojieli/queqiao/internal/pathmodel"
 )
 
@@ -19,17 +18,6 @@ func losses(n int) []quiccongestion.LostPacketInfo {
 		out[i] = quiccongestion.LostPacketInfo{PacketNumber: quiccongestion.PacketNumber(i), BytesLost: 1200}
 	}
 	return out
-}
-
-// Until the channel has been measured, every loss is congestion as far as this
-// controller knows, and it must behave exactly like the BBR it wraps. Guessing
-// early is how a clean path would be driven into collapse.
-func TestUnmeasuredLossIsTreatedAsCongestion(t *testing.T) {
-	e := NewErasureSender(1200)
-	got := e.congestive(lossmodel.Snapshot{}, losses(10))
-	if len(got) != 10 {
-		t.Fatalf("forwarded %d of 10 losses before the channel was measured", len(got))
-	}
 }
 
 func TestExplicitCongestionOutcomesDoNotInferAmbiguousPacketGaps(t *testing.T) {
@@ -79,228 +67,61 @@ func TestClusteredStartupLossDoesNotBecomeAnErasureFloor(t *testing.T) {
 	}
 }
 
-// Gating the floor on evidence must not turn the erasure controller into plain
-// BBR. Once enough independent losses have been observed, compensation should
-// still converge on the channel's actual arrival rate.
-func TestIndependentLossBecomesAnErasureFloor(t *testing.T) {
+// Compensation must still converge on the channel's actual arrival rate.
+// Without it, pacing a delivered-rate estimate makes the sending rate its own
+// input and the loop walks down to nothing rather than to the bottleneck.
+//
+// It now waits for a measured minimum round trip, because that is when the
+// delay bound can act, and compensation may not run ahead of the brake that
+// bounds it. Before then the sender behaves as plain BBR that ignores loss:
+// it neither compensates nor collapses.
+func TestCompensationConvergesOnTheMeasuredArrivalRate(t *testing.T) {
 	e := NewErasureSender(1200)
-	rng := rand.New(rand.NewSource(1))
-	var acked []quiccongestion.AckedPacketInfo
-	var lost []quiccongestion.LostPacketInfo
-	for pn := 0; pn < 5000; pn++ {
-		if rng.Float64() >= 0.42 {
-			acked = append(acked, quiccongestion.AckedPacketInfo{
-				PacketNumber: quiccongestion.PacketNumber(pn), BytesAcked: 1200,
-			})
-		} else {
-			lost = append(lost, quiccongestion.LostPacketInfo{
-				PacketNumber: quiccongestion.PacketNumber(pn), BytesLost: 1200,
-			})
+	e.inner.minRTT = 200 * time.Millisecond
+	e.SetRTTStatsProvider(&fixedRTT{min: 200 * time.Millisecond, smoothed: 200 * time.Millisecond})
+
+	rng := rand.New(rand.NewSource(3))
+	number := quiccongestion.PacketNumber(0)
+	for round := 0; round < 20; round++ {
+		var acked []quiccongestion.AckedPacketInfo
+		var lost []quiccongestion.LostPacketInfo
+		for i := 0; i < 500; i++ {
+			if rng.Float64() < 0.42 {
+				lost = append(lost, quiccongestion.LostPacketInfo{PacketNumber: number, BytesLost: 1200})
+			} else {
+				acked = append(acked, quiccongestion.AckedPacketInfo{PacketNumber: number, BytesAcked: 1200})
+			}
+			number++
 		}
+		e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
 	}
-	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
-
-	if got := e.arrivalRate(); got < 0.54 || got > 0.62 {
-		t.Fatalf("independent 42%% loss produced arrival rate %.3f, want about 0.58", got)
+	if got := e.arrivalRate(); got < 0.5 || got > 0.66 {
+		t.Fatalf("arrival rate %.3f on a 42%% erasure channel, want about 0.58", got)
 	}
 }
 
-// A real erasure channel needs a conservative bootstrap before the formal
-// memoryless verdict has enough transitions. Otherwise BBR backs away from the
-// channel first and a short transfer spends most of its life recovering.
-func TestIndependentLossBootstrapsBeforeTheMemorylessVerdict(t *testing.T) {
+// Before a round trip has been measured the brake cannot act, so compensation
+// must not either. The sender is then plain BBR that ignores loss.
+func TestCompensationWaitsForTheBrake(t *testing.T) {
 	e := NewErasureSender(1200)
-	rng := rand.New(rand.NewSource(2))
-	var acked []quiccongestion.AckedPacketInfo
-	var lost []quiccongestion.LostPacketInfo
-	for pn := 0; pn < 180; pn++ {
-		if rng.Float64() >= 0.42 {
-			acked = append(acked, quiccongestion.AckedPacketInfo{
-				PacketNumber: quiccongestion.PacketNumber(pn), BytesAcked: 1200,
-			})
-		} else {
-			lost = append(lost, quiccongestion.LostPacketInfo{
-				PacketNumber: quiccongestion.PacketNumber(pn), BytesLost: 1200,
-			})
+	rng := rand.New(rand.NewSource(3))
+	number := quiccongestion.PacketNumber(0)
+	for round := 0; round < 20; round++ {
+		var acked []quiccongestion.AckedPacketInfo
+		var lost []quiccongestion.LostPacketInfo
+		for i := 0; i < 500; i++ {
+			if rng.Float64() < 0.42 {
+				lost = append(lost, quiccongestion.LostPacketInfo{PacketNumber: number, BytesLost: 1200})
+			} else {
+				acked = append(acked, quiccongestion.AckedPacketInfo{PacketNumber: number, BytesAcked: 1200})
+			}
+			number++
 		}
+		e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
 	}
-	e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
-
-	if snapshot := e.estimator.Snapshot(); snapshot.Memoryless {
-		t.Fatalf("test already reached the formal memoryless verdict: %+v", snapshot)
-	}
-	if got := e.arrivalRate(); got >= 0.9 || got < 0.5 {
-		t.Fatalf("early independent loss produced arrival rate %.3f, want conservative compensation", got)
-	}
-}
-
-func TestPartiallyClusteredLossDoesNotBootstrapCompensation(t *testing.T) {
-	snapshot := lossmodel.Snapshot{
-		Decided:          1000,
-		Samples:          1000,
-		Loss:             0.90,
-		LossAfterArrival: 0.70,
-		Floor:            0.88,
-	}
-	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
-		t.Fatalf("partially clustered loss produced erasure floor %.3f", floor)
-	}
-}
-
-func TestExtremeLossRequiresTheFormalVerdict(t *testing.T) {
-	snapshot := lossmodel.Snapshot{
-		Decided:          1000,
-		Samples:          1000,
-		Loss:             0.85,
-		LossAfterArrival: 0.84,
-		BurstFactor:      1,
-		Floor:            0.85,
-	}
-	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
-		t.Fatalf("unconfirmed extreme loss produced erasure floor %.3f", floor)
-	}
-	snapshot.Memoryless = true
-	if floor, _ := conservativeErasureFloor(snapshot); floor != 0 {
-		t.Fatalf("short formal verdict produced extreme floor %.3f", floor)
-	}
-	snapshot.Decided = 2 * lossmodel.DefaultRoundSamples
-	if floor, _ := conservativeErasureFloor(snapshot); floor != snapshot.Floor {
-		t.Fatalf("formal verdict produced floor %.3f, want %.3f", floor, snapshot.Floor)
-	}
-}
-
-func TestAnEstablishedEarlyFloorSurvivesLaterClustering(t *testing.T) {
-	e := NewErasureSender(1200)
-	early := lossmodel.Snapshot{
-		Decided:          120,
-		Samples:          120,
-		Loss:             0.42,
-		LossAfterArrival: 0.41,
-		Floor:            0.38,
-	}
-	if floor, _ := e.establishedErasureFloor(early); floor != early.LossAfterArrival {
-		t.Fatalf("early independent floor = %.3f, want %.3f", floor, early.LossAfterArrival)
-	}
-
-	clustered := lossmodel.Snapshot{
-		Decided:          1000,
-		Samples:          1000,
-		Loss:             0.75,
-		LossAfterArrival: 0.40,
-		Floor:            0.60,
-	}
-	if floor, _ := e.establishedErasureFloor(clustered); floor != early.LossAfterArrival {
-		t.Fatalf("later clustering moved established floor to %.3f, want %.3f", floor, early.LossAfterArrival)
-	}
-
-	completed := clustered
-	completed.Decided = lossmodel.DefaultRoundSamples
-	completed.Floor = 0.41
-	if floor, _ := e.establishedErasureFloor(completed); floor != completed.Floor {
-		t.Fatalf("completed-round floor = %.3f, want %.3f", floor, completed.Floor)
-	}
-}
-
-// A saturated path can keep every round congested long enough for the
-// estimator's entire minimum window to rise. That observation is not a new
-// physical erasure floor: compensating for it would add parity and pacing
-// pressure to the queue that caused it.
-func TestCompletedCongestedRoundsCannotRaiseAnEstablishedFloor(t *testing.T) {
-	e := NewErasureSender(1200)
-	established := lossmodel.Snapshot{
-		Decided:          200,
-		Samples:          200,
-		Loss:             0.42,
-		LossAfterArrival: 0.42,
-		BurstFactor:      1,
-		Floor:            0.42,
-	}
-	if floor, _ := e.establishedErasureFloor(established); floor != 0.42 {
-		t.Fatalf("established floor = %.3f, want 0.420", floor)
-	}
-
-	overloaded := lossmodel.Snapshot{
-		Decided:          10 * lossmodel.DefaultRoundSamples,
-		Samples:          4 * lossmodel.DefaultRoundSamples,
-		Loss:             0.72,
-		LossAfterArrival: 0.50,
-		BurstFactor:      1.4,
-		Floor:            0.66,
-	}
-	if floor, _ := e.establishedErasureFloor(overloaded); floor != 0.42 {
-		t.Fatalf("congested rounds raised established floor to %.3f, want 0.420", floor)
-	}
-}
-
-func TestIndependentEvidenceCanLowerAnEstablishedFloor(t *testing.T) {
-	e := NewErasureSender(1200)
-	first := lossmodel.Snapshot{
-		Decided:          200,
-		Samples:          200,
-		Loss:             0.42,
-		LossAfterArrival: 0.42,
-		BurstFactor:      1,
-		Floor:            0.42,
-	}
-	e.establishedErasureFloor(first)
-
-	cleaner := lossmodel.Snapshot{
-		Decided:          2 * lossmodel.DefaultRoundSamples,
-		Samples:          lossmodel.DefaultRoundSamples,
-		Loss:             0.30,
-		LossAfterArrival: 0.30,
-		BurstFactor:      1,
-		Floor:            0.30,
-		Memoryless:       true,
-	}
-	if floor, _ := e.establishedErasureFloor(cleaner); floor != 0.30 {
-		t.Fatalf("lower independent floor = %.3f, want 0.300", floor)
-	}
-}
-
-// A channel whose loss is entirely its floor is not congested at any rate, and
-// forwarding those losses is what costs the path: BBR-TUIC delivers 1.56
-// Mbit/s where the same path carries 13.89.
-func TestChannelLossIsNotForwarded(t *testing.T) {
-	e := NewErasureSender(1200)
-	snapshot := lossmodel.Snapshot{Decided: 5000, Floor: 0.42, Recent: 0.42}
-	var forwarded int
-	for i := 0; i < 100; i++ {
-		forwarded += len(e.congestive(snapshot, losses(10)))
-	}
-	if forwarded != 0 {
-		t.Fatalf("forwarded %d losses on a channel whose loss is all floor", forwarded)
-	}
-}
-
-// Loss above the floor is the sender's own, and it must reach BBR or the
-// controller has no congestion response at all.
-func TestLossAboveTheFloorIsForwarded(t *testing.T) {
-	e := NewErasureSender(1200)
-	// Two thirds of this loss is above the floor.
-	snapshot := lossmodel.Snapshot{Decided: 5000, Floor: 0.24, Recent: 0.72}
-	var forwarded int
-	for i := 0; i < 100; i++ {
-		forwarded += len(e.congestive(snapshot, losses(10)))
-	}
-	if want := 1000 * 2 / 3; forwarded < want*9/10 || forwarded > want*11/10 {
-		t.Fatalf("forwarded %d of 1000 losses, want about %d", forwarded, want)
-	}
-}
-
-// A congestive share below a half must still be reported. Rounding it away
-// would blind the controller to exactly the mild persistent congestion it most
-// needs to see, so the fractional part is carried rather than dropped.
-func TestASmallCongestiveShareIsNotRoundedAway(t *testing.T) {
-	e := NewErasureSender(1200)
-	// A tenth of the loss is congestive, and losses arrive one at a time.
-	snapshot := lossmodel.Snapshot{Decided: 5000, Floor: 0.45, Recent: 0.5}
-	var forwarded int
-	for i := 0; i < 1000; i++ {
-		forwarded += len(e.congestive(snapshot, losses(1)))
-	}
-	if forwarded < 80 || forwarded > 120 {
-		t.Fatalf("forwarded %d of 1000 single losses at a tenth congestive, want about 100", forwarded)
+	if got := e.arrivalRate(); got < 0.99 {
+		t.Fatalf("compensated at %.3f with no measured round trip, so nothing could have "+
+			"bounded it", got)
 	}
 }
 
@@ -368,8 +189,8 @@ func TestTheCongestionWindowIsCompensated(t *testing.T) {
 func TestAJoiningSenderStartsFromWhatIsAlreadyKnown(t *testing.T) {
 	model := pathmodel.NewPathModel()
 	const perMember = 2e6
-	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
-	model.Report(2, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
+	model.Report(1, pathmodel.Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
+	model.Report(2, pathmodel.Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perMember, RoundTrip: 0})
 
 	seeded := NewErasureSenderOn(1200, model)
 	if seeded.Share() <= 0 {
@@ -379,42 +200,6 @@ func TestAJoiningSenderStartsFromWhatIsAlreadyKnown(t *testing.T) {
 	if seeded.bandwidth() <= fresh.bandwidth() {
 		t.Fatalf("seeded sender starts at %d, no better than an unseeded %d",
 			seeded.bandwidth(), fresh.bandwidth())
-	}
-}
-
-func TestAJoiningSenderUsesButDoesNotClaimTheInheritedFloor(t *testing.T) {
-	model := pathmodel.NewPathModel()
-	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 250 * time.Millisecond})
-
-	seeded := NewErasureSenderOn(1200, model)
-	if seeded.floorTrusted || seeded.establishedFloor != 0 {
-		t.Fatalf("joining sender claimed trusted=%t local floor=%.3f before measuring",
-			seeded.floorTrusted, seeded.establishedFloor)
-	}
-	if got := seeded.arrivalRate(); got < 0.579 || got > 0.581 {
-		t.Fatalf("joining sender arrival rate = %.3f, want 0.580", got)
-	}
-
-	// Its first local sample is intentionally too small to establish a floor;
-	// zero weight leaves the shared model's retained value intact.
-	floor, samples := seeded.establishedErasureFloor(lossmodel.Snapshot{Decided: 12, Samples: 12})
-	if floor != 0 || samples != 0 {
-		t.Fatalf("first replacement report = floor %.3f samples %.0f, want no local verdict", floor, samples)
-	}
-	if got := model.Report(seeded.id(), pathmodel.Observation{Floor: floor, FloorSamples: samples, Erasure: floor, BurstFactor: 1, ObservedSamples: 12}).Floor; got != 0.42 {
-		t.Fatalf("untrusted replacement report erased retained floor: %.3f", got)
-	}
-
-	// A new connection is the measurement generation boundary. If this path
-	// really changed, its own independent evidence must be allowed to replace
-	// the inherited value in either direction; treating the inheritance as a
-	// local lower envelope would lock a worse path to the old rate forever.
-	changed := lossmodel.Snapshot{
-		Decided: 200, Samples: 200, Loss: 0.55, LossAfterArrival: 0.55,
-		BurstFactor: 1, Floor: 0.55,
-	}
-	if floor, _ := seeded.establishedErasureFloor(changed); floor != 0.55 {
-		t.Fatalf("new connection remained locked to inherited floor: %.3f", floor)
 	}
 }
 
@@ -429,7 +214,7 @@ func TestAJoiningSenderUsesButDoesNotClaimTheInheritedFloor(t *testing.T) {
 func TestAJoiningSenderStartsWithTheWindowItsRateImplies(t *testing.T) {
 	const rate, roundTrip = 2e6, 250 * time.Millisecond
 	model := pathmodel.NewPathModel()
-	model.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: roundTrip})
+	model.Report(1, pathmodel.Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: roundTrip})
 
 	seeded := NewErasureSenderOn(1200, model)
 	fresh := NewErasureSender(1200)
@@ -449,7 +234,7 @@ func TestAJoiningSenderStartsWithTheWindowItsRateImplies(t *testing.T) {
 	// sender must still start from the rate rather than refusing to start.
 	blind := NewErasureSenderOn(1200, func() *pathmodel.PathModel {
 		m := pathmodel.NewPathModel()
-		m.Report(1, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
+		m.Report(1, pathmodel.Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
 		return m
 	}())
 	if blind.bandwidth() <= NewErasureSender(1200).bandwidth() {
@@ -489,19 +274,17 @@ func TestAnEmptiedPipeKeepsWhatItMeasured(t *testing.T) {
 	}
 }
 
-// What the controller was charged is not what the path did, and until now only
-// the charged figure left the process. On the live gateway that meant a path
-// erasing a fifth of its downstream reported single-digit loss: the rest had
-// been correctly reclassified as erasure and then dropped from the record, so
-// no dashboard could show the erasure this transport exists to handle.
+// Every loss now reaches the controller, so what this sender saw and what the
+// controller was charged must be the same number.
 //
-// The three counters have to satisfy observed = charged + suppressed, and
-// observed has to be the one that tracks the channel.
-func TestTheSenderReportsWhatThePathDidAndWhatItWasCharged(t *testing.T) {
+// They are derived independently -- one from this sender's own counter, one
+// from the controller's telemetry -- so the agreement is a check rather than a
+// tautology. While loss was classified they differed by most of the loss, and
+// publishing only the controller's figure let a gateway erasing a fifth of its
+// downstream report single-digit loss.
+func TestEveryLossReachesTheController(t *testing.T) {
 	e := NewErasureSender(1200)
 
-	// Establish a memoryless erasure floor the way a real channel does, then
-	// keep feeding it at that rate.
 	const erasure = 0.2
 	rng := rand.New(rand.NewSource(7))
 	number := quiccongestion.PacketNumber(0)
@@ -522,31 +305,44 @@ func TestTheSenderReportsWhatThePathDidAndWhatItWasCharged(t *testing.T) {
 	}
 
 	telemetry := e.Telemetry()
-	_, suppressed, passed := e.Channel()
-	t.Logf("observed=%d charged=%d suppressed=%d (channel lost %d of %d)",
-		telemetry.PacketsLostObserved, telemetry.PacketsLost, telemetry.PacketsLostSuppressed,
-		observedLost, number)
+	_, passed := e.Channel()
+	t.Logf("observed=%d charged=%d (channel lost %d of %d)",
+		telemetry.PacketsLostObserved, telemetry.PacketsLost, observedLost, number)
 
-	if telemetry.PacketsLostObserved != telemetry.PacketsLost+telemetry.PacketsLostSuppressed {
-		t.Fatalf("observed %d != charged %d + suppressed %d, so the three cannot be read together",
-			telemetry.PacketsLostObserved, telemetry.PacketsLost, telemetry.PacketsLostSuppressed)
-	}
-	if telemetry.PacketsLost != passed || telemetry.PacketsLostSuppressed != suppressed {
-		t.Fatalf("telemetry (charged=%d suppressed=%d) disagrees with the sender's own counters (%d/%d)",
-			telemetry.PacketsLost, telemetry.PacketsLostSuppressed, passed, suppressed)
-	}
 	if telemetry.PacketsLostObserved != uint64(observedLost) {
 		t.Fatalf("observed %d losses, the channel produced %d", telemetry.PacketsLostObserved, observedLost)
 	}
-	// The point of the split: a floor was established, so most of the loss was
-	// correctly withheld from the controller, and the charged figure alone
-	// would understate the channel by a wide margin.
-	if telemetry.PacketsLostSuppressed == 0 {
-		t.Fatal("nothing was suppressed on a 20% memoryless erasure channel; the floor never established")
+	if telemetry.PacketsLostObserved != telemetry.PacketsLost {
+		t.Fatalf("this sender saw %d losses and the controller was charged %d; nothing should be "+
+			"withheld any more", telemetry.PacketsLostObserved, telemetry.PacketsLost)
 	}
-	if telemetry.PacketsLost >= telemetry.PacketsLostObserved/2 {
-		t.Fatalf("charged %d of %d observed: the controller absorbed most of an erasure channel",
-			telemetry.PacketsLost, telemetry.PacketsLostObserved)
+	if passed != uint64(observedLost) {
+		t.Fatalf("the sender's own counter says %d against a channel that lost %d", passed, observedLost)
+	}
+}
+
+// Charging the controller for every loss must not put it into recovery on an
+// erasure path. That is the collapse this controller exists to avoid, and it is
+// the reason loss used to be classified before being forwarded.
+func TestErasureDoesNotDriveTheControllerIntoRecovery(t *testing.T) {
+	e := NewErasureSender(1200)
+	rng := rand.New(rand.NewSource(11))
+	number := quiccongestion.PacketNumber(0)
+	for round := 0; round < 30; round++ {
+		var acked []quiccongestion.AckedPacketInfo
+		var lost []quiccongestion.LostPacketInfo
+		for i := 0; i < 400; i++ {
+			if rng.Float64() < 0.42 {
+				lost = append(lost, quiccongestion.LostPacketInfo{PacketNumber: number, BytesLost: 1200})
+			} else {
+				acked = append(acked, quiccongestion.AckedPacketInfo{PacketNumber: number, BytesAcked: 1200})
+			}
+			number++
+		}
+		e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+	}
+	if e.InRecovery() {
+		t.Fatal("a 42% erasure channel put the controller into recovery; loss is being read as congestion")
 	}
 }
 
@@ -567,9 +363,6 @@ func TestControllersThatDoNotClassifyReportObservedEqualToCharged(t *testing.T) 
 				t.Fatalf("observed %d against charged %d for a controller that classifies nothing",
 					got.PacketsLostObserved, got.PacketsLost)
 			}
-			if got.PacketsLostSuppressed != 0 {
-				t.Fatalf("suppressed %d for a controller that suppresses nothing", got.PacketsLostSuppressed)
-			}
 		})
 	}
 }
@@ -582,7 +375,6 @@ func TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom(t *testing.T) {
 	model := pathmodel.NewPathModel()
 	// A model whose floor and measurement disagree the way the live one did.
 	model.Report(2, pathmodel.Observation{
-		Floor: 0.0176, FloorSamples: 5000,
 		Erasure: 0.199, BurstFactor: 1,
 		ObservedSamples: 5000, Delivered: 2e6, RoundTrip: 200 * time.Millisecond,
 	})
@@ -595,12 +387,9 @@ func TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom(t *testing.T) {
 	}, nil)
 
 	got := e.Telemetry()
-	t.Logf("published erasure %.4f against floor %.4f", got.Erasure, got.ErasureFloor)
+	t.Logf("published erasure %.4f", got.Erasure)
 	if got.Erasure < 0.1 {
 		t.Fatalf("the sender published %.4f on a path measured at 0.199", got.Erasure)
 	}
-	if got.Erasure <= got.ErasureFloor {
-		t.Fatalf("published erasure %.4f is not above the floor %.4f, so the two cannot be "+
-			"told apart in a trace", got.Erasure, got.ErasureFloor)
-	}
+
 }

--- a/internal/congestion/telemetry.go
+++ b/internal/congestion/telemetry.go
@@ -31,29 +31,22 @@ type ControllerTelemetry struct {
 	// so these count congestion and not erasure.
 	BytesLost   uint64
 	PacketsLost uint64
-	// PacketsLostObserved is every loss this sender detected, before any of it
-	// was classified, and PacketsLostSuppressed is the part withheld from the
-	// controller as erasure. The three satisfy
+	// PacketsLostObserved is every loss the sender detected. It is derived
+	// independently of PacketsLost above -- one from the sender's own counter,
+	// one from the controller's -- and the two now agree, because no loss is
+	// withheld from the controller any more.
 	//
-	//	observed = PacketsLost + suppressed
+	// They did not always agree. While loss was classified, only the share the
+	// channel could not explain reached the controller, and publishing the
+	// controller's figure alone let a gateway erasing a fifth of its downstream
+	// report single-digit loss. The pair is kept rather than collapsed to one
+	// field so that a divergence between them is visible rather than silent.
 	//
-	// and a controller that classifies nothing reports observed == PacketsLost
-	// with suppressed zero, so the identity holds for every kind.
-	//
-	// Observed is the only one of the three that answers "what is this path
-	// doing to my packets". Publishing the controller's figure alone is what
-	// let a gateway erasing a fifth of its downstream report single-digit
-	// loss: the rest had been correctly reclassified and then silently
-	// dropped from the record.
-	//
-	// They are packet counts and not byte counts because a loss rate is a
-	// count over a count of trials; the sender's own byte totals do not divide
-	// into the suppressed and charged shares without attributing bytes to a
-	// classification made per packet.
-	PacketsLostObserved   uint64
-	PacketsLostSuppressed uint64
-	MinRTT                time.Duration
-	InRecovery            bool
+	// It is a packet count and not a byte count because a loss rate is a count
+	// over a count of trials.
+	PacketsLostObserved uint64
+	MinRTT              time.Duration
+	InRecovery          bool
 	// DelayBrake is the share of the sending rate the delay bound is currently
 	// removing, in [0,1). It is non-zero only while the path is carrying more
 	// than one bandwidth-delay product of queue.
@@ -72,12 +65,6 @@ type ControllerTelemetry struct {
 	// connection, so it keeps what a clean window established while this
 	// follows the path. On the live incident the two read 1.76% and 19.9%.
 	Erasure float64
-	// ErasureFloor is the share of packets this path drops for reasons that
-	// have nothing to do with sending rate, as the controller currently
-	// believes it. Everything sized for the path is sized from this number --
-	// the pacing compensation, the congestion window, and the erasure code's
-	// rate -- so a trace that does not carry it cannot explain any of them.
-	ErasureFloor float64
 }
 
 const (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -218,7 +218,6 @@ type quicCounterTotals struct {
 	packetsSent             atomic.Uint64
 	packetsReceived         atomic.Uint64
 	lossObservedPackets     atomic.Uint64
-	lossSuppressedPackets   atomic.Uint64
 	codedSources            atomic.Uint64
 	codedRecovered          atomic.Uint64
 	codedLost               atomic.Uint64
@@ -237,7 +236,6 @@ func (t *quicCounterTotals) add(d QUICConnectionCounters) {
 	t.packetsSent.Add(d.PacketsSent)
 	t.packetsReceived.Add(d.PacketsReceived)
 	t.lossObservedPackets.Add(d.LossObservedPackets)
-	t.lossSuppressedPackets.Add(d.LossSuppressedPackets)
 	t.codedSources.Add(d.CodedSources)
 	t.codedRecovered.Add(d.CodedRecovered)
 	t.codedLost.Add(d.CodedLost)
@@ -257,7 +255,6 @@ func (t *quicCounterTotals) load() QUICConnectionCounters {
 		PacketsSent:             t.packetsSent.Load(),
 		PacketsReceived:         t.packetsReceived.Load(),
 		LossObservedPackets:     t.lossObservedPackets.Load(),
-		LossSuppressedPackets:   t.lossSuppressedPackets.Load(),
 		CodedSources:            t.codedSources.Load(),
 		CodedRecovered:          t.codedRecovered.Load(),
 		CodedLost:               t.codedLost.Load(),
@@ -290,7 +287,7 @@ type Snapshot struct {
 	QUICLatestRTT, QUICSmoothedRTT                                time.Duration
 	QUICBytesSent, QUICBytesReceived                              uint64
 	QUICPacketsSent, QUICPacketsReceived                          uint64
-	QUICLossObservedPackets, QUICLossSuppressedPackets            uint64
+	QUICLossObservedPackets                                       uint64
 	QUICCodedSources, QUICCodedRecovered, QUICCodedLost           uint64
 	QUICControllerKind                                            string
 	QUICControllerMode                                            uint32
@@ -303,7 +300,7 @@ type Snapshot struct {
 	QUICControllerCongestionWindow, QUICControllerBytesInFlight   uint64
 	QUICControllerBytesLost, QUICControllerPacketsLost            uint64
 	QUICControllerMinRTT                                          time.Duration
-	QUICErasureSend, QUICControllerErasureFloor                   float64
+	QUICErasureSend                                               float64
 	QUICDelayBrake                                                float64
 	QUICControllerInRecovery                                      bool
 	// QUICObservationsExpired counts flow telemetry entries dropped because
@@ -342,7 +339,6 @@ type QUICObservation struct {
 	ControllerMinRTT           time.Duration
 	ControllerErasure          float64
 	ControllerDelayBrake       float64
-	ControllerErasureFloor     float64
 	ControllerInRecovery       bool
 }
 
@@ -424,7 +420,6 @@ func (c QUICConnectionCounters) Advance(previous QUICConnectionCounters) QUICCon
 		PacketsSent:             forward(c.PacketsSent, previous.PacketsSent),
 		PacketsReceived:         forward(c.PacketsReceived, previous.PacketsReceived),
 		LossObservedPackets:     forward(c.LossObservedPackets, previous.LossObservedPackets),
-		LossSuppressedPackets:   forward(c.LossSuppressedPackets, previous.LossSuppressedPackets),
 		CodedSources:            forward(c.CodedSources, previous.CodedSources),
 		CodedRecovered:          forward(c.CodedRecovered, previous.CodedRecovered),
 		CodedLost:               forward(c.CodedLost, previous.CodedLost),
@@ -445,7 +440,6 @@ func (c *QUICConnectionCounters) Add(delta QUICConnectionCounters) {
 	c.PacketsSent += delta.PacketsSent
 	c.PacketsReceived += delta.PacketsReceived
 	c.LossObservedPackets += delta.LossObservedPackets
-	c.LossSuppressedPackets += delta.LossSuppressedPackets
 	c.CodedSources += delta.CodedSources
 	c.CodedRecovered += delta.CodedRecovered
 	c.CodedLost += delta.CodedLost
@@ -680,7 +674,7 @@ func (r *Registry) Snapshot() Snapshot {
 	var controllerLatestAckRate, controllerLatestSendRate uint64
 	var controllerRound uint64
 	var controllerMinRTT time.Duration
-	var controllerErasure, controllerErasureFloor, controllerDelayBrake float64
+	var controllerErasure, controllerDelayBrake float64
 	var controllerRecovery bool
 	for key, entry := range r.quicFlows {
 		// An entry nobody refreshes is not a measurement of anything. Because
@@ -746,9 +740,6 @@ func (r *Registry) Snapshot() Snapshot {
 			if o.ControllerDelayBrake > controllerDelayBrake {
 				controllerDelayBrake = o.ControllerDelayBrake
 			}
-			if o.ControllerErasureFloor > controllerErasureFloor {
-				controllerErasureFloor = o.ControllerErasureFloor
-			}
 			controllerRecovery = controllerRecovery || o.ControllerInRecovery
 		}
 	}
@@ -768,7 +759,6 @@ func (r *Registry) Snapshot() Snapshot {
 	s.QUICPacketsSent = counters.PacketsSent
 	s.QUICPacketsReceived = counters.PacketsReceived
 	s.QUICLossObservedPackets = counters.LossObservedPackets
-	s.QUICLossSuppressedPackets = counters.LossSuppressedPackets
 	s.QUICCodedSources = counters.CodedSources
 	s.QUICCodedRecovered = counters.CodedRecovered
 	s.QUICCodedLost = counters.CodedLost
@@ -792,7 +782,6 @@ func (r *Registry) Snapshot() Snapshot {
 	s.QUICControllerMinRTT = controllerMinRTT
 	s.QUICErasureSend = controllerErasure
 	s.QUICDelayBrake = controllerDelayBrake
-	s.QUICControllerErasureFloor = controllerErasureFloor
 	s.QUICControllerInRecovery = controllerRecovery
 	return s
 }
@@ -851,7 +840,6 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// figure below is congestion only, and on an erasure path the two differ
 	// by most of the loss.
 	fmt.Fprintf(w, "queqiao_quic_loss_observed_packets_total %d\n", s.QUICLossObservedPackets)
-	fmt.Fprintf(w, "queqiao_quic_loss_suppressed_packets_total %d\n", s.QUICLossSuppressedPackets)
 	// A rising expiry count means some flow's telemetry stopped being
 	// refreshed without being removed. The RTT values above are maxima, so
 	// that is the failure mode which freezes them at a stale constant.
@@ -899,11 +887,6 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// is being held back by it, which is a different condition from a path that
 	// simply measured less.
 	fmt.Fprintf(w, "queqiao_delay_brake_ratio %.9f\n", s.QUICDelayBrake)
-	// The floor is the conservative, pacing-side view of the same channel:
-	// biased low on purpose, and a lower envelope for a connection's lifetime.
-	// It is not a smaller version of the figure above and a code sized from it
-	// is sized for a channel that may no longer exist.
-	fmt.Fprintf(w, "queqiao_quic_controller_erasure_floor_ratio %.9f\n", s.QUICControllerErasureFloor)
 	if s.QUICControllerInRecovery {
 		fmt.Fprintln(w, "queqiao_quic_controller_in_recovery 1")
 	} else {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -30,12 +30,11 @@ func TestRegistryCountersAndHandler(t *testing.T) {
 		ControllerLatestSendRate: 900_000, ControllerRound: 7,
 		ControllerPacingRate: 1_250_000, ControllerCongestionWindow: 400_000,
 		ControllerBytesInFlight: 200_000, ControllerMinRTT: 190 * time.Millisecond,
-		ControllerErasureFloor: 0.0475,
-		ControllerInRecovery:   true,
+		ControllerInRecovery: true,
 	})
 	r.AddQUICConnectionCounters(QUICConnectionCounters{
 		BytesSent: 100, BytesReceived: 200, PacketsSent: 80, PacketsReceived: 75,
-		LossSuppressedPackets: 3, LossObservedPackets: 4, ControllerSamples: 12,
+		LossObservedPackets: 4, ControllerSamples: 12,
 		ControllerNonAppSamples: 10, ControllerAppSamples: 2,
 		ControllerStateMisses: 1, ControllerZeroSamples: 3,
 	})
@@ -49,12 +48,12 @@ func TestRegistryCountersAndHandler(t *testing.T) {
 	if s.UDPPathUnavailable != 1 || s.EndpointTransportRaceFailures != 1 || s.TransientUDPSendErrors != 1 {
 		t.Fatalf("unexpected endpoint transport snapshot: %+v", s)
 	}
-	if s.QUICPacketsSent != 80 || s.QUICPacketsReceived != 75 || s.QUICLossObservedPackets != 4 || s.QUICControllerErasureFloor != 0.0475 {
+	if s.QUICPacketsSent != 80 || s.QUICPacketsReceived != 75 || s.QUICLossObservedPackets != 4 {
 		t.Fatalf("unexpected loss telemetry snapshot: %+v", s)
 	}
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
-	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "queqiao_lane_replacements_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_path_unavailable_total 1") || !strings.Contains(rec.Body.String(), "queqiao_endpoint_transport_races_failed_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_transient_send_errors_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_association_reconnects_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_association_rescue_failures_total 1") || !strings.Contains(rec.Body.String(), "queqiao_flow_timeouts_total 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_smoothed_rtt_seconds 0.200000000") || !strings.Contains(rec.Body.String(), "queqiao_quic_packets_sent 80") || !strings.Contains(rec.Body.String(), "queqiao_quic_packets_received 75") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_kind{kind=\"bbr\"} 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_latest_sample_bytes_per_second 900000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_latest_ack_rate_bytes_per_second 1100000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_non_app_limited_samples_total 10") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_state_misses_total 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_round 7") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_pacing_rate_bytes_per_second 1250000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_erasure_floor_ratio 0.047500000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_in_recovery 1") {
+	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "queqiao_lane_replacements_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_path_unavailable_total 1") || !strings.Contains(rec.Body.String(), "queqiao_endpoint_transport_races_failed_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_transient_send_errors_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_association_reconnects_total 1") || !strings.Contains(rec.Body.String(), "queqiao_udp_association_rescue_failures_total 1") || !strings.Contains(rec.Body.String(), "queqiao_flow_timeouts_total 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_smoothed_rtt_seconds 0.200000000") || !strings.Contains(rec.Body.String(), "queqiao_quic_packets_sent 80") || !strings.Contains(rec.Body.String(), "queqiao_quic_packets_received 75") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_kind{kind=\"bbr\"} 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_latest_sample_bytes_per_second 900000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_latest_ack_rate_bytes_per_second 1100000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_non_app_limited_samples_total 10") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_state_misses_total 1") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_round 7") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_pacing_rate_bytes_per_second 1250000") || !strings.Contains(rec.Body.String(), "queqiao_quic_controller_in_recovery 1") {
 		t.Fatalf("unexpected exposition: %s", rec.Body.String())
 	}
 }
@@ -393,8 +392,7 @@ func TestRepublishingTheSameConnectionReadingCountsOnce(t *testing.T) {
 func TestTheExpositionPublishesNoCounterItCannotProduce(t *testing.T) {
 	r := New()
 	r.AddQUICConnectionCounters(QUICConnectionCounters{
-		PacketsSent: 1000, LossObservedPackets: 200, LossSuppressedPackets: 160,
-		ControllerPacketsLost: 40,
+		PacketsSent: 1000, LossObservedPackets: 200, ControllerPacketsLost: 40,
 	})
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
@@ -409,7 +407,6 @@ func TestTheExpositionPublishesNoCounterItCannotProduce(t *testing.T) {
 	}
 	for _, want := range []string{
 		"queqiao_quic_loss_observed_packets_total 200",
-		"queqiao_quic_loss_suppressed_packets_total 160",
 		"queqiao_quic_controller_packets_lost 40",
 	} {
 		if !strings.Contains(body, want) {
@@ -423,8 +420,8 @@ func TestTheExpositionPublishesNoCounterItCannotProduce(t *testing.T) {
 func TestObservedLossIsTheSumOfChargedAndSuppressedAcrossConnections(t *testing.T) {
 	r := New()
 	for _, c := range []QUICConnectionCounters{
-		{PacketsSent: 500, LossObservedPackets: 100, LossSuppressedPackets: 80, ControllerPacketsLost: 20},
-		{PacketsSent: 300, LossObservedPackets: 60, LossSuppressedPackets: 45, ControllerPacketsLost: 15},
+		{PacketsSent: 500, LossObservedPackets: 100, ControllerPacketsLost: 100},
+		{PacketsSent: 300, LossObservedPackets: 60, ControllerPacketsLost: 60},
 	} {
 		r.AddQUICConnectionCounters(c)
 	}
@@ -432,17 +429,15 @@ func TestObservedLossIsTheSumOfChargedAndSuppressedAcrossConnections(t *testing.
 	if s.QUICLossObservedPackets != 160 {
 		t.Fatalf("observed = %d, want 160", s.QUICLossObservedPackets)
 	}
-	if s.QUICLossObservedPackets != s.QUICLossSuppressedPackets+s.QUICControllerPacketsLost {
-		t.Fatalf("observed %d != suppressed %d + charged %d",
-			s.QUICLossObservedPackets, s.QUICLossSuppressedPackets, s.QUICControllerPacketsLost)
+	if s.QUICLossObservedPackets != s.QUICControllerPacketsLost {
+		t.Fatalf("observed %d != charged %d; nothing is withheld from the controller any more",
+			s.QUICLossObservedPackets, s.QUICControllerPacketsLost)
 	}
 	// And the loss rate a dashboard would derive is the channel's, not the
 	// controller's. Publishing only the charged figure understated a fifth of
 	// downstream erasure as a few percent.
-	observed := 100 * float64(s.QUICLossObservedPackets) / float64(s.QUICPacketsSent)
-	charged := 100 * float64(s.QUICControllerPacketsLost) / float64(s.QUICPacketsSent)
-	if observed <= charged*2 {
-		t.Fatalf("observed %.1f%% and charged %.1f%% are too close to be distinguishable", observed, charged)
+	if observed := 100 * float64(s.QUICLossObservedPackets) / float64(s.QUICPacketsSent); observed < 15 {
+		t.Fatalf("observed loss rate reads %.1f%% against 160 losses in 800 packets", observed)
 	}
 }
 
@@ -450,7 +445,7 @@ func TestObservedLossIsTheSumOfChargedAndSuppressedAcrossConnections(t *testing.
 // only ever move forward from what a connection actually reported.
 func TestLossTotalsOnlyMoveForward(t *testing.T) {
 	r := New()
-	r.AddQUICConnectionCounters(QUICConnectionCounters{LossObservedPackets: 50, LossSuppressedPackets: 40})
+	r.AddQUICConnectionCounters(QUICConnectionCounters{LossObservedPackets: 50})
 	before := r.Snapshot()
 	// quic-go may withdraw a loss it decides was reordering, and a pooled
 	// connection replaced by a fresh generation restarts at zero.
@@ -458,9 +453,6 @@ func TestLossTotalsOnlyMoveForward(t *testing.T) {
 	after := r.Snapshot()
 	if after.QUICLossObservedPackets < before.QUICLossObservedPackets {
 		t.Fatalf("observed total fell from %d to %d", before.QUICLossObservedPackets, after.QUICLossObservedPackets)
-	}
-	if after.QUICLossSuppressedPackets < before.QUICLossSuppressedPackets {
-		t.Fatalf("suppressed total fell from %d to %d", before.QUICLossSuppressedPackets, after.QUICLossSuppressedPackets)
 	}
 }
 
@@ -472,14 +464,11 @@ func TestLossTotalsOnlyMoveForward(t *testing.T) {
 func TestTheMeasuredErasureIsPublishedBesideTheFloorAndLabelledByDirection(t *testing.T) {
 	r := New()
 	r.ObserveQUIC(1, QUICObservation{
-		ControllerKind: "erasure", ControllerErasure: 0.199, ControllerErasureFloor: 0.0176,
+		ControllerKind: "erasure", ControllerErasure: 0.199,
 	})
 	s := r.Snapshot()
 	if s.QUICErasureSend != 0.199 {
 		t.Fatalf("measured send erasure = %v, want 0.199", s.QUICErasureSend)
-	}
-	if s.QUICControllerErasureFloor != 0.0176 {
-		t.Fatalf("floor = %v, want 0.0176", s.QUICControllerErasureFloor)
 	}
 
 	rec := httptest.NewRecorder()
@@ -487,7 +476,6 @@ func TestTheMeasuredErasureIsPublishedBesideTheFloorAndLabelledByDirection(t *te
 	body := rec.Body.String()
 	for _, want := range []string{
 		`queqiao_erasure_ratio{direction="send"} 0.199000000`,
-		"queqiao_quic_controller_erasure_floor_ratio 0.017600000",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("exposition is missing %q", want)
@@ -501,9 +489,9 @@ func TestTheMeasuredErasureIsPublishedBesideTheFloorAndLabelledByDirection(t *te
 // single lane right now" and jump between 1.8% and 6.9% within minutes.
 func TestErasureFoldsAcrossEndpointPairsNotLanes(t *testing.T) {
 	r := New()
-	r.ObserveQUIC(1, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.05, ControllerErasureFloor: 0.01})
-	r.ObserveQUIC(2, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.30, ControllerErasureFloor: 0.02})
-	r.ObserveQUIC(3, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.10, ControllerErasureFloor: 0.03})
+	r.ObserveQUIC(1, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.05})
+	r.ObserveQUIC(2, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.30})
+	r.ObserveQUIC(3, QUICObservation{ControllerKind: "erasure", ControllerErasure: 0.10})
 	if s := r.Snapshot(); s.QUICErasureSend != 0.30 {
 		t.Fatalf("send erasure = %v across three pairs, want the worst at 0.30", s.QUICErasureSend)
 	}

--- a/internal/pathmodel/pathmodel.go
+++ b/internal/pathmodel/pathmodel.go
@@ -68,8 +68,6 @@ type PathModel struct {
 }
 
 type pathKnowledge struct {
-	floor           float64
-	floorKnown      bool
 	erasure         float64
 	burst           float64
 	erasureKnown    bool
@@ -82,8 +80,6 @@ type pathKnowledge struct {
 type Member uint64
 
 type report struct {
-	floor     float64
-	samples   float64
 	erasure   float64
 	burst     float64
 	observed  float64
@@ -104,12 +100,6 @@ type report struct {
 // serve both, so the model pools both and each consumer reads the one whose
 // error it can survive.
 type Observation struct {
-	// Floor is the erasure this contributor's controller has established as
-	// independent of its sending rate, and FloorSamples is the weight behind
-	// it. A contributor with no trustworthy estimate reports zero weight
-	// rather than diluting a floor another lane has established.
-	Floor        float64
-	FloorSamples float64
 	// Erasure is the loss rate this contributor measured, unclassified, and
 	// BurstFactor is how much of it arrived in runs. Both are what a code has
 	// to be sized against; neither is safe to pace from.
@@ -128,11 +118,6 @@ type Observation struct {
 // State is what an endpoint pair has been measured to do, from the point of
 // view of one contributor.
 type State struct {
-	// Floor is the erasure rate that does not respond to sending more slowly,
-	// pooled across every lane's samples. It is deliberately conservative and
-	// is for pacing; a code sized from it under-protects the path. See
-	// Observation.
-	Floor float64
 	// Erasure is the loss rate the contributors measured on the direction they
 	// send into, pooled and unclassified, and BurstFactor is how much of it
 	// arrived in runs. This is what a code is sized against.
@@ -215,7 +200,6 @@ func (m *PathModel) Report(member Member, o Observation) State {
 		entry = &report{}
 		m.members[member] = entry
 	}
-	entry.floor, entry.samples = o.Floor, o.FloorSamples
 	entry.erasure, entry.burst = o.Erasure, o.BurstFactor
 	entry.observed, entry.delivered, entry.at = o.ObservedSamples, o.Delivered, now
 	if o.RoundTrip > 0 {
@@ -223,7 +207,7 @@ func (m *PathModel) Report(member Member, o Observation) State {
 	}
 
 	var state State
-	var weighted, weight, observed, sum float64
+	var observed, sum float64
 	var erasureWeighted, burstWeighted float64
 	live := 0
 	for key, other := range m.members {
@@ -235,21 +219,12 @@ func (m *PathModel) Report(member Member, o Observation) State {
 		sum += other.delivered
 		// A lane with few samples should not move the pooled estimate much,
 		// which is also what lets a new lane join without disturbing it.
-		weighted += other.floor * other.samples
-		weight += other.samples
 		erasureWeighted += other.erasure * other.observed
 		burstWeighted += other.burst * other.observed
 		observed += other.observed
 		if other.roundTrip > 0 && (state.RoundTrip == 0 || other.roundTrip < state.RoundTrip) {
 			state.RoundTrip = other.roundTrip
 		}
-	}
-	if weight > 0 {
-		state.Floor = weighted / weight
-		m.knowledge.floor = state.Floor
-		m.knowledge.floorKnown = true
-	} else if m.knowledge.floorKnown {
-		state.Floor = m.knowledge.floor
 	}
 	if observed > 0 {
 		state.Erasure = erasureWeighted / observed
@@ -320,7 +295,7 @@ func (m *PathModel) Current() State {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var state State
-	var weighted, weight, observed, bottleneck float64
+	var observed, bottleneck float64
 	var erasureWeighted, burstWeighted float64
 	live := 0
 	for key, entry := range m.members {
@@ -329,21 +304,12 @@ func (m *PathModel) Current() State {
 			continue
 		}
 		live++
-		weighted += entry.floor * entry.samples
-		weight += entry.samples
 		erasureWeighted += entry.erasure * entry.observed
 		burstWeighted += entry.burst * entry.observed
 		observed += entry.observed
 		if entry.roundTrip > 0 && (state.RoundTrip == 0 || entry.roundTrip < state.RoundTrip) {
 			state.RoundTrip = entry.roundTrip
 		}
-	}
-	if weight > 0 {
-		state.Floor = weighted / weight
-		m.knowledge.floor = state.Floor
-		m.knowledge.floorKnown = true
-	} else if m.knowledge.floorKnown {
-		state.Floor = m.knowledge.floor
 	}
 	if observed > 0 {
 		state.Erasure = erasureWeighted / observed

--- a/internal/pathmodel/pathmodel_test.go
+++ b/internal/pathmodel/pathmodel_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// The floor is pooled so that four lanes reach a usable estimate on four
+// The erasure is pooled so that four lanes reach a usable estimate on four
 // lanes' worth of samples rather than each waiting for its own, and so that
 // they agree. Lanes that disagree compensate differently and the aggregate
 // stops being predictable.
@@ -14,18 +14,18 @@ func TestTheFloorIsPooledAcrossLanes(t *testing.T) {
 	m := NewPathModel()
 	// Three lanes with plenty of samples agree on 0.42; a fourth has just
 	// started and has seen almost nothing.
-	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
-	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
-	m.Report(3, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
-	floor := m.Report(4, Observation{Floor: 0.05, FloorSamples: 20, Erasure: 0.05, BurstFactor: 1, ObservedSamples: 20, Delivered: 1e6, RoundTrip: 0}).Floor
+	m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(2, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(3, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	erasure := m.Report(4, Observation{Erasure: 0.05, BurstFactor: 1, ObservedSamples: 20, Delivered: 1e6}).Erasure
 
-	if math.Abs(floor-0.42) > 0.01 {
-		t.Fatalf("pooled floor %.3f, want the weight of the measured lanes at about 0.42", floor)
+	if math.Abs(erasure-0.42) > 0.01 {
+		t.Fatalf("pooled erasure %.3f, want the weight of the measured lanes at about 0.42", erasure)
 	}
 	// And the new lane is handed that estimate rather than its own, so it does
 	// not have to rediscover the path.
-	if floor < 0.4 {
-		t.Fatalf("a joining lane was left with its own uninformed floor of %.3f", floor)
+	if erasure < 0.4 {
+		t.Fatalf("a joining lane was left with its own uninformed erasure of %.3f", erasure)
 	}
 }
 
@@ -35,10 +35,10 @@ func TestTheFloorIsPooledAcrossLanes(t *testing.T) {
 func TestTheShareDividesTheBottleneck(t *testing.T) {
 	m := NewPathModel()
 	const perLane = 1e6 // bytes per second
-	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
-	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
-	m.Report(3, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
-	share := m.Report(4, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0}).Share
+	m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	m.Report(2, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	m.Report(3, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0})
+	share := m.Report(4, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: perLane, RoundTrip: 0}).Share
 
 	if m.Members() != 4 {
 		t.Fatalf("model counts %d lanes, want 4", m.Members())
@@ -60,26 +60,26 @@ func TestTheShareDividesTheBottleneck(t *testing.T) {
 // A lane on its own must not be capped by a bottleneck nobody has measured.
 func TestAnUnknownBottleneckDoesNotCap(t *testing.T) {
 	m := NewPathModel()
-	if share := m.Report(1, Observation{Floor: 0, FloorSamples: 0, Erasure: 0, BurstFactor: 1, ObservedSamples: 0, Delivered: 0, RoundTrip: 0}).Share; share != 0 {
+	if share := m.Report(1, Observation{Erasure: 0, BurstFactor: 1, ObservedSamples: 0, Delivered: 0, RoundTrip: 0}).Share; share != 0 {
 		t.Fatalf("share %.0f before any delivered rate was reported, want 0 for no cap", share)
 	}
 }
 
 func TestObservationProgressDoesNotWeightAnUntrustedFloor(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
-	state := m.Report(2, Observation{Floor: 0, FloorSamples: 0, Erasure: 0, BurstFactor: 1, ObservedSamples: 120, Delivered: 0, RoundTrip: 0})
+	m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	state := m.Report(2, Observation{Erasure: 0, BurstFactor: 1, ObservedSamples: 120, Delivered: 0, RoundTrip: 0})
 	if state.ObservedSamples != 5120 {
 		t.Fatalf("observed samples = %.0f, want 5120", state.ObservedSamples)
 	}
-	if math.Abs(state.Floor-0.42) > 0.001 {
-		t.Fatalf("untrusted zero diluted established floor to %.3f", state.Floor)
+	if math.Abs(state.Erasure-0.42) > 0.02 {
+		t.Fatalf("a contributor with few samples diluted the pooled erasure to %.3f", state.Erasure)
 	}
 }
 
 func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 240 * time.Millisecond})
+	m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 240 * time.Millisecond})
 
 	// Membership governs only concurrent bandwidth sharing. Simulate a lane
 	// going idle without making a five-second unit test: the measurement must
@@ -89,8 +89,8 @@ func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 	m.mu.Unlock()
 
 	state := m.Current()
-	if state.Floor != 0.42 {
-		t.Fatalf("retained floor = %.3f, want 0.420", state.Floor)
+	if state.Erasure != 0.42 {
+		t.Fatalf("retained erasure = %.3f, want 0.420", state.Erasure)
 	}
 	if state.ObservedSamples != 5000 {
 		t.Fatalf("retained observations = %.0f, want 5000", state.ObservedSamples)
@@ -104,9 +104,9 @@ func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 
 	// Retained knowledge is a handoff, not a permanent verdict. Once a new
 	// connection supplies trusted evidence, it becomes the path's knowledge.
-	changed := m.Report(2, Observation{Floor: 0.55, FloorSamples: 5000, Erasure: 0.55, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 300 * time.Millisecond})
-	if changed.Floor != 0.55 {
-		t.Fatalf("new generation floor = %.3f, want 0.550", changed.Floor)
+	changed := m.Report(2, Observation{Erasure: 0.55, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 300 * time.Millisecond})
+	if changed.Erasure != 0.55 {
+		t.Fatalf("new generation erasure = %.3f, want 0.550", changed.Erasure)
 	}
 }
 
@@ -115,8 +115,8 @@ func TestPathKnowledgeOutlivesTheConnectionThatMeasuredIt(t *testing.T) {
 // controller, so membership has to expire.
 func TestAnIdleLaneStopsCounting(t *testing.T) {
 	m := NewPathModel()
-	m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
-	m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	m.Report(2, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
 	if m.Members() != 2 {
 		t.Fatalf("members = %d, want 2", m.Members())
 	}
@@ -125,7 +125,7 @@ func TestAnIdleLaneStopsCounting(t *testing.T) {
 	m.members[1].at = time.Now().Add(-2 * memberIdle)
 	m.mu.Unlock()
 
-	state := m.Report(2, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
+	state := m.Report(2, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 1e6, RoundTrip: 0})
 	if m.Members() != 1 {
 		t.Fatalf("members = %d after one went idle, want 1", m.Members())
 	}
@@ -156,7 +156,7 @@ func TestSharedPathIsPerPeer(t *testing.T) {
 func TestASingleSharedLaneIsNotPenalised(t *testing.T) {
 	m := NewPathModel()
 	const rate = 2e6
-	state := m.Report(1, Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
+	state := m.Report(1, Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: rate, RoundTrip: 0})
 	// Not capped at its own rate: not capped at all. A lone lane has nothing
 	// to compound with, and a ceiling equal to what it has already delivered
 	// is one it can never probe past.
@@ -202,7 +202,7 @@ func TestTheShareDoesNotRatchetDown(t *testing.T) {
 			var share float64
 			for round := 0; round < 40; round++ {
 				for i := 0; i < lanes; i++ {
-					share = m.Report(Member(i+1), Observation{Floor: 0.1, FloorSamples: 5000, Erasure: 0.1, BurstFactor: 1, ObservedSamples: 5000, Delivered: delivered[i], RoundTrip: 0}).Share
+					share = m.Report(Member(i+1), Observation{Erasure: 0.1, BurstFactor: 1, ObservedSamples: 5000, Delivered: delivered[i], RoundTrip: 0}).Share
 					// The next round delivers what this one is allowed to,
 					// bounded by the path itself.
 					next := capacity / float64(lanes)

--- a/internal/pep/codedlane_test.go
+++ b/internal/pep/codedlane_test.go
@@ -492,13 +492,11 @@ func measuredErasure(t *testing.T) float64 {
 func measuredErasureAndFloor(t *testing.T) (erasure, floor float64) {
 	t.Helper()
 	for _, model := range pathmodel.Live() {
-		state := model.Current()
-		if state.Erasure > erasure {
+		if state := model.Current(); state.Erasure > erasure {
 			erasure = state.Erasure
-			floor = state.Floor
 		}
 	}
-	return erasure, floor
+	return erasure, 0
 }
 
 // The delay bound, against a real queue rather than a supplied round trip.

--- a/internal/pep/conntelemetry.go
+++ b/internal/pep/conntelemetry.go
@@ -112,7 +112,6 @@ func connectionCounters(stats laneTransportStats) metrics.QUICConnectionCounters
 		PacketsSent:             stats.packetsSent,
 		PacketsReceived:         stats.packetsReceived,
 		LossObservedPackets:     stats.controller.PacketsLostObserved,
-		LossSuppressedPackets:   stats.controller.PacketsLostSuppressed,
 		CodedSources:            stats.codedSources,
 		CodedRecovered:          stats.codedRecovered,
 		CodedLost:               stats.codedLost,

--- a/internal/pep/initiation_test.go
+++ b/internal/pep/initiation_test.go
@@ -232,7 +232,7 @@ func TestThePrewarmLeavesTheUplinkMeasured(t *testing.T) {
 	key := pathKey(loopback, loopback)
 
 	// Start from nothing known about this uplink.
-	before := pathmodel.Shared(key).Current().Floor
+	before := pathmodel.Shared(key).Current().Erasure
 
 	// ServeListener starts the production uplink watcher, which performs one
 	// automatic prewarm. Calling prewarmPath here as well used to race a
@@ -244,7 +244,7 @@ func TestThePrewarmLeavesTheUplinkMeasured(t *testing.T) {
 	deadline := time.Now().Add(prewarmTimeout + 5*time.Second)
 	var after float64
 	for time.Now().Before(deadline) {
-		after = pathmodel.Shared(key).Current().Floor
+		after = pathmodel.Shared(key).Current().Erasure
 		if after > 0 {
 			break
 		}

--- a/internal/pep/lanetrace.go
+++ b/internal/pep/lanetrace.go
@@ -59,7 +59,7 @@ func traceLane(f *multipathFlow, laneID uint64, stats laneTransportStats) {
 		"t", time.Since(traceStart).Seconds(), "flow", fmt.Sprintf("%p", f), "flow_id", f.flowID, "lane", laneID,
 		"cwnd", c.CongestionWindow, "inflight", c.BytesInFlight,
 		"minrtt", float64(c.MinRTT.Microseconds())/1000, "srtt", float64(stats.smoothedRTT.Microseconds())/1000,
-		"pacing", c.PacingRate, "maxbw", c.MaxBandwidth, "floor", c.ErasureFloor,
+		"pacing", c.PacingRate, "maxbw", c.MaxBandwidth, "erasure", c.Erasure,
 		"round", c.Round, "appsamp", c.AppSamples, "nonapp", c.NonAppSamples,
 		"window", window, "held", held, "queued", queued, "chunks", chunks, "ready", ready, "flowheld", flowHeld,
 		"issued", issued, "reissued", reissued, "source", sourceBytes, "breissued", reissuedBytes, "lanefail", laneFailures,
@@ -70,8 +70,7 @@ func traceLane(f *multipathFlow, laneID uint64, stats laneTransportStats) {
 		// What the path did, not what the controller was charged. quic-go's own
 		// loss counters are absent because this transport replaces its
 		// congestion controller, so they never leave zero.
-		"lost", c.PacketsLostObserved, "lostsupp", c.PacketsLostSuppressed,
-		"lostcong", c.PacketsLost, "mode", c.Mode)
+		"lost", c.PacketsLostObserved, "lostcong", c.PacketsLost, "mode", c.Mode)
 }
 
 // residency records how long a chunk stays in the scheduler's window: from the

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -699,9 +699,6 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 			if controller.DelayBrake > observation.ControllerDelayBrake {
 				observation.ControllerDelayBrake = controller.DelayBrake
 			}
-			if controller.ErasureFloor > observation.ControllerErasureFloor {
-				observation.ControllerErasureFloor = controller.ErasureFloor
-			}
 			observation.ControllerInRecovery = observation.ControllerInRecovery || controller.InRecovery
 		}
 	}

--- a/internal/pep/smallflow_test.go
+++ b/internal/pep/smallflow_test.go
@@ -164,7 +164,7 @@ func TestSmallExchangesAreRepairedOnceThePathIsKnown(t *testing.T) {
 	// learns this from its own traffic or from the prewarm; only the floor is
 	// seeded, because a delivered rate would also claim a share of the
 	// bottleneck and that is a different experiment.
-	pathmodel.Shared(key).Report(99, pathmodel.Observation{Floor: 0.42, FloorSamples: 5000, Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
+	pathmodel.Shared(key).Report(99, pathmodel.Observation{Erasure: 0.42, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
 	knowingSamples := exchange(10, time.Minute)
 	knowing := median(knowingSamples)
 
@@ -828,7 +828,7 @@ func TestAShortFlowCostsARoundTrip(t *testing.T) {
 	// timing test explicitly so scheduler speed under -race cannot decide how
 	// many of its measured flows run before the asynchronous prewarm finishes.
 	loopback := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
-	pathmodel.Shared(pathKey(loopback, loopback)).Report(99, pathmodel.Observation{Floor: path.LossRate, FloorSamples: 5000, Erasure: path.LossRate, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
+	pathmodel.Shared(pathKey(loopback, loopback)).Report(99, pathmodel.Observation{Erasure: path.LossRate, BurstFactor: 1, ObservedSamples: 5000, Delivered: 0, RoundTrip: 0})
 	// Warm the shared transport independently of the path measurement.
 	warm := dialWithRetries(t, socks, destination, 3)
 	request := make([]byte, 16)


### PR DESCRIPTION
The last sequencing step from `docs/CONTROL-REDESIGN.md`. The controller
separated erasure from congestion statistically and forwarded only the share the
channel could not explain. That separation is gone.

It was a statistical answer to a question the delivery-versus-rate curve answers
directly — erasure scales delivery down proportionally at every rate and cannot
produce a knee; congestion produces one. And it was **least reliable exactly
when loss was worst**, because heavy erasure is bursty and the burst test then
refused to call it erasure at all: on the incident path it read a floor of 1.76%
against a measured 19.9%.

## Losses still reach the controller

This is the part that isn't obvious. `bytesInFlight` is `priorInFlight` less
what was acknowledged **and what was lost**, so a controller told about only a
fraction of the losses believes the pipe is fuller than it is and throttles
itself for packets that are already gone.

So what changed is not that the controller hears less — it now hears everything
— but that it no longer *enters recovery* on what it hears. `TUICBBRSender`
gains `lossIsCongestion`: true for a sender used on its own, so the benchmark
reference keeps TUIC's behaviour, and cleared by `ErasureSender`.

## What removing the classifier actually cost

The existing suite caught this, not a review.

A first flight can overrun a clean path's queue before the controller has found
its bottleneck. Those drops arrive in runs and are congestion. With the
compensation on the raw measurement, the sender compensates for its own queue
drops and **sends twice as fast into a queue that is already overflowing** —
precisely the positive feedback the classifier existed to prevent.

The delay bound from #63 cannot stop it: at that moment there is no minimum
round trip to bound against, so the brake is inert. **The two safeguards did not
overlap the way the sequencing assumed.**

The resolution is a coupling, not a restored classifier: **compensation waits
for a measured minimum round trip**, which is exactly when the brake can act. It
makes no judgement about what kind of loss it is seeing. Before that the sender
is plain BBR that ignores loss — it neither compensates nor collapses.

`TestClusteredStartupLossDoesNotBecomeAnErasureFloor` predates this work and now
holds the new arrangement unchanged, which is the strongest available evidence
that the property survived the mechanism.

## Verified against the failure that motivated the classifier

On the emulated 42% erasure channel, a 48 KB flow crosses in **640 ms / 1.169 s
/ 1.193 s**, against **1.101 s** with suppression in place. No collapse — where
the documented failure with a loss-responsive controller is 0.39 Mbit/s. A unit
test asserts the controller does not enter recovery on a 42% channel at all.

## Metrics removed

`queqiao_quic_controller_erasure_floor_ratio` and
`queqiao_quic_loss_suppressed_packets_total`. There is no floor any more and
nothing is withheld, so neither can be produced — and by the standard set in
#55, a counter that cannot be produced is worse than a missing one once it is
monotonic. `pathmodel` drops `Floor` and `FloorSamples` for the same reason.
`queqiao_erasure_ratio{direction="send"}` is the measurement that replaced the
first.

## Checks

`go test -short ./...` green across 27 packages · full `internal/pep` 145 s,
`internal/coded` 45 s, `internal/congestion`, `internal/pathmodel` · `go test
-race` on `internal/congestion` · `go vet` · `gofmt` · `staticcheck
-checks=all,-U1000` on the whole tree · gosec baseline (133 reviewed, none
unreviewed) · `./scripts/changelog.py check`.

One flake seen once under full-suite load and not reproducible in four isolated
runs: `TestQUICOneLaneSOCKSEndToEnd` i/o timeout.

## What remains

Falsification case 4 — a shallow dropper that erases at capacity without
building a queue — is still open and is now the only thing between this design
and having no unbraked path class. With loss no longer a signal and no queue to
measure, that case has nothing to brake on, and the honest outcome may be to
document it as unbraked.

`kindReport` (the receiver report closing the residual loop) is the remaining
sequencing item.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
