### PR TITLE
fix: record whether a replacement lane was ever attempted

### DIFF
--- a/changelog.d/record-whether-a-replacement-was-attempted.fixed.md
+++ b/changelog.d/record-whether-a-replacement-was-attempted.fixed.md
@@ -1,0 +1,11 @@
+Flow completion records now say whether a replacement lane was ever attempted,
+not only whether one arrived: `lane_replacement_attempts` and
+`lane_replacement_failures` join the fields already written by both endpoints.
+On a live gateway, 84% of the flows that failed with "lane replacement
+timeout" ended with no replacement lane admitted, and the record could not say
+why. A client pool that will not rebuild opens nothing; a path that will not
+carry a handshake opens dials that never complete. Those need different fixes,
+and both leave `lanes_joined` unchanged, because a dial that fails never
+reaches lane admission. The client's own failure log now also carries the
+`flow_id` and attempt number, so the attempts behind a failed flow can be
+found rather than inferred.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -153,6 +153,17 @@ did not. A flow that never lost its last healthy lane reports zeroes. Both
 endpoints use the same names, so a client record and a gateway record about the
 same failure can be read side by side.
 
+`lane_replacement_attempts` and `lane_replacement_failures` say what the
+endpoint that opens replacements actually did, and are the pair that separates
+a client pool which will not rebuild from a path which will not carry a
+handshake. No attempts means nothing was dialled; attempts equal to failures
+means every dial was made and none completed; attempts above failures means
+dials are still outstanding. They are written by both endpoints under the same
+names, and a gateway reports zeroes because it opens nothing -- the replacement
+is the client's to send. `lanes_joined` cannot answer this on its own: a dial
+whose handshake never completes never reaches lane admission, so it leaves the
+record identical to a flow where nothing was tried.
+
 `lane_replacement_waits` counts waiters, not graces. The flow's run loop, its
 frame and control writers, and its acknowledgement loop all wait for a missing
 lane, so a lane that dies with writes in flight leaves several of them waiting

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -1486,6 +1486,11 @@ type laneJoinResult struct {
 	lane *mpLane
 	id   uint64
 	err  error
+	// replacement distinguishes a join opened because the flow has no lane
+	// left from one opened to widen a healthy bundle. Only the first is a
+	// replacement attempt, and the result arrives too late to tell by looking
+	// at the flow: by then it may have recovered or died.
+	replacement bool
 }
 
 // errLaneJoinRejected reports that the peer answered a lane join and refused
@@ -1948,7 +1953,9 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 				}
 				recoveryAttempts++
 				lastRecoveryAttempt = now
+				flow.noteReplacementAttempt()
 				if err := c.openRecoveryLane(manageCtx, flow, sessionID, flowID); err != nil {
+					flow.noteReplacementFailure()
 					if errors.Is(err, errLaneJoinRejected) {
 						// The peer answered, and its answer was that it does
 						// not hold this session. That does not change: a
@@ -1957,11 +1964,16 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 						// grace learning the same thing, so record the refusal
 						// and let the flow fail now.
 						flow.resumeRefused.Store(true)
-						c.cfg.Logger.Debug("peer cannot resume this association", "error", err)
+						c.cfg.Logger.Debug("peer cannot resume this association", "flow_id", flowID, "error", err)
 						return
 					}
 					if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-						c.cfg.Logger.Warn("lane recovery unavailable", "error", err)
+						// The flow this belongs to is the whole point of the
+						// line: a gateway record saying a flow failed with no
+						// replacement cannot be told from one where none was
+						// tried unless the attempts can be found by flow.
+						c.cfg.Logger.Warn("lane recovery unavailable", "flow_id", flowID,
+							"attempt", recoveryAttempts, "error", err)
 					}
 					if recoveryBackoff == 0 {
 						recoveryBackoff = time.Second
@@ -2094,16 +2106,19 @@ func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessi
 	var lastFailure time.Time
 	observedLaneFailures := flow.laneFailureCount()
 
-	launch := func() bool {
+	launch := func(replacement bool) bool {
 		laneID, err := flow.allocateJoinID()
 		if err != nil {
 			return false
+		}
+		if replacement {
+			flow.noteReplacementAttempt()
 		}
 		pending++
 		go func() {
 			lane, joinErr := c.openJoinLane(manageCtx, TransportTCP, sessionID, flowID, laneID)
 			select {
-			case joins <- laneJoinResult{lane: lane, id: laneID, err: joinErr}:
+			case joins <- laneJoinResult{lane: lane, id: laneID, err: joinErr, replacement: replacement}:
 			case <-manageCtx.Done():
 				if lane != nil {
 					_ = lane.fc.Close()
@@ -2124,6 +2139,9 @@ func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessi
 				pending--
 			}
 			if result.err != nil {
+				if result.replacement {
+					flow.noteReplacementFailure()
+				}
 				if manageCtx.Err() != nil || flow.doneChanClosed() {
 					return
 				}
@@ -2206,7 +2224,7 @@ func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessi
 			}
 			recoveryAttempts++
 			lastRecoveryAttempt = now
-			launch()
+			launch(true)
 			continue
 		}
 		// An accept-then-close peer must not reset the replacement budget on
@@ -2235,7 +2253,10 @@ func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessi
 		}
 		missing := c.cfg.TCPFallbackLanes - healthy - pending
 		for range missing {
-			if !launch() {
+			// Widening a bundle that already has a healthy lane is not a
+			// replacement, and counting it as one would bury the flows that
+			// have nothing left in the ordinary run of bulk transfers.
+			if !launch(false) {
 				break
 			}
 		}

--- a/internal/pep/lanegrace_test.go
+++ b/internal/pep/lanegrace_test.go
@@ -260,3 +260,57 @@ func TestAStaleDeadlineDoesNotDenyTheNextOutageItsGrace(t *testing.T) {
 		t.Fatalf("an outage inheriting a stale deadline waited %s of its %s grace", elapsed, grace)
 	}
 }
+
+// The gateway's failing flows say a replacement never arrived: 84% of its
+// lane-replacement-timeout failures ended with no replacement lane ever
+// admitted. The record could not say why, and the two reasons need different
+// fixes -- a client pool that will not rebuild opens nothing, and a path that
+// will not carry a handshake opens attempts that never complete. A dial that
+// fails never reaches addLane, so `lanes_joined` reads the same either way.
+// See issue #53.
+func TestAFlowRecordsWhetherAReplacementWasEvenAttempted(t *testing.T) {
+	fields := func(f *multipathFlow) map[string]any {
+		raw := f.replacementLogFields()
+		out := map[string]any{}
+		for i := 0; i+1 < len(raw); i += 2 {
+			out[raw[i].(string)] = raw[i+1]
+		}
+		return out
+	}
+
+	// Nothing tried: the pool never rebuilt.
+	quiet := newGraceTestFlow(t)
+	got := fields(quiet)
+	if got["lane_replacement_attempts"] != uint64(0) || got["lane_replacement_failures"] != uint64(0) {
+		t.Fatalf("a flow that attempted nothing reports attempts=%v failures=%v",
+			got["lane_replacement_attempts"], got["lane_replacement_failures"])
+	}
+
+	// Tried and could not finish a handshake: the path will not carry one.
+	refused := newGraceTestFlow(t)
+	for i := 0; i < 3; i++ {
+		refused.noteReplacementAttempt()
+		refused.noteReplacementFailure()
+	}
+	got = fields(refused)
+	if got["lane_replacement_attempts"] != uint64(3) || got["lane_replacement_failures"] != uint64(3) {
+		t.Fatalf("three failed dials reported attempts=%v failures=%v, want 3 and 3",
+			got["lane_replacement_attempts"], got["lane_replacement_failures"])
+	}
+
+	// Both flows are indistinguishable by the fields that existed before: they
+	// waited for nothing and nothing joined. That is the gap being closed.
+	if fields(quiet)["lanes_joined"] != fields(refused)["lanes_joined"] {
+		t.Fatal("the test no longer exercises the case the attempt counts were added for")
+	}
+
+	// A dial still outstanding is not yet a failure, or "nothing came back
+	// yet" would read as "the path refused it".
+	pending := newGraceTestFlow(t)
+	pending.noteReplacementAttempt()
+	got = fields(pending)
+	if got["lane_replacement_attempts"] != uint64(1) || got["lane_replacement_failures"] != uint64(0) {
+		t.Fatalf("an outstanding dial reported attempts=%v failures=%v, want 1 and 0",
+			got["lane_replacement_attempts"], got["lane_replacement_failures"])
+	}
+}

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -275,6 +275,18 @@ type multipathFlow struct {
 	// waiter spends separately, and it is cleared in startLane so that a flow
 	// which really is being rescued gets a fresh grace for its next outage.
 	replacementDeadline atomic.Int64
+	// Replacement attempts, counted only for a flow that has no lane left.
+	// `lanes_joined` says whether a replacement was ever admitted, and for
+	// 84% of the gateway's lane-replacement-timeout failures the answer is no
+	// -- but it cannot say why, because a dial whose handshake never completes
+	// never reaches addLane and leaves the record identical to a flow where
+	// nothing was ever dialled. Those are the two faults #53 needs separated:
+	// a client pool that will not rebuild, against a path that will not carry
+	// a handshake. Only the endpoint that opens replacements can tell them
+	// apart, and only while it is trying. The other endpoint reports zeroes,
+	// which is the true answer there: it opens nothing.
+	replacementAttempts atomic.Uint64
+	replacementFailures atomic.Uint64
 	// controlLaneShared reports whether another flow is currently using the
 	// pooled control connection. Nil means "no", which is what a flow on a
 	// dedicated connection should answer.
@@ -1727,8 +1739,22 @@ func (f *multipathFlow) replacementLogFields() []any {
 		"lane_replacement_timeouts", timeouts,
 		"lane_replacement_wait", waited,
 		"lanes_joined", joined,
+		"lane_replacement_attempts", f.replacementAttempts.Load(),
+		"lane_replacement_failures", f.replacementFailures.Load(),
 	}
 }
+
+// noteReplacementAttempt records that this endpoint has begun opening a
+// replacement lane for a flow that has none. It is counted at the point the
+// dial starts rather than when it finishes, because a dial that never returns
+// is exactly the case the count exists to make visible.
+func (f *multipathFlow) noteReplacementAttempt() { f.replacementAttempts.Add(1) }
+
+// noteReplacementFailure records that one such attempt did not produce a lane.
+// Attempts without failures mean the dials are still outstanding; attempts
+// equal to failures mean the path is refusing to carry a handshake; no
+// attempts at all means nothing tried.
+func (f *multipathFlow) noteReplacementFailure() { f.replacementFailures.Add(1) }
 
 // replacementDiagnostics reports what this flow's lane replacements did, for
 // the record written when a flow ends. Zero waits is the ordinary case and


### PR DESCRIPTION
Third step on #53, and the one the re-measurement asked for. Measurement
posted on the issue; the short version is below.

## What the gateway says now

169,293 flow records from `rtx-pro`, spanning five deployed builds. In the
window running #50 and #54 (`main-89a1ecf` → `diag-trace-8bd98b9`, 26,475
flows, 279 `lane replacement timeout` failures):

| | |
| --- | --- |
| failures with **no replacement lane admitted** (`lanes_joined` ≤ 1) | **234 / 279 = 83.9%** |
| failures with a replacement admitted and still failing | 45 / 279 = 16.1% |

So the dominant residue is a flow whose last lane died and for which nothing
ever arrived. The record stops there. It cannot say whether anything was
**tried**, and the two answers want different fixes:

- a **client pool that will not rebuild** opens nothing at all;
- a **path that will not carry a handshake** opens dials that never complete.

Both leave `lanes_joined` untouched, because a dial that fails never reaches
`addLane`. #53 named this distinction as the thing the logs could not make and
#54 did not close it — it recorded what the *waiting* did, not what the
*opening* did.

## What this adds

`lane_replacement_attempts` and `lane_replacement_failures`, on flow completion
records from both endpoints under the same names, beside the four fields #54
added.

- **No attempts** — nothing was dialled. The pool did not rebuild.
- **Attempts equal to failures** — every dial was made and none completed. The
  path is refusing handshakes.
- **Attempts above failures** — dials are still outstanding, which is not the
  same as refused and must not read as it.

Attempts are counted where the dial *starts*, not where it returns. A dial that
never returns is precisely the case the count exists to make visible, and
counting on completion would leave it invisible in exactly the population being
investigated.

A gateway reports zeroes. That is the true answer there rather than a gap: the
replacement is the client's to send, and #54's convention of writing the same
names from both ends is what lets a client record and a gateway record about
one failure be read side by side.

## Both replacement paths, and only those

`manageQUICLanes` and the TCP bundle manager both replace a lost lane. The
bundle manager also opens joins to *widen* a healthy bundle, and its results
arrive asynchronously — too late to tell the two apart by inspecting the flow,
which by then may have recovered or died. So the launch is tagged at the point
the reason is known. Widening a healthy bundle is not a replacement, and
counting it would bury the flows that have nothing left in the ordinary run of
bulk transfers.

## The client log

`lane recovery unavailable` (`client.go`) recorded only the error — no flow —
so even when the attempts behind a failed flow *had* been logged they could not
be found. It now carries `flow_id` and the attempt number. `lane recovery
abandoned` already had the flow but only fires when the whole 8-attempt budget
is spent, which the flows in question do not reach.

## Checks

`go test -short ./...` green across 27 packages, `go vet`, `gofmt`, and
`./scripts/changelog.py check`. The new test asserts the two faults are
distinguishable by the new fields *and* that they remain indistinguishable by
`lanes_joined`, so it fails if the gap it was written for ever stops existing.

## Changelog

- [x] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [ ] Or: this change is not user-visible (refactor, test, internal docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01858EDFqaLY9C1ahbiUrjtN
