### PR TITLE
fix: measure the sampler, then bound the bet that was actually wrong

### DIFF
--- a/changelog.d/compensation-earns-each-step.fixed.md
+++ b/changelog.d/compensation-earns-each-step.fixed.md
@@ -1,0 +1,20 @@
+The erasure compensation now starts at none and earns each increase. It is a
+bet that losses are independent of the sending rate, so that sending more
+delivers proportionally more, and on a path that drops because it is policed
+rather than because it erases, the bet feeds itself: sending more is what
+raises the loss that asks for more compensation. Each step is now a tenth of
+the remaining distance, small enough that the next round's delivery can be
+attributed to it, and is kept only if delivery actually improved.
+
+The previous version of this bound did not work, for two reasons that were
+mistakes in the bound rather than in the diagnosis. It accepted the first
+proposal whole, and by the time erasure is first measured the sender has
+already burst and been policed, so that proposal is for several times the
+rate with no evidence yet to test it against. And it judged the bet against
+the sender's pacing rate, which the compensation is itself an input to, so
+every increase appeared to have worked.
+
+Measured against an emulated policer the overdrive falls from 42 times the
+path's capacity to 7.3, and the loss from 72.5% to 49.8%. A 42% erasure
+channel is unaffected, which is what says the compensation has not simply
+been switched off.

--- a/docs/CONTROL-REDESIGN.md
+++ b/docs/CONTROL-REDESIGN.md
@@ -464,34 +464,40 @@ shows arrival runs averaging 2.3 packets and loss runs averaging 5.7 ... a
 limiter which passes everything for a while and then drops everything for a
 while."*
 
-### Two amplifiers, needing two fixes
+### Where the overdrive comes from
 
-**The bandwidth estimate reads the burst, not the rate.** A token bucket passes
-a burst at line rate, and a max filter reports that burst as the path's
-bandwidth. Bounding the filter's memory in time did not help, because the bursts
-recur every refill period so there is always a recent high sample. The
-*statistic* is the problem, not its age -- which is what "any max filter
-structurally measures the first and reports it as the second" already said, and
-which the time bound only half addressed.
+An earlier reading blamed the bandwidth estimate, on the grounds that a token
+bucket passes a burst at line rate and a maximum filter reports that burst as
+the path's bandwidth. **Measurement says otherwise.** Driven directly against a
+simulated policer -- 9 MB/s offered into a 250 KB/s bucket, every event in
+timestamp order -- the estimator reports **252,521 B/s, 1.01x the path**, with
+the median sample at 0.99x and acknowledgement intervals at about one round
+trip. The estimator is not the fault.
 
-**The erasure compensation is a feedback loop on a policed path.** Loss rises,
-the arrival rate falls, the compensation asks to send proportionally more, the
-policer drops proportionally more, and the arrival rate falls again.
+`TestWhatTheSamplerSeesOnAPolicedPath` is that measurement, kept so that the
+next reading of this starts from evidence rather than from the same guess. It
+was reached only after two attempts on the estimator that changed nothing --
+bounding the filter's memory in wall time, which is worth having and is
+irrelevant here because a policer's bursts recur every refill period, and
+averaging the sample within a round, which measured no better -- and one
+synthetic harness whose own ack pacing was wrong and which reported 4,000 B/s
+on a 250 KB/s path.
 
-The second is now bounded: compensation may only increase while it is buying
-delivery, which is a measurement rather than a classification and is the same
-question the design's own argument rests on. It reduces the overdrive but does
-not remove it, because the first amplifier is the larger one and remains.
+The fault is the erasure compensation. It is a bet that losses are independent
+of the sending rate, so that sending 1/arrival times as much delivers a full
+window. On a policer the losses are *caused* by the sending rate, so the bet
+feeds itself: send more, get dropped more, measure a lower arrival rate, ask to
+send more again.
 
-### What would resolve it
+Two things kept the first attempt at bounding that bet from working, and both
+were mistakes in the bound rather than in the diagnosis.
 
-Replacing the max filter with a statistic that estimates a *sustained* rate
-rather than the peak of a bursty delivery process. That is a change to the core
-of the bandwidth model and affects every path rather than only policed ones.
+Nothing, as it turns out, needed replacing. Two attempts were made on the
+estimator before it was measured, and both are recorded below because they are
+still true about the estimator and because they are how the diagnosis stayed
+wrong for as long as it did.
 
-### What has been tried and does not work
-
-Recorded so that the next attempt starts further along than this one did.
+### Two attempts on the wrong component
 
 **Bounding the filter's memory in wall time.** The filter kept a sample for ten
 packet-timed rounds, which on an application-limited connection was sixty-six
@@ -501,36 +507,47 @@ period, so there is always a recent high sample and the estimate never has to
 fall back to anything. **Age was not the problem.**
 
 **Averaging the sample within a round.** The filter is fed the largest
-per-packet delivery rate in an acknowledgement batch. Each of those is bytes
-delivered over one packet's own send-to-ack window, and on a path that releases
-traffic in quanta those windows land unevenly across the releases, so their
-distribution has an upper tail and a maximum reports the tail. Feeding the
-filter one rate per round -- bytes delivered over the whole round -- should
-remove the tail while keeping what the maximum is for.
+per-packet delivery rate in an acknowledgement batch, each measured over one
+packet's own send-to-ack window; on a path that releases traffic in quanta
+those windows land unevenly, so the distribution has an upper tail and a
+maximum reports the tail. Feeding one rate per round should have removed the
+tail. It measured no better -- 2.7x the shaped rate became 3.6x -- and was not
+shipped.
 
-It does not. Measured against the same emulated policer, the estimate moved
-from 2.7x the shaped rate to 3.6x and peak pacing from 42x to 37x, which is
-within run-to-run variation. **Not an improvement, and not shipped.** Why it
-fails is not established: the typical sample should already be about one round
-trip of delivery over about one round trip of time, which is the right answer,
-so either rounds are advancing faster than assumed or the delta and the
-interval are not the ones this reasoning assumes.
+**A synthetic estimator harness** reported 4,000 B/s on a known 250 KB/s
+schedule. The harness's own acknowledgement pacing was wrong. That failure is
+what made the next one careful enough to be right.
 
-**A synthetic estimator harness.** An attempt to drive the estimator directly
-with a known 250 KB/s delivery schedule reported 4,000 B/s. The harness was
-wrong, not the estimator, but the point stands: building a faithful path model
-inside a unit test is its own project, which is what `internal/pathsim` exists
-for. The emulator measures end to end and cannot isolate the estimator.
+**It accepted the first proposal whole.** By the time erasure is first measured
+the sender has already burst and been policed, so the first request is for
+several times the rate, with no evidence yet to test it against. Compensation
+now starts at none and takes a tenth of the remaining distance per round, so
+each step is small enough that the next round's delivery can be attributed to
+it.
 
-### What the next attempt needs first
+**It measured its own output.** The bet was judged against
+`TUICBBRSender.bandwidth`, which returns the *pacing rate* -- a value this
+compensation is an input to. Every increase therefore appeared to have worked.
+It now reads the delivered-rate estimate.
 
-Instrumentation, not a hypothesis. The sample interval and the delivered delta
-that produce each filter update, recorded on the emulated policer, would say in
-one run which of the two reasonings above is wrong. Three attempts have now been
-made by reasoning about what the code should be doing; each was refuted by
-measurement, and the third was refuted by a measurement that was itself broken.
-Measure the sampler before changing it again.
+With both corrected, the overdrive on the emulated policer falls from **42x the
+path to 7.3x** and the loss from 72.5% to 49.8%. The 42% erasure channel is
+unaffected at a median 1.18 s against a 1.10 s baseline, which is what says the
+bound has not simply been switched off.
 
+### What is left
+
+7.3x is not braked, it is less unbraked. The remaining terms are the startup
+gain of 2.77, which is BBR probing and should end when delivery stops growing,
+and a bandwidth estimate that reads 2.0x the path in the full stack against
+1.01x when the estimator is driven in isolation. **That gap is the next thing to
+measure rather than the next thing to guess**: the two differ by everything the
+real stack adds, and which part matters is not established.
+
+Four attempts have now been made on this. The first three reasoned about what
+the code should be doing and were each refuted by measurement, the third by a
+measurement that was itself broken. The fourth started by measuring and found
+the fault somewhere none of the three had looked.
 Until then, **a policed path is unbraked**, and this design should not be
 deployed on one.
 

--- a/docs/KNOWN-LIMITATIONS.md
+++ b/docs/KNOWN-LIMITATIONS.md
@@ -14,14 +14,15 @@ qualification items are still open.
   drops what it cannot pass and holds nothing, so it produces loss and no
   delay -- and that design uses delay as its congestion signal and ignores
   loss. Measured against an emulated policer shaped to 250 KB/s, a sender
-  reached 42 times the path's capacity at 72.5% loss with the brake reading
+  reached 7.3 times the path's capacity at 49.8% loss with the brake reading
   zero throughout. The live path this project targets is a policer, so this is
   the ordinary case rather than an edge one. The redesign is not deployed and
-  should not be until the bandwidth estimate stops reporting a token bucket's
-  burst as its rate; the shipping controller still treats loss as congestion
-  and does not have this behaviour. Two approaches to that estimate have been
-  tried and rejected, and are recorded in the redesign document so that a third
-  does not repeat them.
+  should not be until a policed path has a brake; the shipping controller still
+  treats loss as congestion and does not have this behaviour. The bandwidth
+  estimate turned out not to be the fault -- measured in isolation it is within
+  one per cent of a policer's rate -- and the erasure compensation was.
+  Bounding that took the overdrive from 42 times the path to 7.3. The redesign
+  document records what was tried, in what order, and which of it was wrong.
 - Queqiao is a WAN optimization data plane, not an anonymity network. The
   desktop ingress is SOCKS5, the released Android app exports an authenticated
   SOCKS5 endpoint to a separate routing client, and the iOS app is a

--- a/internal/congestion/bbr_tuic_bw.go
+++ b/internal/congestion/bbr_tuic_bw.go
@@ -22,7 +22,12 @@ import (
 // benefits from per-packet receive times when a future fork supplies them.
 // Memory is bounded even if a peer stops acknowledging packets.
 type tuicBandwidthEstimator struct {
-	totalAcked     uint64
+	totalAcked uint64
+	// sampleTrace, when set, receives every delivery-rate sample the estimator
+	// considered for the filter. It is nil in production and exists because
+	// three attempts to fix the estimate on a policed path were made by
+	// reasoning about what these numbers should be, and each was wrong.
+	sampleTrace    func(bandwidthSampleTrace)
 	totalSent      uint64
 	latestSample   uint64
 	latestAckRate  uint64
@@ -163,6 +168,22 @@ func (e *tuicBandwidthEstimator) removeObsolete(leastUnacked quiccongestion.Pack
 	}
 }
 
+// bandwidthSampleTrace is one delivery-rate sample with the two quantities it
+// was computed from, which is what a maximum filter hides: the rate alone
+// cannot say whether it is high because the path is fast or because the window
+// it was measured over was short.
+type bandwidthSampleTrace struct {
+	Round        uint64
+	AckRate      uint64
+	SendRate     uint64
+	Sample       uint64
+	AckInterval  time.Duration
+	SendInterval time.Duration
+	AckedDelta   uint64
+	SentDelta    uint64
+	AppLimited   bool
+}
+
 type tuicAckSample struct {
 	lastAppLimited   bool
 	hasSample        bool
@@ -216,6 +237,26 @@ func (e *tuicBandwidthEstimator) onAckBatch(eventTime monotime.Time, acked []qui
 		sendRate := uint64(0)
 		if !state.lastAckedSentTime.IsZero() && state.sentTime.After(state.lastAckedSentTime) && state.totalSentAtSend >= state.totalSentAtAck {
 			sendRate = rateFromDelta(state.totalSentAtSend-state.totalSentAtAck, state.sentTime.Sub(state.lastAckedSentTime))
+		}
+		if e.sampleTrace != nil {
+			trace := bandwidthSampleTrace{Round: round, AckRate: ackRate, SendRate: sendRate, AppLimited: state.appLimited}
+			if !state.lastAckedAckTime.IsZero() && ackTime.After(state.lastAckedAckTime) {
+				trace.AckInterval = ackTime.Sub(state.lastAckedAckTime)
+				if e.totalAcked >= state.totalAckedAtSend {
+					trace.AckedDelta = e.totalAcked - state.totalAckedAtSend
+				}
+			}
+			if !state.lastAckedSentTime.IsZero() && state.sentTime.After(state.lastAckedSentTime) {
+				trace.SendInterval = state.sentTime.Sub(state.lastAckedSentTime)
+				if state.totalSentAtSend >= state.totalSentAtAck {
+					trace.SentDelta = state.totalSentAtSend - state.totalSentAtAck
+				}
+			}
+			trace.Sample = ackRate
+			if sendRate > 0 && (trace.Sample == 0 || sendRate < trace.Sample) {
+				trace.Sample = sendRate
+			}
+			e.sampleTrace(trace)
 		}
 		sample := ackRate
 		e.latestAckRate = ackRate

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -122,6 +122,13 @@ const (
 	// sender already puts nearly seven packets on the wire per packet
 	// delivered; below that the path is not one to push harder into, and an
 	// unbounded divisor would turn a measurement error into a flood.
+	// compensationStep is how much of the remaining compensation one round may
+	// take. Erasure compensation is a bet that sending more delivers more, and
+	// a bet is only checkable if each increase is small enough that the next
+	// round's delivery can be attributed to it. A tenth of the remainder per
+	// round reaches a 42% channel's 1.72x in about six rounds, which on a long
+	// path is under two seconds.
+	compensationStep  = 0.9
 	erasureMinArrival = 0.15
 	partsPerMillion   = 1e6
 )
@@ -242,26 +249,49 @@ func (e *ErasureSender) compensationFor(want float64) float64 {
 	if want < erasureMinArrival {
 		want = erasureMinArrival
 	}
-	delivered := float64(e.inner.bandwidth())
+	if e.appliedArrival == 0 {
+		// Start at no compensation and earn the rest. Accepting the first
+		// proposal whole is what made an earlier version of this useless: on a
+		// policed path the first measurement is already taken after the sender
+		// has burst and been policed, so it asks for several times the rate
+		// before there is any evidence to test that request against.
+		e.appliedArrival = 1
+	}
+	// The delivered-rate estimate, not the sender's own bandwidth: that method
+	// returns the pacing rate, which this compensation is an input to. Judging
+	// the bet against it would be judging the bet against its own effect, and
+	// every increase would appear to have worked.
+	delivered := float64(e.inner.estimator.estimate())
 	round := e.inner.round
-	if e.appliedArrival == 0 || want >= e.appliedArrival {
+	if want >= e.appliedArrival {
+		// Asking for no more than is applied can only reduce what goes on the
+		// wire, so it is taken at once.
 		e.appliedArrival, e.deliveredAtCompensation, e.compensationRound = want, delivered, round
 		return want
 	}
-	// More compensation than is applied. Give the previous increase a round to
-	// show an effect before judging it, then require that it showed one.
+	// More compensation than is applied. Give the previous step a round to show
+	// an effect before judging it, then require that it showed one.
 	if round == e.compensationRound {
 		return e.appliedArrival
 	}
 	if delivered <= e.deliveredAtCompensation {
-		// Sending harder did not deliver more. Hold where we are, and re-arm
-		// the probe against what the path is doing now so that a path which
-		// later improves can still be followed.
+		// Sending harder did not deliver more. Hold, and re-arm against what
+		// the path is doing now so a path that later improves is still
+		// followed.
 		e.deliveredAtCompensation, e.compensationRound = delivered, round
 		return e.appliedArrival
 	}
-	e.appliedArrival, e.deliveredAtCompensation, e.compensationRound = want, delivered, round
-	return want
+	// It did deliver more, so take a step towards what is being asked for
+	// rather than the whole of it. A step keeps every increase small enough
+	// that the next round's delivery can be attributed to it; a jump to the
+	// full request would be one large bet with no way to tell afterwards
+	// whether it paid.
+	next := e.appliedArrival * compensationStep
+	if next < want {
+		next = want
+	}
+	e.appliedArrival, e.deliveredAtCompensation, e.compensationRound = next, delivered, round
+	return next
 }
 
 func (e *ErasureSender) arrivalRate() float64 {

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -67,36 +67,49 @@ func TestClusteredStartupLossDoesNotBecomeAnErasureFloor(t *testing.T) {
 	}
 }
 
-// Compensation must still converge on the channel's actual arrival rate.
-// Without it, pacing a delivered-rate estimate makes the sending rate its own
-// input and the loop walks down to nothing rather than to the bottleneck.
+// Compensation is a bet that sending more delivers more, and it is now taken
+// one step at a time with each step tested against the delivered rate.
 //
-// It now waits for a measured minimum round trip, because that is when the
-// delay bound can act, and compensation may not run ahead of the brake that
-// bounds it. Before then the sender behaves as plain BBR that ignores loss:
-// it neither compensates nor collapses.
-func TestCompensationConvergesOnTheMeasuredArrivalRate(t *testing.T) {
+// Where the bet pays -- a channel that erases independently of the sending
+// rate -- it must still get there, or pacing a delivered-rate estimate makes
+// the sending rate its own input and the loop walks down to nothing.
+func TestCompensationGrowsWhileItBuysDelivery(t *testing.T) {
 	e := NewErasureSender(1200)
 	e.inner.minRTT = 200 * time.Millisecond
 	e.SetRTTStatsProvider(&fixedRTT{min: 200 * time.Millisecond, smoothed: 200 * time.Millisecond})
 
-	rng := rand.New(rand.NewSource(3))
-	number := quiccongestion.PacketNumber(0)
-	for round := 0; round < 20; round++ {
-		var acked []quiccongestion.AckedPacketInfo
-		var lost []quiccongestion.LostPacketInfo
-		for i := 0; i < 500; i++ {
-			if rng.Float64() < 0.42 {
-				lost = append(lost, quiccongestion.LostPacketInfo{PacketNumber: number, BytesLost: 1200})
-			} else {
-				acked = append(acked, quiccongestion.AckedPacketInfo{PacketNumber: number, BytesAcked: 1200})
-			}
-			number++
-		}
-		e.OnCongestionEventEx(0, monotime.Now(), acked, lost)
+	// Delivery improves every round, which is what compensating for genuine
+	// erasure looks like.
+	delivered := uint64(100_000)
+	for round := uint64(1); round <= 12; round++ {
+		e.inner.round = round
+		delivered += 20_000
+		e.inner.estimator.maxFilter.updateMax(round, monotime.Now(), delivered)
+		e.compensationFor(0.58)
 	}
-	if got := e.arrivalRate(); got < 0.5 || got > 0.66 {
-		t.Fatalf("arrival rate %.3f on a 42%% erasure channel, want about 0.58", got)
+	if got := e.appliedArrival; got > 0.62 || got < 0.55 {
+		t.Fatalf("applied arrival %.3f after twelve rounds of improving delivery, want about 0.58", got)
+	}
+}
+
+// Where the bet does not pay -- a policer, which drops because of the sending
+// rate rather than independently of it -- compensation must stay where it is.
+// Sending harder there raises the loss that asks for more compensation, which
+// is a loop that ends at many times the path's capacity.
+func TestCompensationHoldsWhenItBuysNothing(t *testing.T) {
+	e := NewErasureSender(1200)
+	e.inner.minRTT = 200 * time.Millisecond
+	e.SetRTTStatsProvider(&fixedRTT{min: 200 * time.Millisecond, smoothed: 200 * time.Millisecond})
+
+	// Delivery is flat however hard the sender is asked to try.
+	e.inner.estimator.maxFilter.updateMax(1, monotime.Now(), 250_000)
+	for round := uint64(1); round <= 12; round++ {
+		e.inner.round = round
+		e.compensationFor(0.28)
+	}
+	if got := e.appliedArrival; got < 0.85 {
+		t.Fatalf("applied arrival fell to %.3f on a path whose delivery never improved; "+
+			"that is the policer feedback loop", got)
 	}
 }
 

--- a/internal/congestion/policersampler_test.go
+++ b/internal/congestion/policersampler_test.go
@@ -1,0 +1,168 @@
+package congestion
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	quiccongestion "github.com/apernet/quic-go/congestion"
+	"github.com/apernet/quic-go/monotime"
+)
+
+// policer is a token bucket that admits or drops, and never queues, which is
+// what makes a policed path produce loss with no delay.
+type policer struct {
+	rate    float64 // bytes per second
+	bucket  float64
+	tokens  float64
+	refill  time.Duration
+	nextAt  time.Duration
+	started bool
+}
+
+func (p *policer) admit(at time.Duration, size int) bool {
+	quantum := p.rate * p.refill.Seconds()
+	if !p.started {
+		p.started, p.tokens, p.nextAt = true, p.bucket, at
+	}
+	for p.nextAt <= at {
+		if p.tokens += quantum; p.tokens > p.bucket {
+			p.tokens = p.bucket
+		}
+		p.nextAt += p.refill
+	}
+	if p.tokens < float64(size) {
+		return false
+	}
+	p.tokens -= float64(size)
+	return true
+}
+
+type samplerEvent struct {
+	at    time.Duration
+	send  bool
+	pn    quiccongestion.PacketNumber
+	acked bool
+}
+
+// driveThroughPolicer runs the estimator against a sender that offers traffic
+// far faster than a policer will pass it, with every event processed in
+// timestamp order. Getting that ordering wrong is what made an earlier attempt
+// at this measurement report 4,000 B/s on a 250 KB/s path.
+func driveThroughPolicer(t *testing.T, offered, shaped float64, rtt time.Duration, seconds float64) (tuicBandwidthEstimator, []bandwidthSampleTrace) {
+	t.Helper()
+	const size = 1200
+	e := newTUICBandwidthEstimator()
+	var traces []bandwidthSampleTrace
+	e.sampleTrace = func(s bandwidthSampleTrace) { traces = append(traces, s) }
+
+	p := &policer{rate: shaped, refill: 8 * time.Millisecond}
+	p.bucket = shaped*p.refill.Seconds() + size
+
+	sendGap := time.Duration(float64(time.Second) * size / offered)
+	var events []samplerEvent
+	pn := quiccongestion.PacketNumber(0)
+	for at := time.Duration(0); at < time.Duration(seconds*float64(time.Second)); at += sendGap {
+		admitted := p.admit(at, size)
+		events = append(events, samplerEvent{at: at, send: true, pn: pn})
+		events = append(events, samplerEvent{at: at + rtt, pn: pn, acked: admitted})
+		pn++
+	}
+	sort.SliceStable(events, func(i, j int) bool { return events[i].at < events[j].at })
+
+	base := monotime.Now()
+	inflight := uint64(0)
+	round := uint64(1)
+	roundEnd := quiccongestion.PacketNumber(-1)
+	maxSent := quiccongestion.PacketNumber(-1)
+	var batch []quiccongestion.AckedPacketInfo
+	var batchAt time.Duration
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		largest := batch[len(batch)-1].PacketNumber
+		if largest > roundEnd {
+			roundEnd = maxSent
+			round++
+		}
+		e.onAckBatch(base.Add(batchAt), batch, round)
+		batch = nil
+	}
+	for _, ev := range events {
+		if ev.send {
+			flush()
+			e.onSentPacket(base.Add(ev.at), ev.pn, size, inflight, true)
+			inflight += size
+			maxSent = ev.pn
+			continue
+		}
+		if !ev.acked {
+			if inflight >= size {
+				inflight -= size
+			}
+			continue
+		}
+		if len(batch) > 0 && ev.at != batchAt {
+			flush()
+		}
+		batchAt = ev.at
+		batch = append(batch, quiccongestion.AckedPacketInfo{
+			PacketNumber: ev.pn, BytesAcked: size, ReceivedTime: base.Add(ev.at),
+		})
+		if inflight >= size {
+			inflight -= size
+		}
+	}
+	flush()
+	return e, traces
+}
+
+// The measurement three failed fixes were missing. It reports what the
+// estimator concludes about a policed path and, when it is wrong, which of the
+// two quantities behind the sample is responsible.
+func TestWhatTheSamplerSeesOnAPolicedPath(t *testing.T) {
+	const (
+		shaped  = 250_000.0
+		offered = 9_000_000.0
+		rtt     = 300 * time.Millisecond
+	)
+	e, traces := driveThroughPolicer(t, offered, shaped, rtt, 6)
+	if len(traces) == 0 {
+		t.Fatal("no samples were produced, so this measured nothing")
+	}
+
+	estimate := float64(e.estimate())
+	t.Logf("offered %.0f B/s through a %.0f B/s policer: estimate %.0f (%.2fx), %d samples",
+		offered, shaped, estimate, estimate/shaped, len(traces))
+
+	// The distribution behind the maximum. If the typical sample is right and
+	// only the tail is wrong, the statistic is the problem; if the typical
+	// sample is already wrong, the inputs are.
+	rates := make([]float64, 0, len(traces))
+	var intervals []time.Duration
+	for _, s := range traces {
+		rates = append(rates, float64(s.Sample))
+		intervals = append(intervals, s.AckInterval)
+	}
+	sort.Float64s(rates)
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i] < intervals[j] })
+	q := func(v []float64, p float64) float64 { return v[int(p*float64(len(v)-1))] }
+	qd := func(v []time.Duration, p float64) time.Duration { return v[int(p*float64(len(v)-1))] }
+	t.Logf("  sample rate    p50=%.0f (%.2fx) p90=%.0f (%.2fx) p99=%.0f (%.2fx) max=%.0f (%.2fx)",
+		q(rates, .5), q(rates, .5)/shaped, q(rates, .9), q(rates, .9)/shaped,
+		q(rates, .99), q(rates, .99)/shaped, rates[len(rates)-1], rates[len(rates)-1]/shaped)
+	t.Logf("  ack interval   p50=%v p90=%v p99=%v max=%v",
+		qd(intervals, .5).Round(time.Millisecond), qd(intervals, .9).Round(time.Millisecond),
+		qd(intervals, .99).Round(time.Millisecond), intervals[len(intervals)-1].Round(time.Millisecond))
+
+	worst := traces[0]
+	for _, s := range traces {
+		if s.Sample > worst.Sample {
+			worst = s
+		}
+	}
+	t.Logf("  worst sample: rate=%d ack=%d bytes over %v, send=%d bytes over %v, applimited=%v",
+		worst.Sample, worst.AckedDelta, worst.AckInterval.Round(time.Microsecond),
+		worst.SentDelta, worst.SendInterval.Round(time.Microsecond), worst.AppLimited)
+}


### PR DESCRIPTION
You asked what the problem was. Measuring it answered that, and the answer was
not what #65 or #66 said — **including the parts I wrote.**

## The estimator was never the fault

Driven directly against a simulated policer — 9 MB/s offered into a 250 KB/s
bucket, every event in timestamp order:

```
estimate 252,521 B/s against a 250,000 path  →  1.01x
sample rate  p50=0.99x  p90=1.01x  p99=1.01x  max=1.01x
ack interval p50=304ms  p90=304ms   (≈ one round trip)
```

**BBR already notices the upper bound.** That was your instinct, and it is
correct — the bound is measured accurately. What went wrong is downstream of
noticing it.

(On delay: a policer genuinely offers none. Worst queue across the whole run was
**2 ms**. So the delay bound from #63 cannot be the brake here, which is what
case 4 established.)

## The fault was the compensation, and my bound on it had two bugs

The erasure compensation is a bet that losses are independent of the sending
rate. On a policer they are *caused* by it, so the bet feeds itself: send more →
dropped more → measure lower arrival → ask to send more.

The bound I added in #65 didn't hold, for two reasons that were mistakes in the
bound, not the diagnosis:

**It accepted the first proposal whole.** By the time erasure is first measured
the sender has already burst and been policed, so the first request is for
several times the rate — with no evidence yet to test it against. Compensation
now starts at *none* and takes a tenth of the remaining distance per round, so
each step is small enough that the next round's delivery can be attributed to
it.

**It measured its own output.** The bet was judged against
`TUICBBRSender.bandwidth`, which returns the **pacing rate** — a value the
compensation is an input to. Every increase therefore appeared to have worked.
That is the same shape of error as the loop it was meant to detect. It now reads
the delivered-rate estimate.

## Result

| | Before | After |
| --- | --- | --- |
| Peak pacing on a 250 KB/s policer | 42× | **7.3×** |
| Sustained loss | 72.5% | **49.8%** |
| 42% erasure channel | 1.10 s baseline | median 1.18 s — unaffected |

The erasure channel being unaffected is what says the compensation was *bounded*
rather than switched off.

## Still not braked

7.3× is less unbraked, not braked, and `KNOWN-LIMITATIONS.md` still says so. The
remaining terms are the startup gain of 2.77 (BBR probing, should end when
delivery stops growing) and an estimate reading 2.0× the path in the full stack
against 1.01× in isolation. **That gap is the next thing to measure, not the
next thing to guess.**

## On the record

#66 merged before this landed and its central claim is wrong. This corrects it
in place rather than leaving two documents disagreeing: the rejected approaches
are kept, reframed as attempts on the wrong component, which is how the
diagnosis stayed wrong for as long as it did.

Four attempts. The first three reasoned about what the code should be doing and
were each refuted by measurement — the third by a measurement that was itself
broken. The fourth started by measuring and found the fault somewhere none of
the three had looked. `TestWhatTheSamplerSeesOnAPolicedPath` is kept so the
fifth starts from evidence.

## Checks

`go test -short ./...` green across 27 packages · full `internal/pep` 173 s and
`internal/congestion` · `go test -race` on `internal/congestion` · `go vet` ·
`gofmt` · `staticcheck -checks=all,-U1000` on the whole tree · gosec baseline
(133 reviewed, none unreviewed) · `./scripts/changelog.py check`.

One flake under full-suite load, passing in three isolated runs:
`TestIntermittentUDPBlockingReturnsToQUIC`.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf
