### PR TITLE
docs: record two rejected approaches to the sustained-rate estimate

### DIFF
--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -487,9 +487,49 @@ not remove it, because the first amplifier is the larger one and remains.
 
 Replacing the max filter with a statistic that estimates a *sustained* rate
 rather than the peak of a bursty delivery process. That is a change to the core
-of the bandwidth model, it affects every path rather than only policed ones, and
-it should not be attempted without measurement on a real path. It is the
-outstanding work this design has left.
+of the bandwidth model and affects every path rather than only policed ones.
+
+### What has been tried and does not work
+
+Recorded so that the next attempt starts further along than this one did.
+
+**Bounding the filter's memory in wall time.** The filter kept a sample for ten
+packet-timed rounds, which on an application-limited connection was sixty-six
+minutes; expiring samples in time as well as in rounds fixed that, and it is
+worth having. It does nothing for a policer. The bursts recur every refill
+period, so there is always a recent high sample and the estimate never has to
+fall back to anything. **Age was not the problem.**
+
+**Averaging the sample within a round.** The filter is fed the largest
+per-packet delivery rate in an acknowledgement batch. Each of those is bytes
+delivered over one packet's own send-to-ack window, and on a path that releases
+traffic in quanta those windows land unevenly across the releases, so their
+distribution has an upper tail and a maximum reports the tail. Feeding the
+filter one rate per round -- bytes delivered over the whole round -- should
+remove the tail while keeping what the maximum is for.
+
+It does not. Measured against the same emulated policer, the estimate moved
+from 2.7x the shaped rate to 3.6x and peak pacing from 42x to 37x, which is
+within run-to-run variation. **Not an improvement, and not shipped.** Why it
+fails is not established: the typical sample should already be about one round
+trip of delivery over about one round trip of time, which is the right answer,
+so either rounds are advancing faster than assumed or the delta and the
+interval are not the ones this reasoning assumes.
+
+**A synthetic estimator harness.** An attempt to drive the estimator directly
+with a known 250 KB/s delivery schedule reported 4,000 B/s. The harness was
+wrong, not the estimator, but the point stands: building a faithful path model
+inside a unit test is its own project, which is what `internal/pathsim` exists
+for. The emulator measures end to end and cannot isolate the estimator.
+
+### What the next attempt needs first
+
+Instrumentation, not a hypothesis. The sample interval and the delivered delta
+that produce each filter update, recorded on the emulated policer, would say in
+one run which of the two reasonings above is wrong. Three attempts have now been
+made by reasoning about what the code should be doing; each was refuted by
+measurement, and the third was refuted by a measurement that was itself broken.
+Measure the sampler before changing it again.
 
 Until then, **a policed path is unbraked**, and this design should not be
 deployed on one.

--- a/docs/KNOWN-LIMITATIONS.md
+++ b/docs/KNOWN-LIMITATIONS.md
@@ -19,7 +19,9 @@ qualification items are still open.
   the ordinary case rather than an edge one. The redesign is not deployed and
   should not be until the bandwidth estimate stops reporting a token bucket's
   burst as its rate; the shipping controller still treats loss as congestion
-  and does not have this behaviour.
+  and does not have this behaviour. Two approaches to that estimate have been
+  tried and rejected, and are recorded in the redesign document so that a third
+  does not repeat them.
 - Queqiao is a WAN optimization data plane, not an anonymity network. The
   desktop ingress is SOCKS5, the released Android app exports an authenticated
   SOCKS5 endpoint to a separate routing client, and the iOS app is a


### PR DESCRIPTION
**You asked me to fix the bigger problem. I could not, and this PR is the
honest result rather than a guess shipped as a fix.**

The bandwidth estimate reporting a token bucket's burst as its rate is what
leaves a policed path unbraked, and #65 established that a policed path is the
one this project targets. I tried two fixes. Neither worked. This records them
so the next attempt starts further along.

## What was tried

**Bounding the filter's memory in wall time** (already shipped in #56). It fixed
a real defect — ten packet-timed rounds is sixty-six minutes on an
application-limited connection — and it does **nothing** for a policer. The
bursts recur every refill period, so there is always a recent high sample and
the estimate never has to fall back to anything. **Age was not the problem.**

**Averaging the sample within a round.** This should have been the fix. The
filter is fed the *largest per-packet* delivery rate in an acknowledgement
batch; each is measured over one packet's own send-to-ack window, and on a path
releasing traffic in quanta those windows land unevenly, so the distribution has
an upper tail and a maximum reports the tail. Feeding one rate per round instead
— bytes delivered over the whole round — should remove the tail while keeping
what the maximum is for.

Measured on the same emulated policer:

| | Estimate | Peak pacing |
| --- | --- | --- |
| Before | 2.7× shaped | 42× |
| Round-averaged | **3.6× shaped** | 37× |

Run-to-run variation, not an improvement. **Not shipped.** Why it fails is not
established, and I am not going to invent a reason: the typical sample should
already be about one round trip of delivery over one round trip of time, which
is the right answer, so either rounds advance faster than I assumed or the delta
and interval are not the ones that reasoning assumes.

**A synthetic estimator harness.** Driving the estimator directly with a known
250 KB/s schedule reported 4,000 B/s. The harness was wrong, not the estimator —
but the lesson holds: a faithful path model inside a unit test is its own
project, which is what `internal/pathsim` is for, and the emulator measures end
to end and cannot isolate the sampler.

## What the next attempt needs

**Instrumentation, not a hypothesis.** The sample interval and the delivered
delta behind each filter update, recorded on the emulated policer, would say in
one run which of the two reasonings is wrong.

Three attempts have now been made by reasoning about what the code should be
doing. Each was refuted by measurement, and the third by a measurement that was
itself broken. Measure the sampler before changing it again.

## Why this is a documentation PR

Changing the core of the bandwidth model affects every path, not only policed
ones. I have had four design assumptions overturned by measurement in this work,
and the one I would be changing here governs the path you actually run. Shipping
an unvalidated rewrite of it — particularly one that measured slightly *worse* —
would be worse than shipping nothing.

The branch is otherwise identical to `main`: the round-averaging code was
reverted, not left behind a flag.

## Checks

`go test -short ./...` green across 27 packages at the reverted state ·
`./scripts/changelog.py check`. No code changes, so no changelog fragment.

## Changelog

- [ ] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [x] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
