### PR TITLE
fix: spend one lane replacement grace per outage, not per waiter

### DIFF
--- a/changelog.d/one-replacement-grace-per-outage.fixed.md
+++ b/changelog.d/one-replacement-grace-per-outage.fixed.md
@@ -1,0 +1,14 @@
+A flow that loses its last lane now spends one replacement grace on the
+outage, rather than one for each part of the flow that happens to be waiting
+for the lane. Four call sites wait for a lane that is not there — the flow's
+own run loop, the frame and control writers, and the acknowledgement loop —
+and a lane that dies with writes in flight leaves more than one of them
+waiting for the same absent replacement. Each started a fresh 45-second grace
+of its own, so a flow that was never going to be rescued failed only after
+some multiple of the grace that depended on which writers were blocked when
+its lane died. A live gateway showed this as failures clustered at 76–106
+seconds against a 45-second grace, for flows that had finished their work in
+the first second and were then held open by the application. The grace is
+unchanged; what changed is that it is now the whole of what a flow waits, and
+a flow that really is given a replacement lane is owed a full grace again for
+any later outage.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -144,6 +144,15 @@ did not. A flow that never lost its last healthy lane reports zeroes. Both
 endpoints use the same names, so a client record and a gateway record about the
 same failure can be read side by side.
 
+`lane_replacement_waits` counts waiters, not graces. The flow's run loop, its
+frame and control writers, and its acknowledgement loop all wait for a missing
+lane, so a lane that dies with writes in flight leaves several of them waiting
+for the same replacement, and a count above one says how much of the flow was
+stuck rather than how long it waited. The grace belongs to the outage: reading
+`lane_replacement_wait` against it tells you whether the flow waited out a
+whole outage or ended early, and `lanes_joined` tells you whether anything ever
+arrived to end one.
+
 The dashboard calculates interval packet loss from changes in
 `queqiao_quic_packets_sent` and `queqiao_quic_loss_observed_packets_total`.
 `queqiao_quic_packets_lost` and `queqiao_quic_bytes_lost` were removed: they

--- a/internal/pep/lanegrace_test.go
+++ b/internal/pep/lanegrace_test.go
@@ -121,18 +121,20 @@ func TestAFlowRecordsWhatItsLaneReplacementsDid(t *testing.T) {
 		t.Fatalf("the flow waited %s but recorded %s", grace, waited)
 	}
 
-	// A second grace has to be visible as a second grace: the observed
-	// durations clustered at roughly twice laneReplacementWait, and a counter
-	// that saturated at one could not have shown that.
+	// A second waiter for the same missing lane has to be visible as a second
+	// waiter -- the counters are how a gateway record separates one call site
+	// giving up from four of them -- but it must not buy the flow a second
+	// grace. The observed durations clustered at roughly twice
+	// laneReplacementWait, which is what that used to cost.
 	if err := flow.waitForHealthyLane(context.Background(), grace); err == nil {
 		t.Fatal("the second wait succeeded with no healthy lane")
 	}
 	waits, timeouts, _, twice := flow.replacementDiagnostics()
 	if waits != 2 || timeouts != 2 {
-		t.Fatalf("two exhausted graces recorded waits=%d timeouts=%d, want 2 and 2", waits, timeouts)
+		t.Fatalf("two waiters recorded waits=%d timeouts=%d, want 2 and 2", waits, timeouts)
 	}
-	if twice <= waited {
-		t.Fatalf("two graces recorded %s, no more than one grace's %s", twice, waited)
+	if twice >= 2*grace {
+		t.Fatalf("two waiters on one outage spent %s, at least two graces of %s", twice, grace)
 	}
 
 	// And an exit that is not a timeout must not be counted as one, or the
@@ -143,5 +145,118 @@ func TestAFlowRecordsWhatItsLaneReplacementsDid(t *testing.T) {
 	}
 	if _, timeouts, _, _ := flow.replacementDiagnostics(); timeouts != 2 {
 		t.Fatalf("abandoning replacement counted as a timeout: timeouts=%d, want 2", timeouts)
+	}
+}
+
+// The grace is what a flow is prepared to wait for a lane that is not there.
+// It was being spent per waiter rather than per outage: run, the frame and
+// control writers and the acknowledgement loop all wait for the same missing
+// lane, so a flow that was never going to be rescued paid the whole grace
+// once for each of them. The live gateway showed it as failures clustered at
+// 76-106 s against a 45 s grace -- two of them, for flows that had finished
+// their work in the first second. See issue #53.
+func TestOneOutageSpendsOneGraceHoweverManyWaitersItHas(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	const grace = 300 * time.Millisecond
+	const concurrent = 3
+
+	// Waiters that are already blocked when the grace runs out share it: a
+	// lane dying with writes in flight puts several of them here at once.
+	started := time.Now()
+	errs := make(chan error, concurrent)
+	for i := 0; i < concurrent; i++ {
+		go func() { errs <- flow.waitForHealthyLane(context.Background(), grace) }()
+	}
+	for i := 0; i < concurrent; i++ {
+		select {
+		case err := <-errs:
+			if !errors.Is(err, errLaneReplacementTimeout) {
+				t.Fatalf("wait error = %v, want %v", err, errLaneReplacementTimeout)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("a waiter never returned")
+		}
+	}
+
+	// And a waiter that arrives afterwards is told at once. This is the one
+	// that cost the flows in the incident: run waits for the lane only after
+	// the failure reaches it, which on a flow whose writer was already blocked
+	// is one whole grace after the outage began. It used to start a second.
+	arrived := time.Now()
+	if err := flow.waitForHealthyLane(context.Background(), grace); !errors.Is(err, errLaneReplacementTimeout) {
+		t.Fatalf("wait error = %v, want %v", err, errLaneReplacementTimeout)
+	}
+	if late := time.Since(arrived); late > grace/2 {
+		t.Fatalf("a waiter arriving after the grace was spent waited %s of a fresh %s", late, grace)
+	}
+	if elapsed := time.Since(started); elapsed >= 2*grace {
+		t.Fatalf("one outage took %s, at least two graces of %s", elapsed, grace)
+	}
+
+	// Every waiter still has to be counted, or the record cannot say how many
+	// call sites were stuck on the same absent lane.
+	const waiters = concurrent + 1
+	if waits, timeouts, _, _ := flow.replacementDiagnostics(); waits != waiters || timeouts != waiters {
+		t.Fatalf("recorded waits=%d timeouts=%d, want %d and %d", waits, timeouts, waiters, waiters)
+	}
+}
+
+// Spending the grace once per outage must not mean spending it once per flow.
+// A long-lived flow that is genuinely being rescued loses a lane, gets one
+// back, and may lose another an hour later; that second outage is a new one
+// and is owed the whole grace.
+func TestANewOutageIsOwedAWholeGrace(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	const grace = 200 * time.Millisecond
+
+	if err := flow.waitForHealthyLane(context.Background(), grace); !errors.Is(err, errLaneReplacementTimeout) {
+		t.Fatalf("wait error = %v, want %v", err, errLaneReplacementTimeout)
+	}
+
+	// A lane arriving is what ends an outage, and it ends it in startLane --
+	// the one point a lane starts carrying traffic -- rather than wherever a
+	// waiter next happens to look.
+	replacement := &mpLane{id: 7, kind: TransportQUIC, fc: newFrameConn(gracePipe(t))}
+	if err := flow.addLane(replacement); err != nil {
+		t.Fatalf("adding a replacement lane: %v", err)
+	}
+	if flow.replacementDeadline.Load() != 0 {
+		t.Fatal("a replacement lane arrived and the spent outage was still holding its deadline")
+	}
+
+	flow.failLane(replacement, errors.New("lane died again"))
+	started := time.Now()
+	if err := flow.waitForHealthyLane(context.Background(), grace); !errors.Is(err, errLaneReplacementTimeout) {
+		t.Fatalf("wait error = %v, want %v", err, errLaneReplacementTimeout)
+	}
+	if elapsed := time.Since(started); elapsed < grace {
+		t.Fatalf("the second outage waited %s of its %s grace", elapsed, grace)
+	}
+}
+
+func gracePipe(t *testing.T) net.Conn {
+	t.Helper()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	return local
+}
+
+// A deadline can outlive the outage it belonged to. A waiter that finds no
+// lane, and whose lane arrives before it records its deadline, writes that
+// deadline after the arriving lane has already cleared the outage, and nothing
+// is then left to remove it. Read as current, it would expire the flow's next
+// outage before that outage began -- failing in an instant a flow that had a
+// full grace coming to it.
+func TestAStaleDeadlineDoesNotDenyTheNextOutageItsGrace(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	const grace = 200 * time.Millisecond
+	flow.replacementDeadline.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	started := time.Now()
+	if err := flow.waitForHealthyLane(context.Background(), grace); !errors.Is(err, errLaneReplacementTimeout) {
+		t.Fatalf("wait error = %v, want %v", err, errLaneReplacementTimeout)
+	}
+	if elapsed := time.Since(started); elapsed < grace {
+		t.Fatalf("an outage inheriting a stale deadline waited %s of its %s grace", elapsed, grace)
 	}
 }

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -50,10 +50,26 @@ const (
 	// the combined queues at maxLaneWriteQueue.
 	maxLaneInteractiveReserve = 8
 	maxLaneBulkQueue          = maxLaneWriteQueue - maxLaneInteractiveReserve
-	// Must exceed QUIC dead-path detection plus TCP handshake time. The
-	// client normally detects a blackhole at ~15 s, then needs one scheduler
-	// tick and a bounded TCP handshake before the replacement can arrive.
-	laneReplacementWait = 45 * time.Second
+	// laneDeadPathDetection is how long QUIC spends deciding that a silent
+	// lane is dead: it is the MaxIdleTimeout every lane is configured with in
+	// quicConfig, named here because the replacement grace below is derived
+	// from it. The two are one budget in two halves, not two independent
+	// constants -- a flow cannot be given a replacement grace shorter than the
+	// time its peer needs to notice there is anything to replace, so raising
+	// the detection budget raises the grace with it.
+	laneDeadPathDetection = 15 * time.Second
+	// laneRescueHandshake is what a replacement lane still needs after the
+	// peer has noticed: one scheduler tick, and a bounded handshake on a path
+	// that has just proved hostile enough to kill a lane.
+	laneRescueHandshake = 30 * time.Second
+	// laneReplacementWait is the whole budget a flow spends with no healthy
+	// lane before it gives up. It is spent per outage rather than per wait:
+	// several call sites wait for the same missing lane, and each used to
+	// start its own copy of this grace, so a flow that was never going to be
+	// rescued burned the budget once per waiter. On the live gateway that was
+	// visible as failures clustered at 76-106 s -- two graces, not one -- for
+	// flows that had done their work in the first second. See issue #53.
+	laneReplacementWait = laneDeadPathDetection + laneRescueHandshake
 	// Once both FIN directions are observed, no additional application bytes
 	// can be delivered. This grace lets a healthy final ACK arrive, but bounds
 	// retention when the peer closes its last lane at exactly that point.
@@ -253,6 +269,12 @@ type multipathFlow struct {
 	replacementTimeouts  atomic.Uint64
 	replacementWaitNanos atomic.Int64
 	lanesJoined          atomic.Uint64
+	// replacementDeadline is when the current outage's grace runs out, in Unix
+	// nanoseconds, or zero when the flow is not in an outage. It is what makes
+	// laneReplacementWait a budget the flow spends once rather than one each
+	// waiter spends separately, and it is cleared in startLane so that a flow
+	// which really is being rescued gets a fresh grace for its next outage.
+	replacementDeadline atomic.Int64
 	// controlLaneShared reports whether another flow is currently using the
 	// pooled control connection. Nil means "no", which is what a flow on a
 	// dedicated connection should answer.
@@ -461,6 +483,13 @@ func (f *multipathFlow) activateLane(lane *mpLane) error {
 }
 
 func (f *multipathFlow) startLane(lane *mpLane) {
+	// This is the one point a lane actually begins carrying traffic, reached
+	// from addLane for an immediate lane and from activateLane for a staged
+	// one, so it is where an outage ends. Ending it here rather than where a
+	// waiter happens to observe the lane matters: nothing obliges a waiter to
+	// look again once it has what it wanted, and a deadline left behind by a
+	// recovered outage would expire the next one before it began.
+	f.endReplacementOutage()
 	// The policy is set before either goroutine exists. Setting it from the
 	// reader, as the first version did, meant the writer could already be
 	// asking for it.
@@ -1703,6 +1732,7 @@ func (f *multipathFlow) replacementDiagnostics() (waits, timeouts, joined uint64
 
 func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Duration) error {
 	if len(f.healthyLanes()) > 0 {
+		f.endReplacementOutage()
 		return nil
 	}
 	if f.resumeRefused.Load() {
@@ -1714,7 +1744,22 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 	f.replacementWaits.Add(1)
 	waitStarted := time.Now()
 	defer func() { f.replacementWaitNanos.Add(int64(time.Since(waitStarted))) }()
-	timer := time.NewTimer(timeout)
+	// The grace belongs to the outage, not to this call. Four call sites wait
+	// for the last lane -- run, the frame and control writers, and the
+	// acknowledgement loop -- and a lane that dies with a write in flight puts
+	// more than one of them here for the same missing lane. Each used to start
+	// a full grace of its own, so the flow's real willingness to wait was a
+	// multiple of this constant that depended on which writers happened to be
+	// blocked.
+	remaining := f.replacementBudget(waitStarted, timeout)
+	if remaining <= 0 {
+		// The outage already outlived its grace. Waiting again cannot produce
+		// a lane; it only holds the application open for another full grace
+		// before telling it what is already known.
+		f.replacementTimeouts.Add(1)
+		return errLaneReplacementTimeout
+	}
+	timer := time.NewTimer(remaining)
 	defer timer.Stop()
 	ticker := time.NewTicker(25 * time.Millisecond)
 	defer ticker.Stop()
@@ -1722,6 +1767,7 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 		select {
 		case <-ticker.C:
 			if len(f.healthyLanes()) > 0 {
+				f.endReplacementOutage()
 				return nil
 			}
 			if f.resumeRefused.Load() {
@@ -1746,7 +1792,7 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 			}
 		case <-timer.C:
 			f.replacementTimeouts.Add(1)
-			return errors.New("lane replacement timeout")
+			return errLaneReplacementTimeout
 		case <-f.done:
 			return errors.New("flow closed while waiting for lane replacement")
 		case <-ctx.Done():
@@ -1754,6 +1800,41 @@ func (f *multipathFlow) waitForHealthyLane(ctx context.Context, timeout time.Dur
 		}
 	}
 }
+
+// replacementBudget reports what is left of the current outage's grace,
+// opening one at now+grace if this waiter is the first to find the flow
+// without a lane. A negative or zero result means the outage has already had
+// its whole grace and nothing is owed to a further waiter.
+//
+// A deadline more than a grace into the past is not this outage's. It is the
+// residue of one that ended in the narrow window between a waiter finding no
+// lane and the arriving lane clearing the outage, where the waiter's own
+// deadline lands after the clear and nothing is left to remove it. Reading it
+// as current would deny a whole grace to an outage that had not started, so
+// it is discarded. The cost of being wrong is the opposite and smaller: a
+// waiter that turns up more than a grace after the last one expired -- on a
+// flow the expiry has usually already failed -- gets one grace of its own
+// rather than none.
+func (f *multipathFlow) replacementBudget(now time.Time, grace time.Duration) time.Duration {
+	for {
+		if deadline := f.replacementDeadline.Load(); deadline != 0 {
+			remaining := time.Unix(0, deadline).Sub(now)
+			if remaining > -grace {
+				return remaining
+			}
+			if !f.replacementDeadline.CompareAndSwap(deadline, 0) {
+				continue
+			}
+		}
+		if f.replacementDeadline.CompareAndSwap(0, now.Add(grace).UnixNano()) {
+			return grace
+		}
+	}
+}
+
+// endReplacementOutage forgets the current outage's deadline, so the next one
+// starts from a full grace.
+func (f *multipathFlow) endReplacementOutage() { f.replacementDeadline.Store(0) }
 
 func (f *multipathFlow) acknowledgeReplay(sequence uint64, final bool) error {
 	f.replayMu.Lock()
@@ -2562,6 +2643,11 @@ var errResumeRefused = errors.New("peer does not hold this session")
 // errReplacementAbandoned reports that this endpoint has stopped attempting
 // replacement lanes for the flow, so its grace has nothing left to wait for.
 var errReplacementAbandoned = errors.New("no replacement lane will be attempted")
+
+// errLaneReplacementTimeout reports that an outage outlived the whole
+// replacement grace. The text is what the live gateway's failure records
+// already say, and is kept verbatim so those records stay greppable.
+var errLaneReplacementTimeout = errors.New("lane replacement timeout")
 
 // retainClose keeps this flow's half-close so a replacement lane can be given
 // it when the lane that carried it dies first.

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -540,7 +540,13 @@ func quicConfig(windows flowWindows) *quic.Config {
 		// Existing-flow TCP rescue cannot begin until QUIC declares the
 		// black-holed lane dead. Keep this bound well below application-level
 		// request timeouts while allowing several PTOs on a 200 ms WAN.
-		MaxIdleTimeout:                 15 * time.Second,
+		//
+		// laneReplacementWait is derived from this, because a flow's grace has
+		// to cover the time its peer spends reaching this same conclusion
+		// before it can even begin opening a replacement. Changing the number
+		// here changes what a flow waits; it is not a knob local to one
+		// connection.
+		MaxIdleTimeout:                 laneDeadPathDetection,
 		KeepAlivePeriod:                5 * time.Second,
 		InitialStreamReceiveWindow:     streamWindow,
 		MaxStreamReceiveWindow:         streamMax,


### PR DESCRIPTION
Second step on #53, after the diagnostics in #54.

## The asymmetry in the title is not what fails these flows

#53 reads the 15 s idle timeout and the 45 s replacement grace as two settings
in the wrong order, and proposes moving budget from the second to the first.
They are not two settings. `laneReplacementWait` is *derived* from
`MaxIdleTimeout`: a flow's grace has to cover the time its **peer** spends
reaching the same dead-lane conclusion before it can begin opening a
replacement at all. Raising the detection budget therefore raises the grace
with it. Taking the grace's time and giving it to the lane inverts a
dependency rather than rebalancing two peers, and would lengthen the tail it
was meant to cut.

The 15 s is deliberately unchanged here. Whether it is too tight for an idle
lane is the question #54's fields exist to answer, and it cannot be answered
from this side of the connection.

## What does fail them

The grace was spent **per waiter**, not per outage, and that needs no gateway
data to establish -- it is four `time.NewTimer(laneReplacementWait)` calls on
four independent code paths:

| | |
| --- | --- |
| `mpflow.go:1335` | `run`, when the last lane's failure reaches it |
| `mpflow.go:1621` | `enqueueOnHealthyLane`, the frame writer |
| `mpflow.go:1811` | `writeControl` |
| `mpflow.go:2032` | the acknowledgement loop |

A lane that dies with a write in flight leaves more than one of them waiting
for the same absent lane, and they do not queue: the writer burns its whole
grace, gives up, its failure reaches `run`, and `run` starts a **fresh** one.
So a flow's real willingness to wait was a multiple of the constant, decided
by which writers happened to be blocked when its lane died.

That is the shape #53 measured. 521 flows in two hours ending in `lane
replacement timeout`, clustered at 76-106 s against a 45 s grace, p50 90.7 s,
for exchanges that finished their work in the first second and were then held
open by the application. Two graces, one after the other. #53 read the
clustering as "a mechanism rather than a loss process" and this is the
mechanism.

## The change

The grace belongs to the outage. The first waiter to find the flow without a
lane opens it, the rest wait out what is left of it, and one that arrives
after it has run out is told so at once instead of starting a second.

Per outage, not per flow: a lane arriving ends the outage in `startLane` --
the one point a lane begins carrying traffic, reached from `addLane` for an
immediate lane and `activateLane` for a staged one -- so a long-lived flow
that is genuinely being rescued is owed a whole grace again the next time it
loses one. Ending it there rather than where a waiter observes the lane
matters: nothing obliges a waiter to look again once it has what it wanted.

A deadline more than a grace old is discarded rather than inherited. That is
the residue of an outage which ended in the window between a waiter finding no
lane and recording its own deadline, where the write lands after the arriving
lane cleared it and nothing is left to remove it. Read as current it would
deny a whole grace to an outage that had not started; the cost of discarding
it is the opposite and smaller, one grace to a waiter arriving on a flow the
earlier expiry has usually already failed.

`MaxIdleTimeout` and `laneReplacementWait` are now one derivation rather than
two independent constants -- `laneDeadPathDetection + laneRescueHandshake` --
so the dependency above cannot be broken by editing one number. The values are
unchanged: 15 s and 45 s, as before.

## What this does not change

Every waiter is still counted. `lane_replacement_waits` measures how much of
the flow was stuck on one absent lane, which is what makes a gateway record
readable; only the grace is now shared between them. `LOGGING.md` says which
of the two those fields measure, because the same number means something
different after this change: waits above one against a `lane_replacement_wait`
near the grace is several call sites in one outage, not several outages.

An exit that is not a timeout is still not counted as one -- `errResumeRefused`
and `errReplacementAbandoned` end a wait early and #54's separation of those
from real expiry is preserved.

## Checks

`go test -short ./...` green across 27 packages, `go vet`, `gofmt`, and
`./scripts/changelog.py check`. The lane-grace tests pass under `-race` at
`-count=4`. Both new assertions were confirmed to **fail** against the old
per-waiter behaviour before the fix was restored, so they discriminate rather
than merely pass.

Unrelated and pre-existing, found while running the package under `-race` and
verified by re-running at 9b1c5ad without this branch: `ErasureSender.
Telemetry()` reaches `TUICBBRSender.minRoundTrip()` (`bbr_tuic.go:299`) with
no lock while `refreshRTTSample()` (`:204`) writes the same field from the
QUIC ACK path, which fails `TestPooledFlowsRecoverThroughOneReplacementGeneration`
under `-race`. It appears to have arrived with #63. Not touched here.

## #53 is not closed by this

It removes the mechanism behind the duration cluster. The two open questions
in that issue -- why a keepalive fails to hold an idle lane, and how much of
the 94% #50 already accounted for -- still need the gateway re-measure, which
is now the only step of #53's suggested order left outstanding.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01858EDFqaLY9C1ahbiUrjtN
