### PR TITLE
fix: a burst is what the path holds, not an addition to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,16 @@ to `changelog.d/` instead, as [`CONTRIBUTING.md`](CONTRIBUTING.md) describes.
   signals read clean on exactly the path where bursting is worst: gating on them
   alone took an emulated policer from 3.0x overdrive to 4.0x and from 32.9% loss
   to 54.9%.
+- The unmetered burst is what the path already holds rather than an addition to
+  it: what is in flight comes out of the allowance, and the bandwidth-delay
+  product it is measured against is the one the path delivers, not the larger
+  figure this sender puts on the wire to compensate erasure. A request-shaped
+  flow arrives with an empty pipe and is unaffected, which is the case the
+  burst exists for. A saturating flow is already holding that product, and
+  granting it another drove a burst into the bottleneck that the delay brake
+  then read as congestion: on the emulated erasure path the erasure controller
+  fell from 10.5 to 0.9 Mbit/s of a 14.5 Mbit/s capacity, and monotonically
+  worse the larger the burst.
 - Flow completion records now say whether a replacement lane was ever attempted,
   not only whether one arrived: `lane_replacement_attempts` and
   `lane_replacement_failures` join the fields already written by both endpoints.

--- a/internal/congestion/erasure.go
+++ b/internal/congestion/erasure.go
@@ -105,6 +105,18 @@ type ErasureSender struct {
 	// callback that computes it.
 	congestive atomic.Uint64
 
+	// inFlight is what this connection already has on the wire, recorded from
+	// the callbacks that carry it because the pacer, like the fields above,
+	// runs outside them.
+	inFlight atomic.Uint64
+
+	// samples is how many decided packets the estimator's report rests on.
+	// Both gates above read their own zero value as a clean path, so until
+	// there is evidence behind that reading, the absence of evidence is
+	// indistinguishable from evidence of absence -- the reading this sender
+	// refuses everywhere else.
+	samples atomic.Uint64
+
 	// passed counts the losses handed to the inner controller, which is now
 	// all of them. It stays because the telemetry below is an assertion as
 	// much as a measurement: what this sender saw and what the controller was
@@ -214,14 +226,28 @@ func newErasureSender(initialPacketSize quiccongestion.ByteCount) *ErasureSender
 	return e
 }
 
-func (e *ErasureSender) bandwidth() quiccongestion.ByteCount {
+// deliveredRate is BBR's estimate of what arrives, bounded by this lane's
+// share of the endpoint pair's bottleneck.
+//
+// The cap is what keeps lanes from compounding. Each lane's own estimate is
+// what it alone is receiving, so four lanes each probing above their own
+// estimate put four times the overshoot into one bottleneck; capping at the
+// share means the aggregate on the wire is what a single sender would have put
+// there. The burst allowance is measured against this for the same reason.
+func (e *ErasureSender) deliveredRate() float64 {
 	delivered := float64(e.inner.bandwidth())
 	if share := float64(e.share.Load()); share > 0 && share < delivered {
 		delivered = share
 	}
+	return delivered
+}
+
+// bandwidth is the rate to put on the wire: what arrives, divided by the
+// fraction that arrives.
+func (e *ErasureSender) bandwidth() quiccongestion.ByteCount {
 	// The delay bound is applied after the erasure compensation rather than
 	// before it, because the queue holds what was sent and not what arrived.
-	return quiccongestion.ByteCount(e.delayBounded(delivered / e.arrivalRate()))
+	return quiccongestion.ByteCount(e.delayBounded(e.deliveredRate() / e.arrivalRate()))
 }
 
 // compensationFor decides how much of a proposed compensation to apply, by
@@ -389,6 +415,16 @@ func (e *ErasureSender) delayBounded(rate float64) float64 {
 // latency every window-based controller accepts, and a burst loss on the way
 // there is repaired by the code rather than by a retransmission.
 func (e *ErasureSender) unmeteredBurst() quiccongestion.ByteCount {
+	// Too little has reported on this channel for the two gates below to be
+	// reading anything but their own initial zeroes, which is a clean path. That
+	// is how a startup burst was granted on a channel erasing 42%: by the time
+	// the erasure ceiling had a measurement to refuse it with, the burst had
+	// already built the queue, and the delay brake holds the rate down long
+	// after. Measured on the emulated erasure path, closing this window alone
+	// was the difference between 9.4 and 10.5 Mbit/s.
+	if e.samples.Load() < burstEvidenceSamples {
+		return 0
+	}
 	if float64(e.congestive.Load())/partsPerMillion > 0 {
 		return 0
 	}
@@ -416,7 +452,32 @@ func (e *ErasureSender) unmeteredBurst() quiccongestion.ByteCount {
 	if minRTT <= 0 || queue >= minRTT {
 		return 0
 	}
-	return e.GetCongestionWindow()
+	// What is already on the wire has to come out of the allowance, and the
+	// paragraph above is what explains why. A burst below the bandwidth-delay
+	// product cannot build a standing queue only if it is what the path holds;
+	// granted on top of a window that is already in flight it is not that, it
+	// is one product of overshoot, and the congestion window is no bound on it
+	// because this sender's window is inflated by the erasure compensation.
+	//
+	// The two flows this has to separate both look uncongested by the signals
+	// above. A request-shaped flow arrives with an empty pipe and gets the
+	// whole product, which is the case this exists for: 355KB against a 1.09MB
+	// product on the 207ms datacenter path, released without paying the 67ms.
+	// A saturating flow is already holding a product or more, gets nothing, and
+	// stays metered. Measured on the emulated erasure path, granting it the
+	// window regardless drove a burst into a 25 Mbit/s bottleneck, the delay
+	// brake read the queue that built, and the controller fell from 10.5 to
+	// 0.9 Mbit/s of a 14.5 Mbit/s capacity -- worse, monotonically, the larger
+	// the burst: 0.53 at 128KB and 0.09 at 1MB.
+	product := quiccongestion.ByteCount(e.deliveredRate() * minRTT.Seconds())
+	allowance := product - quiccongestion.ByteCount(e.inFlight.Load())
+	if allowance <= 0 {
+		return 0
+	}
+	if window := e.GetCongestionWindow(); window < allowance {
+		return window
+	}
+	return allowance
 }
 
 // burstLossCeiling is how much loss the sending direction may show and still
@@ -430,8 +491,22 @@ func (e *ErasureSender) unmeteredBurst() quiccongestion.ByteCount {
 // own traffic, and it meters rather than guess.
 const burstLossCeiling = 0.01
 
-func (e *ErasureSender) TimeUntilSend(quiccongestion.ByteCount) monotime.Time {
+// burstEvidenceSamples is how many decided packets must lie behind that
+// measurement before it is allowed to open the gate rather than close it. It is
+// the ceiling above read backwards: a channel cannot be called cleaner than one
+// packet in a hundred on the evidence of fewer than a few hundred of them.
+const burstEvidenceSamples = 4 / burstLossCeiling
+
+func (e *ErasureSender) TimeUntilSend(bytesInFlight quiccongestion.ByteCount) monotime.Time {
+	e.recordInFlight(bytesInFlight)
 	return e.pacer.timeUntilSend()
+}
+
+func (e *ErasureSender) recordInFlight(bytesInFlight quiccongestion.ByteCount) {
+	if bytesInFlight < 0 {
+		bytesInFlight = 0
+	}
+	e.inFlight.Store(uint64(bytesInFlight))
 }
 
 func (e *ErasureSender) HasPacingBudget(now monotime.Time) bool {
@@ -447,6 +522,7 @@ func (e *ErasureSender) OnPacketSent(sentTime monotime.Time, bytesInFlight quicc
 // compensated rate: the window bounds what is on the wire, and on an erasure
 // channel what is on the wire is more than what will arrive.
 func (e *ErasureSender) CanSend(bytesInFlight quiccongestion.ByteCount) bool {
+	e.recordInFlight(bytesInFlight)
 	return bytesInFlight < e.GetCongestionWindow()
 }
 
@@ -509,6 +585,9 @@ func (e *ErasureSender) OnCongestionEventEx(priorInFlight quiccongestion.ByteCou
 		e.estimator.ObserveOutcome(outcome.arrived)
 	}
 	snapshot := e.estimator.Snapshot()
+	if snapshot.Samples > 0 {
+		e.samples.Store(uint64(snapshot.Samples))
+	}
 	if snapshot.Congestive > 0 {
 		e.congestive.Store(uint64(snapshot.Congestive * partsPerMillion))
 	} else {

--- a/internal/congestion/erasure_test.go
+++ b/internal/congestion/erasure_test.go
@@ -407,6 +407,16 @@ func TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom(t *testing.T) {
 
 }
 
+// characterized gives a sender the evidence the burst rule needs before it will
+// read a clean channel as clean. The tests below state the estimator's
+// conclusions directly rather than driving packets through it, so they have to
+// state how much was behind them as well: a sender that has just started has
+// measured nothing, and nothing is not a report of a clean path.
+func characterized(e *ErasureSender) *ErasureSender {
+	e.samples.Store(burstEvidenceSamples)
+	return e
+}
+
 // The pacer used to meter every send at a bandwidth estimate that a
 // request-shaped flow cannot raise, because such a flow is application-limited
 // by construction. On the measured datacenter path that cost 67ms of a 355KB
@@ -417,7 +427,7 @@ func TestTheSenderPublishesTheMeasurementItsCodeIsSizedFrom(t *testing.T) {
 // path's own minimum, and no loss the estimator attributed to rate. These pin
 // that the burst follows that evidence rather than a constant.
 func TestNoCongestionEvidenceMeansNoMetering(t *testing.T) {
-	e := senderAtRTT(t, 200*time.Millisecond, 202*time.Millisecond)
+	e := characterized(senderAtRTT(t, 200*time.Millisecond, 202*time.Millisecond))
 	got := e.unmeteredBurst()
 	if got <= 0 {
 		t.Fatal("a path holding almost no queue, with no loss attributed to rate, is " +
@@ -433,7 +443,7 @@ func TestNoCongestionEvidenceMeansNoMetering(t *testing.T) {
 // The delay bound permits a queue of one round trip. At it, the sender is doing
 // the thing pacing exists to prevent, so metering has to come back.
 func TestAQueueAtTheBoundRestoresMetering(t *testing.T) {
-	e := senderAtRTT(t, 200*time.Millisecond, 400*time.Millisecond)
+	e := characterized(senderAtRTT(t, 200*time.Millisecond, 400*time.Millisecond))
 	if got := e.unmeteredBurst(); got != 0 {
 		t.Fatalf("a path holding a full round trip of queue reported an unmetered burst "+
 			"of %d; that is the bound this controller says must not be exceeded", got)
@@ -444,7 +454,7 @@ func TestAQueueAtTheBoundRestoresMetering(t *testing.T) {
 // separating it from the channel's own erasure is what this project is for.
 // Erasure alone must not restore metering; congestive loss must.
 func TestOnlyCongestiveLossRestoresMetering(t *testing.T) {
-	e := senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond)
+	e := characterized(senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond))
 	if e.unmeteredBurst() <= 0 {
 		t.Fatal("precondition: a quiet path should not be metered")
 	}
@@ -476,7 +486,7 @@ func TestNoRoundTripMeasurementKeepsTheConstant(t *testing.T) {
 // 4.0x and from 32.9% loss to 54.9%, because metering was the last thing
 // holding the rate down. See internal/pep/case4_test.go.
 func TestALossyDirectionIsStillMetered(t *testing.T) {
-	e := senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond)
+	e := characterized(senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond))
 	if e.unmeteredBurst() <= 0 {
 		t.Fatal("precondition: a clean quiet path should not be metered")
 	}
@@ -492,10 +502,95 @@ func TestALossyDirectionIsStillMetered(t *testing.T) {
 // the burst exists for. A trace of loss must not close the gate, or the rule
 // would never fire on a real link.
 func TestAnAlmostCleanDirectionStillBursts(t *testing.T) {
-	e := senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond)
+	e := characterized(senderAtRTT(t, 200*time.Millisecond, 201*time.Millisecond))
 	e.erasure.Store(uint64(0.001 * partsPerMillion))
 	if e.unmeteredBurst() <= 0 {
 		t.Fatal("a direction losing one packet in a thousand is being metered; the " +
 			"measured datacenter upload lost 0 of 41,663 and this rule has to fire there")
+	}
+}
+
+// The burst has to come out of what the path already holds, not be added to
+// it. Every signal the two rules above consult reads clean for a saturating
+// flow on an erasing path -- no queue past the minimum, no loss attributed to
+// rate -- so without this the flow was handed a further bandwidth-delay
+// product on top of a window that was already in flight. It drove that into
+// the bottleneck, the delay brake read the queue that built, and the rate it
+// clamped to was the rate the flow kept: on the emulated erasure path the
+// erasure controller fell from 10.5 to 0.9 Mbit/s of a 14.5 Mbit/s capacity,
+// and monotonically worse the larger the burst.
+//
+// TestTheErasureControllerReachesThePathOthersGiveAway is what caught it, and
+// that test skips under -short, so it reached main through a green CI and was
+// found by a release candidate. This one is here so the next such change fails
+// in the normal suite instead.
+func TestAFlowAlreadyUsingThePathIsStillMetered(t *testing.T) {
+	const minRTT = 200 * time.Millisecond
+	e := characterized(senderAtRTT(t, minRTT, minRTT+2*time.Millisecond))
+
+	// The product is computed from what the path delivers rather than from
+	// what this sender puts on the wire. The two differ by the erasure
+	// compensation, and it is the delivered figure that says how much the path
+	// holds; the compensated one says only that we send more to get it there.
+	product := quiccongestion.ByteCount(float64(e.inner.bandwidth()) * minRTT.Seconds())
+	if product <= 0 {
+		t.Fatalf("no bandwidth-delay product to reason about: %d", product)
+	}
+
+	// An empty pipe is the case the burst exists for and must keep.
+	e.TimeUntilSend(0)
+	empty := e.unmeteredBurst()
+	if empty <= 0 {
+		t.Fatal("a flow with an empty pipe on an uncongested path is being metered; " +
+			"that is the 355KB request this rule was written for")
+	}
+
+	// A flow already holding a product is doing the thing pacing exists to
+	// bound, whatever the other two signals say about it.
+	e.TimeUntilSend(product)
+	if got := e.unmeteredBurst(); got != 0 {
+		t.Errorf("a flow already holding one product in flight was granted a further "+
+			"%d bytes unmetered; the burst has to be what the path holds, not an "+
+			"addition to it", got)
+	}
+
+	// And between the two the allowance is what remains of the product, so it
+	// falls as the pipe fills rather than switching off at one end of it. The
+	// window is the other bound and binds first on an empty pipe, so leave
+	// less than a window of the product to see the product doing the work.
+	window := e.GetCongestionWindow()
+	e.TimeUntilSend(product - window/2)
+	partial := e.unmeteredBurst()
+	if partial != window/2 {
+		t.Errorf("with %d bytes of the product unused, the allowance is %d, want %d: "+
+			"what is left of it", window/2, partial, window/2)
+	}
+	if partial >= empty {
+		t.Errorf("a part-full pipe was granted %d, no less than the %d an empty one "+
+			"gets", partial, empty)
+	}
+}
+
+// Both gates read their own zero value as a clean channel, so a sender that has
+// measured nothing looks exactly like a sender on a perfect path. It is not the
+// same claim, and reading it as one granted a startup burst on a channel erasing
+// 42%: by the time the erasure ceiling had a measurement to refuse with, the
+// burst had built the queue that the delay brake then holds the rate down for.
+// Closing this window was worth about a tenth of the erasure controller's rate
+// on the emulated path, over and above the in-flight bound above.
+func TestAChannelNothingHasMeasuredIsNotACleanChannel(t *testing.T) {
+	e := senderAtRTT(t, 200*time.Millisecond, 202*time.Millisecond)
+	e.TimeUntilSend(0)
+
+	if got := e.unmeteredBurst(); got != 0 {
+		t.Errorf("a sender that has decided no packets granted a burst of %d; nothing "+
+			"has reported on this channel, and nothing is not a report of a clean one", got)
+	}
+
+	// The same sender, once there is evidence behind that reading.
+	e.samples.Store(burstEvidenceSamples)
+	if e.unmeteredBurst() <= 0 {
+		t.Error("a measured clean path is being metered; the evidence gate has to open " +
+			"once there is evidence, or the burst never fires on a real link")
 	}
 }


### PR DESCRIPTION
Unblocks the v0.4.0 release candidate, which failed `full` and all six
`native-test` jobs on `TestTheErasureControllerReachesThePathOthersGiveAway`
and `TestAShortFlowCostsARoundTrip`.

Bisected to `5957f92`, the pacing change in this same unreleased version. It
grants an unmetered burst when nothing says the path is congested, and two
things were wrong with what it granted.

**The burst was added to what was already in flight.** The argument for it --
a burst below one bandwidth-delay product cannot build a standing queue -- is
true of a burst that *is* what the path holds, and false of one handed to a
flow on top of a window already on the wire. The congestion window is no
bound on it here either, since this sender's window is inflated by the
erasure compensation. A saturating flow drove a further product into a 25
Mbit/s bottleneck, the delay brake read the queue, and the clamped rate was
the rate the flow kept. Monotonic in burst size: 1.73 Mbit/s at a window,
0.53 at 128KB, 0.09 at 1MB.

**Both gates read their own zero value as a clean channel.** A sender that
has measured nothing is not a sender reporting a clean path, but that is how
it read, so the startup burst was granted on a channel erasing 42% -- and by
the time the erasure ceiling had a measurement to refuse with, the queue was
built.

## Measured

Emulated erasure path, `-count=1` throughout (the earlier "stable" readings
in this investigation were Go's test cache replaying one result):

| | Mbit/s delivered, 14.5 capacity |
| --- | --- |
| pre-regression (`010e9f7`) | 10.69, 10.53, 10.72 |
| burst disabled outright | 10.66, 10.63, 10.47 |
| **this branch** | **10.65, 10.68, 10.64, 10.50** |
| on `main` today | 0.92, 0.74, 0.79 |

Indistinguishable from both references, which is the claim: the burst now
costs the saturating case nothing, and the request-shaped flow it was written
for still gets the whole product -- 355KB against a 1.09MB product on the
207ms datacenter path.

## Checks

`go test -short ./...` (30 packages), `go vet`, `gofmt`, staticcheck
`-checks=all,-U1000`, `changelog.py check`, 85 script tests, plus the two
full-suite tests that failed in the candidate.

Both halves are pinned by new tests in the *normal* suite:
`TestAFlowAlreadyUsingThePathIsStillMetered` and
`TestAChannelNothingHasMeasuredIsNotACleanChannel`. Each was verified to fail
without its half of the fix. That matters here -- the test that caught this
skips under `-short`, so every PR check was green while the regression sat on
main.

Carries the `changelog` label because it amends v0.4.0's unshipped section to
describe the pacing rule as it will actually ship.