### PR TITLE
fix: the sample shape never left the controller

### DIFF
--- a/changelog.d/sample-shape-never-left-the-controller.fixed.md
+++ b/changelog.d/sample-shape-never-left-the-controller.fixed.md
@@ -1,0 +1,19 @@
+The bandwidth sample shape is published rather than reading zero.
+`queqiao_quic_sample_mean_bytes_per_second`, `..._max_bytes_per_second`,
+`..._max_delivered_bytes` and `..._max_interval_seconds` were added in v0.3.0
+to describe the delivery-rate samples the bandwidth estimate is built from.
+The controller stored all four in atomics and the snapshot that carries
+telemetry out of it never read them back, so every one of them left the
+process as zero.
+
+That is the failure mode v0.3.0 removed two other counters for: a figure that
+cannot be produced reads as a measurement rather than as an absence, and
+"the widest sample this connection ever took was nothing" is a claim these
+metrics were making on every scrape. It was found by deploying v0.3.0 to the
+gateway it was written for and reading the metric it added.
+
+The four are the instrumentation for a question that a harness could not
+settle -- an estimator driven against a simulated policer reports within one
+per cent of the path while the same estimator in the full stack reported
+twice it -- so publishing them as zero left that question exactly as open as
+it was before they existed.

--- a/internal/congestion/sampleshape_test.go
+++ b/internal/congestion/sampleshape_test.go
@@ -1,0 +1,37 @@
+package congestion
+
+import (
+	"testing"
+	"time"
+)
+
+// The sample shape has to survive the trip out of the controller.
+//
+// updateSampleShape stores four figures in atomics and snapshot builds the
+// struct the rest of the process reads. A field written on one side and not
+// read on the other produces a metric that is always zero, which is worse than
+// a missing one: queqiao_quic_sample_max_bytes_per_second reads as "the widest
+// sample was nothing" rather than as "nobody published this".
+//
+// This is asserted against the telemetry state directly rather than through a
+// sender, because the defect is in the copy and a test that drives a sender
+// would only find it if the sender happened to take a sample first.
+func TestTheSampleShapeSurvivesTheSnapshot(t *testing.T) {
+	var state telemetryState
+	state.updateSampleShape(1_100, 9_400, 13_000, 37*time.Millisecond)
+
+	got := state.snapshot()
+
+	if got.SampleMean != 1_100 {
+		t.Errorf("SampleMean = %d, want 1100", got.SampleMean)
+	}
+	if got.SampleMax != 9_400 {
+		t.Errorf("SampleMax = %d, want 9400", got.SampleMax)
+	}
+	if got.SampleMaxDelivered != 13_000 {
+		t.Errorf("SampleMaxDelivered = %d, want 13000", got.SampleMaxDelivered)
+	}
+	if got.SampleMaxInterval != 37*time.Millisecond {
+		t.Errorf("SampleMaxInterval = %v, want 37ms", got.SampleMaxInterval)
+	}
+}

--- a/internal/congestion/telemetry.go
+++ b/internal/congestion/telemetry.go
@@ -205,5 +205,9 @@ func (t *telemetryState) snapshot() ControllerTelemetry {
 		PacketsLostObserved: t.packetsLost.Load(),
 		MinRTT:              time.Duration(t.minRTTNS.Load()),
 		InRecovery:          t.inRecovery.Load(),
+		SampleMean:          t.sampleMean.Load(),
+		SampleMax:           t.sampleMax.Load(),
+		SampleMaxDelivered:  t.sampleMaxDelivered.Load(),
+		SampleMaxInterval:   time.Duration(t.sampleMaxIntervalNS.Load()),
 	}
 }


### PR DESCRIPTION
Found by deploying v0.3.0 to the gateway it was written for and reading the metric it added.

## The defect

`updateSampleShape` stores four figures in atomics:

```go
func (t *telemetryState) updateSampleShape(mean, max, delivered uint64, interval time.Duration) {
	t.sampleMean.Store(mean)
	t.sampleMax.Store(max)
	t.sampleMaxDelivered.Store(delivered)
	t.sampleMaxIntervalNS.Store(int64(interval))
}
```

`snapshot()` builds the `ControllerTelemetry` that everything downstream reads — and copied **none of them**. The plumbing on either side is correct: the estimator counts samples, `publishTelemetry` calls `updateSampleShape`, `mpflow` maxes the fields across lanes, `metrics` maxes them across flows. The one link that was missing is the copy out of the atomics, so all four were structurally zero on every scrape.

Live on the gateway, with 5,933 samples recorded:

```
queqiao_quic_controller_samples_total 5933
queqiao_quic_sample_mean_bytes_per_second 0
queqiao_quic_sample_max_bytes_per_second 0
```

## Why it is worth a fix rather than a note

This is the exact failure mode v0.3.0 **deleted** `queqiao_quic_packets_lost` and `queqiao_quic_bytes_lost` for, in its own changelog:

> A counter that cannot be produced is worse than a missing one once it is monotonic, because it then reads as a measurement rather than as an absence.

"The widest sample this connection ever took was nothing" is what these four were asserting on every scrape.

And it defeats their whole purpose. The v0.3.0 entry says they exist because the question could not be settled in a harness — an estimator driven against a simulated policer reports within 1% of the path while the same estimator in the full stack reported twice it. Publishing zeros left that question exactly as open as before they were added, which is why this was invisible until someone read the metric on a real endpoint.

## The test

Asserts the copy directly rather than driving a sender: the defect is in `snapshot()`, and a sender-level test only catches it if the sender happens to take a sample first. Verified red against the defect on all four fields, green after.

```
--- FAIL: TestTheSampleShapeSurvivesTheSnapshot
    SampleMean = 0, want 1100
    SampleMax = 0, want 9400
    SampleMaxDelivered = 0, want 13000
    SampleMaxInterval = 0s, want 37ms
```

Telemetry only — no traffic path touches these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01554FNHpKrhTdAX4TCcittf