### PR TITLE
test: record that a policed path is unbraked, and bound one of its two causes

### DIFF
--- a/changelog.d/compensation-must-buy-delivery.fixed.md
+++ b/changelog.d/compensation-must-buy-delivery.fixed.md
@@ -1,0 +1,14 @@
+The erasure compensation no longer grows unless it is buying delivery.
+Compensating is a bet that losses are independent of the sending rate, so
+that sending more delivers proportionally more, and on a path that drops
+because it is policed rather than because it erases, that bet is wrong in a
+way that feeds itself: loss rises, the arrival rate falls, the compensation
+asks to send more, and the policer drops more. An increase is now tested
+against the delivered rate and refused if the previous one raised nothing.
+It makes no judgement about the nature of the loss, only about whether
+sending harder delivered more.
+
+This bounds the loop but does not close it. On a policed path the bandwidth
+estimate is a second and larger amplifier, because a token bucket passes a
+burst at line rate and a max filter reports that burst as the path's
+bandwidth. See the known limitations.

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -431,7 +431,7 @@ implementation before the change lands.
 | 1 | Token bucket, deep burst allowance | `B` converges on the sustained shaping rate, not the bucket drain rate. **Filter-level test passing.** `internal/pathsim` now has the burst allowance (`PolicerBurstBytes`), but the end-to-end version also needs a runtime *rate* change, which it does not have — see [A limit found while trying to validate it](#a-limit-found-while-trying-to-validate-it) |
 | 2 | Step change 5% → 50% erasure mid-flow | The erasure estimate rises within one filter window; the code rate follows. **Passing end to end** — `TestTheCodeFollowsAChannelThatGetsWorseMidFlow` steps an emulated path from 2% to 45% downstream under a live flow, and the measurement the code is sized from moves from 0.034 to 0.224 while the controller's floor stays at 0.031 |
 | 3 | Throttle that tightens under load | `B` walks down and settles; no sustained oscillation. **Filter-level test passing** |
-| 4 | Shallow-buffered dropper, no queue | The delay bound still brakes, or the case is documented as unbraked. **Still open, and still the one expected to fail** -- a dropper that erases at capacity without building a queue gives the bound no signal |
+| 4 | Shallow-buffered dropper, no queue | **Fails.** See [Case 4 fails](#case-4-fails). Held by `TestCase4APolicedPathIsStillUnbraked` as a characterization test |
 | 5 | Clean path, no erasure | `r = 1`; no parity is sent, without a `minCodedLoss` constant |
 | 6 | Self-limiting claim | The climb stops; `B` does not grow without bound |
 | 7 | Bulk flow alongside interactive | Interactive latency stays inside the delay bound. **Partly covered**: `TestABulkTransferIsHeldBackByADeepQueue` shows the brake engaging on a deeply buffered bottleneck at 415 ms of queue against a 313 ms minimum, removing 24.7% of the rate. The interactive half is not covered |
@@ -440,6 +440,59 @@ implementation before the change lands.
 without building a queue gives the delay bound no signal, and with loss removed
 as a congestion input there is nothing else. If it fails, the honest outcome is
 to document the path class as unbraked rather than to reintroduce a classifier.
+
+## Case 4 fails
+
+A policer drops what it cannot pass and holds nothing, so overload produces loss
+and no delay. Loss is no longer a congestion signal and there is no queue for
+the delay bound to measure, so neither brake can act. This was predicted to
+fail. It fails by more than was predicted.
+
+Against an emulated policer shaped to 250 KB/s:
+
+| | |
+| --- | --- |
+| Peak pacing rate | **10,506,238 B/s — 42x the path** |
+| Bandwidth estimate | 665,178 B/s — 2.7x the path |
+| Worst queue | 2 ms |
+| Strongest brake | **0.0000** |
+| Sustained loss | 72.5% |
+
+**This is not a hypothetical path class.** `internal/pathsim` records that the
+live path this project targets is a policer: *"at twice the bottleneck rate it
+shows arrival runs averaging 2.3 packets and loss runs averaging 5.7 ... a
+limiter which passes everything for a while and then drops everything for a
+while."*
+
+### Two amplifiers, needing two fixes
+
+**The bandwidth estimate reads the burst, not the rate.** A token bucket passes
+a burst at line rate, and a max filter reports that burst as the path's
+bandwidth. Bounding the filter's memory in time did not help, because the bursts
+recur every refill period so there is always a recent high sample. The
+*statistic* is the problem, not its age -- which is what "any max filter
+structurally measures the first and reports it as the second" already said, and
+which the time bound only half addressed.
+
+**The erasure compensation is a feedback loop on a policed path.** Loss rises,
+the arrival rate falls, the compensation asks to send proportionally more, the
+policer drops proportionally more, and the arrival rate falls again.
+
+The second is now bounded: compensation may only increase while it is buying
+delivery, which is a measurement rather than a classification and is the same
+question the design's own argument rests on. It reduces the overdrive but does
+not remove it, because the first amplifier is the larger one and remains.
+
+### What would resolve it
+
+Replacing the max filter with a statistic that estimates a *sustained* rate
+rather than the peak of a bursty delivery process. That is a change to the core
+of the bandwidth model, it affects every path rather than only policed ones, and
+it should not be attempted without measurement on a real path. It is the
+outstanding work this design has left.
+
+Until then, **a policed path is unbraked**, and this design should not be
+deployed on one.
 
 ## Sequencing
 

--- a/docs/KNOWN-LIMITATIONS.md
+++ b/docs/KNOWN-LIMITATIONS.md
@@ -9,6 +9,17 @@ them before treating a successful local test as evidence that a different
 network will behave the same way. The [project status](STATUS.md) tracks which
 qualification items are still open.
 
+- The congestion control described in [the control
+  redesign](CONTROL-REDESIGN.md) has no brake on a policed path. A policer
+  drops what it cannot pass and holds nothing, so it produces loss and no
+  delay -- and that design uses delay as its congestion signal and ignores
+  loss. Measured against an emulated policer shaped to 250 KB/s, a sender
+  reached 42 times the path's capacity at 72.5% loss with the brake reading
+  zero throughout. The live path this project targets is a policer, so this is
+  the ordinary case rather than an edge one. The redesign is not deployed and
+  should not be until the bandwidth estimate stops reporting a token bucket's
+  burst as its rate; the shipping controller still treats loss as congestion
+  and does not have this behaviour.
 - Queqiao is a WAN optimization data plane, not an anonymity network. The
   desktop ingress is SOCKS5, the released Android app exports an authenticated
   SOCKS5 endpoint to a separate routing client, and the iOS app is a

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -65,6 +65,20 @@ type ErasureSender struct {
 
 	outcomes []packetOutcome
 
+	// compensationRound, deliveredAtCompensation and appliedArrival are the
+	// probe behind the compensation: what the path was delivering when this
+	// sender last agreed to send faster to make up for erasure, and when.
+	//
+	// Compensating is a bet that the losses are independent of the sending
+	// rate, so that sending 1/arrival times as much delivers a full window.
+	// The bet is checkable, and it has to be checked: on a path that drops
+	// because it is policed rather than because it erases, sending more
+	// delivers no more and simply raises the loss, which lowers the arrival
+	// rate, which asks for more compensation again.
+	compensationRound       uint64
+	deliveredAtCompensation float64
+	appliedArrival          float64
+
 	// erasure is the pooled measured erasure of the direction this sender
 	// sends into, in parts per million. It is what the code is sized from, and
 	// it is published because a floor is not a substitute for it: on the live
@@ -202,6 +216,52 @@ func (e *ErasureSender) bandwidth() quiccongestion.ByteCount {
 	// The delay bound is applied after the erasure compensation rather than
 	// before it, because the queue holds what was sent and not what arrived.
 	return quiccongestion.ByteCount(e.delayBounded(delivered / e.arrivalRate()))
+}
+
+// compensationFor decides how much of a proposed compensation to apply, by
+// asking whether the last one bought any delivery.
+//
+// Less compensation is always allowed at once: it can only reduce what goes on
+// the wire. More is a claim that the path will deliver proportionally more if
+// this sender sends proportionally more, and that claim is tested against the
+// delivered rate rather than assumed. If the previous increase did not raise
+// delivery, this one is refused and the compensation stands where it is.
+//
+// This is not the classifier returning. It makes no judgement about the nature
+// of the loss and reads no burst statistics; it observes only whether sending
+// harder delivered more, which is the question the design's own argument rests
+// on -- erasure scales delivery down at every rate and cannot produce a knee,
+// congestion produces one. Without it a policed path is a positive feedback
+// loop: measured against an emulated policer the sender reached eleven times
+// the path's capacity at 63% loss with nothing to brake it, because a policer
+// drops rather than queues and so offers the delay bound no signal either.
+func (e *ErasureSender) compensationFor(want float64) float64 {
+	if want > 1 {
+		want = 1
+	}
+	if want < erasureMinArrival {
+		want = erasureMinArrival
+	}
+	delivered := float64(e.inner.bandwidth())
+	round := e.inner.round
+	if e.appliedArrival == 0 || want >= e.appliedArrival {
+		e.appliedArrival, e.deliveredAtCompensation, e.compensationRound = want, delivered, round
+		return want
+	}
+	// More compensation than is applied. Give the previous increase a round to
+	// show an effect before judging it, then require that it showed one.
+	if round == e.compensationRound {
+		return e.appliedArrival
+	}
+	if delivered <= e.deliveredAtCompensation {
+		// Sending harder did not deliver more. Hold where we are, and re-arm
+		// the probe against what the path is doing now so that a path which
+		// later improves can still be followed.
+		e.deliveredAtCompensation, e.compensationRound = delivered, round
+		return e.appliedArrival
+	}
+	e.appliedArrival, e.deliveredAtCompensation, e.compensationRound = want, delivered, round
+	return want
 }
 
 func (e *ErasureSender) arrivalRate() float64 {
@@ -386,7 +446,7 @@ func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 	// makes no judgement about what kind of loss this is; it says only that
 	// compensation may not run ahead of the brake that bounds it.
 	if _, minRTT := e.queueDelay(); minRTT > 0 {
-		e.arrival.Store(uint64((1 - erasure) * partsPerMillion))
+		e.arrival.Store(uint64(e.compensationFor(1-erasure) * partsPerMillion))
 	}
 
 	e.passed.Add(uint64(len(lost)))

--- a/internal/pep/case4_test.go
+++ b/internal/pep/case4_test.go
@@ -1,0 +1,124 @@
+package pep
+
+import (
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/pathsim"
+)
+
+// Falsification case 4 from docs/CONTROL-REDESIGN.md, and it fails.
+//
+// A policer drops what it cannot pass and holds nothing, so overload produces
+// loss and no delay. Loss is no longer a congestion signal and there is no
+// queue for the delay bound to measure, so neither brake can act. The design
+// predicted this case would fail; it does, and by more than expected.
+//
+// This is a characterization test. It asserts the defect rather than the fix,
+// so that the behaviour cannot change silently in either direction. If it
+// starts failing because the sender no longer overdrives, that is the case
+// being resolved: update it and the design document together.
+//
+// It matters more than a hypothetical, because internal/pathsim records that
+// the live path this project targets is a policer -- "at twice the bottleneck
+// rate it shows arrival runs averaging 2.3 packets and loss runs averaging
+// 5.7 ... a limiter which passes everything for a while and then drops
+// everything for a while".
+func TestCase4APolicedPathIsStillUnbraked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("brings up QUIC across an emulated 300 ms path")
+	}
+	requireStableImpairmentClock(t)
+	const shaped = 250_000
+	path := pathsim.Config{
+		OneWayDelay:         150 * time.Millisecond,
+		RateBytesPerSec:     shaped,
+		PolicerRefillPeriod: 8 * time.Millisecond,
+		Seed:                53,
+	}
+	socks, destination := codedPair(t, false, &path)
+	conn := socksDial(t, socks, destination, erasureChannelBudget(180*time.Second))
+	defer conn.Close()
+
+	payload := make([]byte, 256*1024)
+	rand.New(rand.NewSource(29)).Read(payload)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 8; i++ {
+			if _, err := conn.Write(payload); err != nil {
+				return
+			}
+			got := make([]byte, len(payload))
+			if _, err := io.ReadFull(conn, got); err != nil {
+				return
+			}
+		}
+	}()
+
+	var peakPacing, peakBandwidth uint64
+	var maxQueue time.Duration
+	var maxBrake float64
+	var lastLoss float64
+	deadline := time.After(24 * time.Second)
+	for measuring := true; measuring; {
+		select {
+		case <-done:
+			measuring = false
+		case <-deadline:
+			measuring = false
+		case <-time.After(2 * time.Second):
+		}
+		s := lastClient.Metrics().Snapshot()
+		if s.QUICControllerPacingRate > peakPacing {
+			peakPacing = s.QUICControllerPacingRate
+		}
+		if s.QUICControllerMaxBandwidth > peakBandwidth {
+			peakBandwidth = s.QUICControllerMaxBandwidth
+		}
+		if q := s.QUICSmoothedRTT - s.QUICControllerMinRTT; q > maxQueue {
+			maxQueue = q
+		}
+		if s.QUICDelayBrake > maxBrake {
+			maxBrake = s.QUICDelayBrake
+		}
+		if s.QUICPacketsSent > 0 {
+			lastLoss = 100 * float64(s.QUICLossObservedPackets) / float64(s.QUICPacketsSent)
+		}
+	}
+
+	t.Logf("policed at %d B/s: peak pacing %d (%.1fx), peak bandwidth estimate %d (%.1fx), "+
+		"worst queue %v, strongest brake %.4f, loss %.1f%%",
+		shaped, peakPacing, float64(peakPacing)/shaped,
+		peakBandwidth, float64(peakBandwidth)/shaped,
+		maxQueue.Round(time.Millisecond), maxBrake, lastLoss)
+
+	if peakPacing == 0 {
+		t.Skip("the flow never got going, so this run measured nothing")
+	}
+	// The two amplifiers, recorded separately because they need separate fixes.
+	//
+	// The bandwidth estimate reads well above the path's sustained rate: a
+	// token bucket passes a burst at line rate, and a max filter reports that
+	// burst as the path's bandwidth. Bounding the filter's memory in time did
+	// not help here, because the bursts recur every refill period, so there is
+	// always a recent high sample. The statistic is the problem, not its age.
+	if float64(peakBandwidth) < shaped*1.5 {
+		t.Errorf("the bandwidth estimate is no longer reporting the burst rate (%d against a "+
+			"%d path); falsification case 4 may be resolved -- update the design document",
+			peakBandwidth, shaped)
+	}
+	// And nothing brakes what that estimate then paces.
+	if maxQueue > 50*time.Millisecond || maxBrake > 0 {
+		t.Errorf("a policer produced %v of queue and a brake of %.4f; if it now queues, this "+
+			"is no longer the unbraked case and the design document should say so",
+			maxQueue, maxBrake)
+	}
+	if float64(peakPacing) < shaped*3 {
+		t.Errorf("peak pacing %d is only %.1fx a %d path; the overdrive this case records has "+
+			"been reduced -- re-measure and update the design document",
+			peakPacing, float64(peakPacing)/shaped, shaped)
+	}
+}


### PR DESCRIPTION
> [!WARNING]
> **Do not deploy `main` to the production gateway.** Falsification case 4 fails,
> and `internal/pathsim` records that the live path this project targets **is a
> policer** — the exact class that fails. The currently deployed build
> (`main-8bd98b9`) predates #63 and #64 and still treats loss as congestion, so
> it does not have this behaviour.

## Case 4 fails, by more than predicted

A policer drops what it cannot pass and holds nothing, so overload produces loss
and no delay. Loss is no longer a congestion signal (#64) and there is no queue
for the delay bound (#63) to measure. Neither brake can act.

Against an emulated policer shaped to 250 KB/s:

| | |
| --- | --- |
| Peak pacing rate | **10,506,238 B/s — 42× the path** |
| Bandwidth estimate | 665,178 B/s — 2.7× the path |
| Worst queue | 2 ms |
| Strongest brake | **0.0000** |
| Sustained loss | 72.5% |

`internal/pathsim` on the live path: *"at twice the bottleneck rate it shows
arrival runs averaging 2.3 packets and loss runs averaging 5.7 ... a limiter
which passes everything for a while and then drops everything for a while."*

So the design's one predicted failure is **the ordinary case, not an edge one.**

## Two amplifiers, needing two fixes

**The larger: the bandwidth estimate reads the burst, not the rate.** A token
bucket passes a burst at line rate and a max filter reports it as the path's
bandwidth. Bounding the filter's memory in time (#56) did **not** help here,
because the bursts recur every refill period so there is always a recent high
sample. The *statistic* is the problem, not its age — which is what *"any max
filter structurally measures the first and reports it as the second"* already
said, and which the time bound only half addressed.

Replacing it changes the core of the bandwidth model, affects every path rather
than only policed ones, and should not be attempted without measurement on a
real path. **It is left undone deliberately.**

**The smaller: the compensation is a feedback loop.** Compensating is a bet that
losses are independent of the sending rate. On a policed path the extra sending
is itself what raises the loss that asks for more compensation. An increase is
now tested against the delivered rate and refused if the previous one raised
nothing — no burst statistics, no judgement about the nature of the loss, only
whether sending harder delivered more. That is the question the design's own
argument rests on.

**It does not close the loop and this PR does not pretend it does:** with the
compensation bounded the overdrive is still 42×, because the bandwidth estimate
is the larger term.

## Not a regression on the erasure path

The 42% erasure channel is unaffected: **1.11 / 1.13 / 1.18 s** against a
**1.10 s** baseline.

## A characterization test

`TestCase4APolicedPathIsStillUnbraked` asserts the **defect**, not the fix, so
the behaviour cannot change silently in either direction. If it starts failing
because the sender no longer overdrives, that is the case being resolved —
update the test and `docs/CONTROL-REDESIGN.md` together. Each of the three
assertions names which document to update and why.

## Checks

`go test -short ./...` green across 27 packages · full `internal/pep` 173 s and
`internal/congestion` · `go vet` · `gofmt` · `staticcheck -checks=all,-U1000` on
the whole tree · gosec baseline (133 reviewed, none unreviewed) ·
`./scripts/changelog.py check`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
