### PR TITLE
feat: a routing rule matcher, and a reader for the set it asks

### DIFF
--- a/internal/routerule/geoip.go
+++ b/internal/routerule/geoip.go
@@ -1,0 +1,167 @@
+package routerule
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+)
+
+// Packed answers GEOIP rules from the fixed-width set that
+// scripts/generate_cn_geoip.py produces from registry delegation data. It is
+// the same file mobile/ios/PacketTunnel/Resources/cn-direct.bin, read by the
+// same rules as mobile/ios/Shared/CountryRoutes.swift, and scripts/
+// test_cn_geoip.py holds the generator's half of the contract.
+//
+// The blob is kept as bytes and searched in place rather than parsed into
+// prefixes. The China set is about seven and a half thousand v4 blocks, which
+// is a quarter of a megabyte once it is netip.Prefix values, and this has to
+// stay resident to answer a rule on every flow -- unlike the Swift reader,
+// which builds the routes once at connect and drops them. docs/MOBILE-MEMORY.md
+// is the budget that makes the difference matter: the packet-tunnel extension
+// shares a fixed profile with the Go runtime.
+//
+// The entries are fixed-width and the generator emits them sorted and
+// collapsed, which is what makes a binary search over the raw bytes possible at
+// all. Load verifies both properties rather than trusting them, because a set
+// that is not sorted answers "no" for addresses it holds, and a GEOIP,CN,DIRECT
+// rule that answers "no" sends Chinese traffic through the tunnel silently --
+// the exact failure this feature exists to remove.
+type Packed struct {
+	code string
+	v4   []byte
+	v6   []byte
+}
+
+const (
+	packedHeaderSize = 16
+	packedV4Entry    = 5
+	packedV6Entry    = 17
+	packedVersion    = 1
+)
+
+var packedMagic = []byte{0x51, 0x51, 0x47, 0x4F} // "QQGO"
+
+// LoadPacked reads a packed set and binds it to a two-letter country code. The
+// file itself does not name the country it holds -- it is generated per country
+// and shipped under a name that says which -- so the caller supplies it.
+func LoadPacked(code string, blob []byte) (*Packed, error) {
+	if len(blob) < packedHeaderSize {
+		return nil, fmt.Errorf("route set is %d bytes, too short for a header", len(blob))
+	}
+	if !bytes.Equal(blob[:4], packedMagic) {
+		return nil, fmt.Errorf("route set does not carry the expected header")
+	}
+	if blob[4] != packedVersion {
+		return nil, fmt.Errorf("route set is format version %d, which this build cannot read", blob[4])
+	}
+	v4Count := int(binary.BigEndian.Uint32(blob[8:12]))
+	v6Count := int(binary.BigEndian.Uint32(blob[12:16]))
+	expected := packedHeaderSize + v4Count*packedV4Entry + v6Count*packedV6Entry
+	if len(blob) != expected {
+		return nil, fmt.Errorf("route set should be %d bytes but is %d", expected, len(blob))
+	}
+	v4End := packedHeaderSize + v4Count*packedV4Entry
+	packed := &Packed{
+		code: strings.ToUpper(code),
+		v4:   blob[packedHeaderSize:v4End],
+		v6:   blob[v4End:],
+	}
+	if err := packed.verifySorted(); err != nil {
+		return nil, err
+	}
+	return packed, nil
+}
+
+func (p *Packed) verifySorted() error {
+	for _, family := range []struct {
+		name  string
+		body  []byte
+		width int
+	}{{"IPv4", p.v4, packedV4Entry}, {"IPv6", p.v6, packedV6Entry}} {
+		count := len(family.body) / family.width
+		for i := 1; i < count; i++ {
+			previous := family.body[(i-1)*family.width : (i-1)*family.width+family.width-1]
+			current := family.body[i*family.width : i*family.width+family.width-1]
+			if bytes.Compare(previous, current) >= 0 {
+				return fmt.Errorf(
+					"%s entries %d and %d are not in ascending order; a set that is not "+
+						"sorted cannot be searched and would answer no for addresses it holds",
+					family.name, i-1, i)
+			}
+		}
+	}
+	return nil
+}
+
+// Contains reports whether the address is in the set this file carries.
+//
+// A code other than the one loaded reports false. A rule naming a set the build
+// does not ship must not decide the flow -- it falls through to whatever the
+// list says next, which is the same thing that happens when no set is loaded at
+// all.
+func (p *Packed) Contains(code string, addr netip.Addr) bool {
+	if p == nil || !strings.EqualFold(code, p.code) || !addr.IsValid() {
+		return false
+	}
+	addr = unmap(addr)
+	if addr.Is4() {
+		key := addr.As4()
+		return search(p.v4, packedV4Entry, key[:])
+	}
+	key := addr.As16()
+	return search(p.v6, packedV6Entry, key[:])
+}
+
+// search finds the last block whose network address is at or below the target
+// and asks whether it covers it. One candidate is enough because the generator
+// collapses the set: no block in it contains another, so if the greatest
+// network at or below the address does not cover it, none does.
+func search(body []byte, width int, key []byte) bool {
+	addrLen := width - 1
+	count := len(body) / width
+	if count == 0 {
+		return false
+	}
+	// The first entry strictly above the target; the candidate is the one
+	// before it.
+	above := sort.Search(count, func(i int) bool {
+		return bytes.Compare(body[i*width:i*width+addrLen], key) > 0
+	})
+	if above == 0 {
+		return false
+	}
+	entry := body[(above-1)*width : above*width]
+	network, ok := netip.AddrFromSlice(entry[:addrLen])
+	if !ok {
+		return false
+	}
+	prefix := netip.PrefixFrom(network, int(entry[addrLen]))
+	if !prefix.IsValid() {
+		return false
+	}
+	target, ok := netip.AddrFromSlice(key)
+	if !ok {
+		return false
+	}
+	return prefix.Contains(target)
+}
+
+// Blocks reports how many blocks the set carries, so a screen can say how heavy
+// a toggle is without holding the prefixes.
+func (p *Packed) Blocks() int {
+	if p == nil {
+		return 0
+	}
+	return len(p.v4)/packedV4Entry + len(p.v6)/packedV6Entry
+}
+
+// Code reports the country this set was loaded for.
+func (p *Packed) Code() string {
+	if p == nil {
+		return ""
+	}
+	return p.code
+}

--- a/internal/routerule/geoip_test.go
+++ b/internal/routerule/geoip_test.go
@@ -1,0 +1,209 @@
+package routerule
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// pack builds a set in the generator's format, so the reader is tested against
+// the layout rather than against itself.
+func pack(t *testing.T, v4 []netip.Prefix, v6 []netip.Prefix) []byte {
+	t.Helper()
+	blob := append([]byte{}, packedMagic...)
+	blob = append(blob, packedVersion, 0, 0, 0)
+	blob = binary.BigEndian.AppendUint32(blob, uint32(len(v4)))
+	blob = binary.BigEndian.AppendUint32(blob, uint32(len(v6)))
+	for _, prefix := range v4 {
+		address := prefix.Addr().As4()
+		blob = append(blob, address[:]...)
+		blob = append(blob, byte(prefix.Bits()))
+	}
+	for _, prefix := range v6 {
+		address := prefix.Addr().As16()
+		blob = append(blob, address[:]...)
+		blob = append(blob, byte(prefix.Bits()))
+	}
+	return blob
+}
+
+func TestThePackedSetAnswersForBothFamilies(t *testing.T) {
+	blob := pack(t,
+		[]netip.Prefix{
+			netip.MustParsePrefix("1.0.1.0/24"),
+			netip.MustParsePrefix("14.0.0.0/8"),
+			netip.MustParsePrefix("223.255.252.0/23"),
+		},
+		[]netip.Prefix{netip.MustParsePrefix("2400:3200::/32")},
+	)
+	set, err := LoadPacked("cn", blob)
+	if err != nil {
+		t.Fatalf("loading the set: %v", err)
+	}
+	if set.Blocks() != 4 {
+		t.Errorf("reported %d blocks, want 4", set.Blocks())
+	}
+	if set.Code() != "CN" {
+		t.Errorf("code is %q, want it upper-cased to CN", set.Code())
+	}
+
+	for _, test := range []struct {
+		address string
+		want    bool
+	}{
+		{"1.0.1.0", true},    // first address of the first block
+		{"1.0.1.255", true},  // last address of it
+		{"1.0.2.0", false},   // one past it
+		{"1.0.0.255", false}, // one before it
+		{"14.203.9.1", true}, // inside the largest block
+		{"223.255.253.7", true},
+		{"223.255.254.0", false},
+		{"8.8.8.8", false},
+		{"2400:3200::1", true},
+		{"2001:db8::1", false},
+	} {
+		got := set.Contains("CN", netip.MustParseAddr(test.address))
+		if got != test.want {
+			t.Errorf("Contains(%s) = %v, want %v", test.address, got, test.want)
+		}
+	}
+}
+
+// The search takes one candidate, which is only sound because the generator
+// collapses the set. Each block's edges are where an off-by-one shows up, and
+// an off-by-one here is traffic taking the wrong path silently.
+func TestEveryBlockEdgeIsAnsweredExactly(t *testing.T) {
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+	}
+	set, err := LoadPacked("XX", pack(t, prefixes, nil))
+	if err != nil {
+		t.Fatalf("loading the set: %v", err)
+	}
+	for _, prefix := range prefixes {
+		first := prefix.Masked().Addr()
+		if !set.Contains("XX", first) {
+			t.Errorf("%s: the network address %s reads as outside the set", prefix, first)
+		}
+		last := lastAddress(prefix)
+		if !set.Contains("XX", last) {
+			t.Errorf("%s: the broadcast address %s reads as outside the set", prefix, last)
+		}
+		if next := last.Next(); set.Contains("XX", next) {
+			t.Errorf("%s: %s is one past the block and reads as inside it", prefix, next)
+		}
+		if before := first.Prev(); set.Contains("XX", before) {
+			t.Errorf("%s: %s is one before the block and reads as inside it", prefix, before)
+		}
+	}
+}
+
+func lastAddress(prefix netip.Prefix) netip.Addr {
+	addr := prefix.Masked().Addr()
+	bytes := addr.As4()
+	host := 32 - prefix.Bits()
+	value := binary.BigEndian.Uint32(bytes[:])
+	value |= (uint32(1) << host) - 1
+	binary.BigEndian.PutUint32(bytes[:], value)
+	return netip.AddrFrom4(bytes)
+}
+
+// An unsorted set cannot be binary-searched, and the failure is silent: it
+// answers "no" for addresses it holds, which sends Chinese traffic through the
+// tunnel while the toggle says it is direct. Refuse it at load.
+func TestAnUnsortedSetIsRefusedRatherThanSearched(t *testing.T) {
+	blob := pack(t, []netip.Prefix{
+		netip.MustParsePrefix("14.0.0.0/8"),
+		netip.MustParsePrefix("1.0.1.0/24"),
+	}, nil)
+	if _, err := LoadPacked("CN", blob); err == nil {
+		t.Fatal("an out-of-order set loaded; it would answer no for addresses it holds")
+	}
+}
+
+func TestAMalformedSetIsRefused(t *testing.T) {
+	good := pack(t, []netip.Prefix{netip.MustParsePrefix("1.0.1.0/24")}, nil)
+	for _, test := range []struct {
+		name string
+		blob []byte
+	}{
+		{"too short for a header", good[:8]},
+		{"wrong magic", append([]byte{'X', 'X', 'X', 'X'}, good[4:]...)},
+		{"truncated body", good[:len(good)-2]},
+	} {
+		if _, err := LoadPacked("CN", test.blob); err == nil {
+			t.Errorf("%s: loaded without complaint", test.name)
+		}
+	}
+	future := append([]byte{}, good...)
+	future[4] = packedVersion + 1
+	if _, err := LoadPacked("CN", future); err == nil {
+		t.Error("a future format version loaded; the layout it describes is not this one")
+	}
+}
+
+// A set loaded for one country must not answer for another, or a
+// GEOIP,JP,DIRECT rule would be decided by the China set.
+func TestASetOnlyAnswersForItsOwnCountry(t *testing.T) {
+	set, err := LoadPacked("CN", pack(t, []netip.Prefix{netip.MustParsePrefix("1.0.1.0/24")}, nil))
+	if err != nil {
+		t.Fatalf("loading the set: %v", err)
+	}
+	inside := netip.MustParseAddr("1.0.1.5")
+	if !set.Contains("cn", inside) {
+		t.Error("the code comparison is case-sensitive; rule files write both")
+	}
+	if set.Contains("JP", inside) {
+		t.Error("the China set answered a rule about Japan")
+	}
+}
+
+// The file the iOS client ships is the one this has to read. If the generator's
+// layout and this reader ever disagree, the toggle silently stops matching, so
+// the real artifact is part of the test rather than only a hand-built fixture.
+func TestTheBundledChinaSetLoadsAndHoldsChineseAddresses(t *testing.T) {
+	path := filepath.Join("..", "..", "mobile", "ios", "PacketTunnel", "Resources", "cn-direct.bin")
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("the bundled set is not in this checkout: %v", err)
+	}
+	set, err := LoadPacked("CN", blob)
+	if err != nil {
+		t.Fatalf("the set the iOS client ships does not load: %v", err)
+	}
+	if set.Blocks() < 1000 {
+		t.Errorf("the bundled set holds %d blocks, which is too few to be the registry set", set.Blocks())
+	}
+	// Well-known Chinese addresses: Alibaba and Tencent public resolvers.
+	for _, address := range []string{"223.5.5.5", "119.29.29.29"} {
+		if !set.Contains("CN", netip.MustParseAddr(address)) {
+			t.Errorf("%s reads as outside the China set", address)
+		}
+	}
+	// Well-known addresses outside it.
+	for _, address := range []string{"8.8.8.8", "1.1.1.1"} {
+		if set.Contains("CN", netip.MustParseAddr(address)) {
+			t.Errorf("%s reads as inside the China set", address)
+		}
+	}
+}
+
+// The whole point of the set is answering a GEOIP rule, so wire the two
+// together once here rather than only testing them apart.
+func TestAGeoIPRuleDecidesFromThePackedSet(t *testing.T) {
+	set, err := LoadPacked("CN", pack(t, []netip.Prefix{netip.MustParsePrefix("223.5.5.0/24")}, nil))
+	if err != nil {
+		t.Fatalf("loading the set: %v", err)
+	}
+	rules := mustSet(t, "GEOIP,CN,DIRECT\nFINAL,PROXY").WithCountries(set)
+	if got, _, _ := rules.Match(Flow{Addr: netip.MustParseAddr("223.5.5.5")}); got != Direct {
+		t.Errorf("a Chinese address got %s, want DIRECT", got)
+	}
+	if got, _, _ := rules.Match(Flow{Addr: netip.MustParseAddr("8.8.8.8")}); got != Proxy {
+		t.Errorf("an address outside the set got %s, want PROXY", got)
+	}
+}

--- a/internal/routerule/parse.go
+++ b/internal/routerule/parse.go
@@ -1,0 +1,205 @@
+package routerule
+
+import (
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+// Problem is a line that did not become a rule, and why.
+//
+// Parsing reports rather than drops. A rule list is a security boundary --
+// every line in it is somebody saying "this must not take the tunnel", or
+// "this must" -- and a parser that skips what it does not understand turns a
+// typo into traffic going somewhere the user did not intend, silently and for
+// as long as the file lives. The caller decides whether to refuse the list or
+// to run it and show what was lost; it cannot decide either without being told.
+type Problem struct {
+	Line   int
+	Text   string
+	Reason string
+}
+
+func (p Problem) String() string {
+	return fmt.Sprintf("line %d: %s: %s", p.Line, p.Reason, p.Text)
+}
+
+// Parse reads a rule list.
+//
+// The accepted form is one rule per line, `TYPE,VALUE,ACTION`, with FINAL
+// taking `FINAL,ACTION` because it has nothing to match on. Blank lines and
+// lines beginning with # or ; are ignored, as is anything after a trailing
+// `,no-resolve`, which is recorded rather than rejected. Type and action names
+// are case-insensitive; a comma inside a value is not supported by any tool
+// using this syntax and is not supported here.
+//
+// A list with problems still returns the rules that parsed, in order. That is
+// what lets a caller show "these 4 lines of your 900 did not load" instead of
+// refusing the file, and it is why Problem carries the line number.
+func Parse(text string) (*Set, []Problem) {
+	var (
+		rules    []Rule
+		problems []Problem
+	)
+	for i, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		rule, err := parseLine(line)
+		if err != nil {
+			problems = append(problems, Problem{Line: i + 1, Text: line, Reason: err.Error()})
+			continue
+		}
+		rules = append(rules, rule)
+	}
+	return &Set{rules: rules}, problems
+}
+
+func parseLine(line string) (Rule, error) {
+	fields := strings.Split(line, ",")
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+	kind, err := parseKind(fields[0])
+	if err != nil {
+		return Rule{}, err
+	}
+	rule := Rule{Kind: kind}
+
+	if kind == KindFinal {
+		// FINAL,PROXY -- and FINAL,PROXY,dns-failed and similar tails exist in
+		// the wild, so anything past the action is ignored rather than refused.
+		if len(fields) < 2 {
+			return Rule{}, fmt.Errorf("FINAL needs an action")
+		}
+		if rule.Action, err = parseAction(fields[1]); err != nil {
+			return Rule{}, err
+		}
+		return rule, nil
+	}
+
+	if len(fields) < 3 {
+		return Rule{}, fmt.Errorf("expected TYPE,VALUE,ACTION")
+	}
+	value := fields[1]
+	if value == "" {
+		return Rule{}, fmt.Errorf("%s needs a value", kind)
+	}
+	if rule.Action, err = parseAction(fields[2]); err != nil {
+		return Rule{}, err
+	}
+	for _, option := range fields[3:] {
+		switch strings.ToLower(option) {
+		case "no-resolve":
+			rule.NoResolve = true
+		case "":
+		default:
+			return Rule{}, fmt.Errorf("unknown option %q", option)
+		}
+	}
+
+	switch kind {
+	case KindDomain, KindDomainSuffix, KindDomainKeyword:
+		rule.Domain = normalizeDomain(value)
+		if rule.Domain == "" {
+			return Rule{}, fmt.Errorf("%s needs a name", kind)
+		}
+	case KindIPCIDR:
+		prefix, err := parsePrefix(value)
+		if err != nil {
+			return Rule{}, err
+		}
+		rule.Prefix = prefix
+	case KindGeoIP:
+		rule.Country = strings.ToUpper(value)
+	case KindDstPort:
+		port, err := strconv.ParseUint(value, 10, 16)
+		if err != nil || port == 0 {
+			return Rule{}, fmt.Errorf("%q is not a port", value)
+		}
+		rule.Port = uint16(port)
+	}
+	return rule, nil
+}
+
+// parsePrefix accepts a block, and also a bare address, which the lists in
+// circulation use for a single host. Masked() is applied so that a rule written
+// 192.168.1.5/24 -- which netip rejects as having bits set below the mask --
+// still means the /24 the author meant rather than failing the whole file.
+func parsePrefix(value string) (netip.Prefix, error) {
+	if prefix, err := netip.ParsePrefix(value); err == nil {
+		return prefix.Masked(), nil
+	}
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("%q is not an address or block", value)
+	}
+	addr = unmap(addr)
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
+}
+
+func parseKind(name string) (Kind, error) {
+	switch strings.ToUpper(name) {
+	case "DOMAIN":
+		return KindDomain, nil
+	case "DOMAIN-SUFFIX":
+		return KindDomainSuffix, nil
+	case "DOMAIN-KEYWORD":
+		return KindDomainKeyword, nil
+	case "IP-CIDR", "IP-CIDR6", "IP6-CIDR":
+		// One kind, three spellings. The tools split them because their
+		// matchers were written per family; netip is not, and a v6 block in an
+		// IP-CIDR rule matches v6 addresses whatever the line called itself.
+		return KindIPCIDR, nil
+	case "GEOIP":
+		return KindGeoIP, nil
+	case "DST-PORT", "PORT":
+		return KindDstPort, nil
+	case "FINAL", "MATCH":
+		return KindFinal, nil
+	default:
+		return 0, fmt.Errorf("unknown rule type %q", name)
+	}
+}
+
+func parseAction(name string) (Action, error) {
+	switch strings.ToUpper(name) {
+	case "PROXY", "QUEQIAO":
+		return Proxy, nil
+	case "DIRECT":
+		return Direct, nil
+	case "REJECT", "REJECT-DROP":
+		return Reject, nil
+	default:
+		// A named proxy group is the one thing this deliberately will not
+		// guess at. Queqiao has one tunnel, so a line naming a group cannot be
+		// honoured, and quietly reading it as PROXY would send traffic through
+		// the one tunnel a multi-group file was written to keep off it.
+		return 0, fmt.Errorf("unknown action %q: this client has one tunnel, so only PROXY, DIRECT and REJECT", name)
+	}
+}
+
+// Format renders a rule back to the line syntax, so that a list can be shown
+// and stored in the form the user typed it.
+func (r Rule) Format() string {
+	var value string
+	switch r.Kind {
+	case KindFinal:
+		return fmt.Sprintf("FINAL,%s", r.Action)
+	case KindDomain, KindDomainSuffix, KindDomainKeyword:
+		value = r.Domain
+	case KindIPCIDR:
+		value = r.Prefix.String()
+	case KindGeoIP:
+		value = r.Country
+	case KindDstPort:
+		value = strconv.Itoa(int(r.Port))
+	}
+	line := fmt.Sprintf("%s,%s,%s", r.Kind, value, r.Action)
+	if r.NoResolve {
+		line += ",no-resolve"
+	}
+	return line
+}

--- a/internal/routerule/routerule.go
+++ b/internal/routerule/routerule.go
@@ -1,0 +1,248 @@
+// Package routerule decides what a flow does: take the tunnel, go direct, or
+// be refused.
+//
+// It lives here rather than in either mobile client because both of them ask
+// the same question at the same moment. The iOS packet tunnel and the Android
+// debug VpnService both hand their packets to the userspace stack in
+// mobile/core, and every flow that stack accepts arrives at one forwarder with
+// a destination and, once DNS is intercepted, a name. One matcher there is one
+// set of semantics to get right and one set of tests to keep it right; two
+// would be a parity script and an argument about which is correct.
+//
+// The syntax is the one the rule files in circulation already use -- Clash,
+// mihomo, sing-box, Shadowrocket all read a list of `TYPE,VALUE,ACTION` lines
+// -- because the point of this is that a user can bring the list they already
+// maintain. Where those tools disagree with each other this follows the
+// majority and says so at the rule concerned.
+package routerule
+
+import (
+	"net/netip"
+	"strings"
+)
+
+// Action is what happens to a flow that matches.
+type Action uint8
+
+const (
+	// Proxy sends the flow through the tunnel. It is the zero value because it
+	// is what this transport exists to do: a flow nothing matched is a flow
+	// nobody made a decision about, and carrying it is the choice that cannot
+	// leak.
+	Proxy Action = iota
+	// Direct sends the flow out the ordinary interface.
+	Direct
+	// Reject refuses the flow without dialing anything.
+	Reject
+)
+
+func (a Action) String() string {
+	switch a {
+	case Direct:
+		return "DIRECT"
+	case Reject:
+		return "REJECT"
+	default:
+		return "PROXY"
+	}
+}
+
+// Kind is what a rule matches on.
+type Kind uint8
+
+const (
+	KindDomain Kind = iota
+	KindDomainSuffix
+	KindDomainKeyword
+	KindIPCIDR
+	KindGeoIP
+	KindDstPort
+	KindFinal
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindDomain:
+		return "DOMAIN"
+	case KindDomainSuffix:
+		return "DOMAIN-SUFFIX"
+	case KindDomainKeyword:
+		return "DOMAIN-KEYWORD"
+	case KindIPCIDR:
+		return "IP-CIDR"
+	case KindGeoIP:
+		return "GEOIP"
+	case KindDstPort:
+		return "DST-PORT"
+	default:
+		return "FINAL"
+	}
+}
+
+// Rule is one line of a rule list.
+type Rule struct {
+	Kind   Kind
+	Action Action
+
+	// Domain carries the name for the three name kinds, already lowered and
+	// stripped of a trailing dot so that matching does no work per flow.
+	Domain string
+	// Prefix carries the block for IP-CIDR.
+	Prefix netip.Prefix
+	// Country carries the two-letter code for GEOIP, upper-cased.
+	Country string
+	// Port carries the destination port for DST-PORT.
+	Port uint16
+
+	// NoResolve is carried because the rule files in circulation set it and a
+	// parser that rejected it would refuse lists that work everywhere else. It
+	// says an address rule must not trigger a name lookup to be evaluated,
+	// which is already true here: this matcher never resolves anything, it is
+	// given what the flow already knows. Kept so a round trip through parse and
+	// format does not silently rewrite a user's file.
+	NoResolve bool
+}
+
+// Countries answers whether an address belongs to a country's registered
+// space. The bundled set that scripts/generate_cn_geoip.py packs is one
+// implementation; a test supplies another.
+type Countries interface {
+	// Contains reports whether addr is registered to the two-letter code,
+	// which is upper-case. An unknown code reports false rather than an error:
+	// a rule naming a set this build does not carry must not decide the flow.
+	Contains(code string, addr netip.Addr) bool
+}
+
+// Flow is what is known about a connection at the moment the decision is made.
+type Flow struct {
+	// Domain is the name the flow was opened to, empty when it is not known.
+	// It is known when DNS was intercepted and the destination is one of the
+	// addresses handed out for a name; it is not known for a flow opened to a
+	// literal address.
+	Domain string
+	// Addr is the destination address, invalid when the flow has a name that
+	// has not been resolved yet.
+	Addr netip.Addr
+	// Port is the destination port.
+	Port uint16
+}
+
+// Set is a parsed rule list, ready to match.
+type Set struct {
+	rules []Rule
+
+	// The list is scanned in order, and that is not a placeholder for an index
+	// that was not written. First match wins, so any structure that answers
+	// faster has to answer with the earliest matching rule and not merely a
+	// matching one -- an exact-name map consulted ahead of the scan gets that
+	// wrong the moment a suffix rule sits above an exact rule for a name under
+	// it, which is the ordinary shape of a real file.
+	// TestTheExactIndexDoesNotOutrankAnEarlierRule caught exactly that and is
+	// kept as the guard on whatever replaces this. Until a list large enough to
+	// need one turns up, a scan of a few thousand rules once per flow -- not
+	// once per packet -- is the honest cost.
+	countries Countries
+}
+
+// Match returns the action for a flow and the rule that decided it.
+//
+// First match wins, which is what every tool using this syntax does, and is
+// why a list is ordered rather than a set. A rule whose input the flow does not
+// carry is skipped rather than treated as a miss: a name rule cannot speak
+// about a flow with no name, and skipping it lets the same list serve the
+// lookup that has a name and the connection that only has an address.
+//
+// A flow that matches nothing takes Proxy. A list that wants otherwise ends
+// with FINAL, and every list in circulation does.
+func (s *Set) Match(flow Flow) (Action, Rule, bool) {
+	if s == nil {
+		return Proxy, Rule{}, false
+	}
+	domain := normalizeDomain(flow.Domain)
+	for _, rule := range s.rules {
+		if !s.matches(rule, domain, flow) {
+			continue
+		}
+		return rule.Action, rule, true
+	}
+	return Proxy, Rule{}, false
+}
+
+func (s *Set) matches(rule Rule, domain string, flow Flow) bool {
+	switch rule.Kind {
+	case KindFinal:
+		return true
+	case KindDomain:
+		return domain != "" && domain == rule.Domain
+	case KindDomainSuffix:
+		if domain == "" {
+			return false
+		}
+		// A suffix rule matches the name itself and anything under it, and
+		// nothing else. Plain string suffix would take "notexample.com" for
+		// "example.com", which is a different registrable name and in the
+		// wrong direction: it sends somebody else's traffic where the user
+		// pointed only their own.
+		return domain == rule.Domain || strings.HasSuffix(domain, "."+rule.Domain)
+	case KindDomainKeyword:
+		return domain != "" && strings.Contains(domain, rule.Domain)
+	case KindIPCIDR:
+		return flow.Addr.IsValid() && rule.Prefix.IsValid() &&
+			rule.Prefix.Contains(unmap(flow.Addr))
+	case KindGeoIP:
+		return flow.Addr.IsValid() && s.countries != nil &&
+			s.countries.Contains(rule.Country, unmap(flow.Addr))
+	case KindDstPort:
+		return flow.Port != 0 && flow.Port == rule.Port
+	default:
+		return false
+	}
+}
+
+// Rules returns the parsed list in order.
+func (s *Set) Rules() []Rule {
+	if s == nil {
+		return nil
+	}
+	out := make([]Rule, len(s.rules))
+	copy(out, s.rules)
+	return out
+}
+
+// Len reports how many rules the set carries.
+func (s *Set) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.rules)
+}
+
+// WithCountries returns the set bound to a country lookup. A set with none
+// evaluates GEOIP rules as misses rather than refusing to build, so a build
+// that ships without the packed set still runs every other rule in the file.
+func (s *Set) WithCountries(c Countries) *Set {
+	if s == nil {
+		return nil
+	}
+	bound := *s
+	bound.countries = c
+	return &bound
+}
+
+// normalizeDomain lowers a name and drops the root dot, so that "EXAMPLE.com."
+// and "example.com" are the same name. Rules are normalized once at parse time
+// and flows once per decision.
+func normalizeDomain(name string) string {
+	name = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(name)), ".")
+	return name
+}
+
+// unmap flattens a v4-in-v6 address so that a v4 rule matches a flow the stack
+// handed over in v6 form. Without it an IP-CIDR of 10.0.0.0/8 silently fails to
+// match ::ffff:10.0.0.1, which is the same address.
+func unmap(addr netip.Addr) netip.Addr {
+	if addr.Is4In6() {
+		return addr.Unmap()
+	}
+	return addr
+}

--- a/internal/routerule/routerule_test.go
+++ b/internal/routerule/routerule_test.go
@@ -1,0 +1,283 @@
+package routerule
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// fixedCountries answers from a literal table, so the matcher's behaviour is
+// tested without the packed resource the clients ship.
+type fixedCountries map[string][]netip.Prefix
+
+func (f fixedCountries) Contains(code string, addr netip.Addr) bool {
+	for _, prefix := range f[code] {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustSet(t *testing.T, text string) *Set {
+	t.Helper()
+	set, problems := Parse(text)
+	if len(problems) != 0 {
+		t.Fatalf("unexpected problems parsing the list: %v", problems)
+	}
+	return set
+}
+
+func addr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("bad test address %q: %v", s, err)
+	}
+	return a
+}
+
+// First match wins, which is the whole reason a rule list is ordered. Getting
+// this backwards makes every list in circulation mean something else, because
+// they are all written with the specific exceptions above the general sweep.
+func TestTheFirstMatchDecides(t *testing.T) {
+	set := mustSet(t, `
+# The shape every real list has: an exception, then the sweep it sits above.
+DOMAIN-SUFFIX,internal.example.com,PROXY
+DOMAIN-SUFFIX,example.com,DIRECT
+FINAL,PROXY
+`)
+	for _, test := range []struct {
+		domain string
+		want   Action
+	}{
+		{"internal.example.com", Proxy},
+		{"host.internal.example.com", Proxy},
+		{"example.com", Direct},
+		{"www.example.com", Direct},
+		{"elsewhere.net", Proxy},
+	} {
+		got, _, _ := set.Match(Flow{Domain: test.domain})
+		if got != test.want {
+			t.Errorf("%s got %s, want %s", test.domain, got, test.want)
+		}
+	}
+}
+
+// A suffix rule names a place in the tree, not a string ending. The difference
+// is somebody else's traffic: notexample.com is a different registrable name
+// from example.com, and a plain HasSuffix sends it wherever the user pointed
+// only their own.
+func TestASuffixRuleStopsAtALabelBoundary(t *testing.T) {
+	set := mustSet(t, "DOMAIN-SUFFIX,example.com,DIRECT\nFINAL,PROXY")
+
+	if got, _, _ := set.Match(Flow{Domain: "notexample.com"}); got != Proxy {
+		t.Errorf("notexample.com matched a rule for example.com and got %s", got)
+	}
+	if got, _, _ := set.Match(Flow{Domain: "a.example.com"}); got != Direct {
+		t.Errorf("a.example.com is under example.com and got %s", got)
+	}
+}
+
+// The same list has to serve two different moments: the lookup, which has a
+// name and no address, and the connection, which may have only an address. A
+// rule whose input the flow does not carry is skipped, not counted as a miss.
+func TestARuleIsSkippedWhenTheFlowCannotAnswerIt(t *testing.T) {
+	set := mustSet(t, `
+DOMAIN-SUFFIX,example.com,REJECT
+IP-CIDR,10.0.0.0/8,DIRECT
+FINAL,PROXY
+`)
+	// An address with no name must not be caught by the name rule.
+	got, rule, _ := set.Match(Flow{Addr: addr(t, "10.1.2.3")})
+	if got != Direct || rule.Kind != KindIPCIDR {
+		t.Errorf("an address-only flow got %s from %s, want DIRECT from IP-CIDR", got, rule.Kind)
+	}
+	// A name with no address must not be caught by the address rule.
+	got, rule, _ = set.Match(Flow{Domain: "www.example.com"})
+	if got != Reject || rule.Kind != KindDomainSuffix {
+		t.Errorf("a name-only flow got %s from %s, want REJECT from DOMAIN-SUFFIX", got, rule.Kind)
+	}
+}
+
+// The stack hands v4 flows over in v4-in-v6 form, and a rule file writes v4
+// blocks in v4 form. Without unmapping, 10.0.0.0/8 silently fails to match
+// ::ffff:10.0.0.1, which is the same address, and the flow takes the tunnel a
+// user had explicitly kept it off.
+func TestAMappedAddressMatchesAnIPv4Rule(t *testing.T) {
+	set := mustSet(t, "IP-CIDR,10.0.0.0/8,DIRECT\nFINAL,PROXY")
+	mapped := netip.AddrFrom16(addr(t, "10.1.2.3").As16())
+	if !mapped.Is4In6() {
+		t.Fatalf("test set-up did not produce a v4-in-v6 address: %s", mapped)
+	}
+	if got, _, _ := set.Match(Flow{Addr: mapped}); got != Direct {
+		t.Errorf("%s got %s, want DIRECT: it is the same address as 10.1.2.3", mapped, got)
+	}
+}
+
+// A flow nothing matched takes the tunnel. The alternative -- defaulting to
+// direct -- makes a list that fails to load, or one whose FINAL line was
+// mistyped, put traffic on the open path, which is the one failure this
+// transport must not have.
+func TestAnUnmatchedFlowTakesTheTunnel(t *testing.T) {
+	set := mustSet(t, "DOMAIN,example.com,DIRECT")
+	got, _, matched := set.Match(Flow{Domain: "elsewhere.net"})
+	if got != Proxy || matched {
+		t.Errorf("an unmatched flow got %s (matched=%v), want PROXY and no rule", got, matched)
+	}
+	var empty *Set
+	if got, _, _ := empty.Match(Flow{Domain: "anything"}); got != Proxy {
+		t.Errorf("a nil set got %s, want PROXY", got)
+	}
+}
+
+func TestGeoIPMatchesTheRegisteredSet(t *testing.T) {
+	set := mustSet(t, "GEOIP,CN,DIRECT\nFINAL,PROXY").WithCountries(fixedCountries{
+		"CN": {netip.MustParsePrefix("223.5.5.0/24")},
+	})
+	if got, _, _ := set.Match(Flow{Addr: addr(t, "223.5.5.5")}); got != Direct {
+		t.Errorf("a registered CN address got %s, want DIRECT", got)
+	}
+	if got, _, _ := set.Match(Flow{Addr: addr(t, "8.8.8.8")}); got != Proxy {
+		t.Errorf("an address outside the set got %s, want PROXY", got)
+	}
+}
+
+// A build that ships without the packed set must still run the rest of the
+// file. Treating a GEOIP rule as a match when there is nothing to match
+// against would decide flows from a set this build does not have.
+func TestGeoIPWithNoSetLoadedDecidesNothing(t *testing.T) {
+	set := mustSet(t, "GEOIP,CN,DIRECT\nIP-CIDR,203.0.113.0/24,REJECT\nFINAL,PROXY")
+	got, rule, _ := set.Match(Flow{Addr: addr(t, "203.0.113.9")})
+	if got != Reject || rule.Kind != KindIPCIDR {
+		t.Errorf("got %s from %s; the GEOIP rule with no set behind it should have "+
+			"been skipped, leaving the IP-CIDR rule to decide", got, rule.Kind)
+	}
+}
+
+// Parsing reports what it could not read instead of dropping it. A rule list is
+// somebody stating where their traffic may and may not go, and a silently
+// skipped line is that statement not being enforced for as long as the file
+// lives.
+func TestABadLineIsReportedAndTheRestStillLoads(t *testing.T) {
+	set, problems := Parse(`
+DOMAIN-SUFFIX,example.com,DIRECT
+NOT-A-TYPE,whatever,DIRECT
+IP-CIDR,not-an-address,DIRECT
+DOMAIN-SUFFIX,short.example
+FINAL,PROXY
+`)
+	if set.Len() != 2 {
+		t.Errorf("loaded %d rules, want the 2 that were valid", set.Len())
+	}
+	if len(problems) != 3 {
+		t.Fatalf("reported %d problems, want 3: %v", len(problems), problems)
+	}
+	for _, want := range []int{3, 4, 5} {
+		found := false
+		for _, p := range problems {
+			if p.Line == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no problem reported for line %d: %v", want, problems)
+		}
+	}
+}
+
+// A line naming a proxy group is refused rather than read as PROXY. Such a file
+// was written for a client with several outbounds, and quietly collapsing them
+// onto this one tunnel routes through it exactly the traffic the group existed
+// to route elsewhere.
+func TestANamedProxyGroupIsRefusedRatherThanAssumed(t *testing.T) {
+	_, problems := Parse("DOMAIN-SUFFIX,example.com,my-hong-kong-group")
+	if len(problems) != 1 {
+		t.Fatalf("a named group produced %d problems, want 1: %v", len(problems), problems)
+	}
+	if !strings.Contains(problems[0].Reason, "one tunnel") {
+		t.Errorf("the reason does not say why: %q", problems[0].Reason)
+	}
+}
+
+// The syntax in circulation is not one syntax. These spellings all appear in
+// files users already maintain, and refusing them means refusing the list the
+// feature exists to accept.
+func TestTheSpellingsInCirculationAreAccepted(t *testing.T) {
+	set, problems := Parse(`
+# comment
+; also a comment
+domain-suffix,Example.COM.,direct
+IP-CIDR6,2001:db8::/32,REJECT
+IP-CIDR,203.0.113.7,DIRECT
+GEOIP,cn,DIRECT,no-resolve
+PORT,443,PROXY
+MATCH,PROXY
+`)
+	if len(problems) != 0 {
+		t.Fatalf("rejected lines that tools in circulation write: %v", problems)
+	}
+	if set.Len() != 6 {
+		t.Fatalf("loaded %d rules, want 6", set.Len())
+	}
+	rules := set.Rules()
+	if rules[0].Domain != "example.com" {
+		t.Errorf("the name was not normalized: %q", rules[0].Domain)
+	}
+	if got := rules[2].Prefix.String(); got != "203.0.113.7/32" {
+		t.Errorf("a bare address became %s, want a /32 host route", got)
+	}
+	if !rules[3].NoResolve {
+		t.Error("no-resolve was parsed away rather than recorded")
+	}
+	if rules[5].Kind != KindFinal {
+		t.Errorf("MATCH did not read as FINAL, got %s", rules[5].Kind)
+	}
+}
+
+// A block written with bits below the mask is what the author meant, not a
+// reason to fail their whole file.
+func TestABlockWithHostBitsSetIsMasked(t *testing.T) {
+	set := mustSet(t, "IP-CIDR,192.168.1.5/24,DIRECT\nFINAL,PROXY")
+	if got := set.Rules()[0].Prefix.String(); got != "192.168.1.0/24" {
+		t.Errorf("got %s, want the 192.168.1.0/24 the line meant", got)
+	}
+	if got, _, _ := set.Match(Flow{Addr: addr(t, "192.168.1.200")}); got != Direct {
+		t.Errorf("an address in the block got %s, want DIRECT", got)
+	}
+}
+
+// A stored list has to survive being shown to the user and read back.
+func TestARuleRoundTripsThroughItsOwnSyntax(t *testing.T) {
+	const text = `DOMAIN,example.com,DIRECT
+DOMAIN-SUFFIX,example.org,PROXY
+DOMAIN-KEYWORD,analytics,REJECT
+IP-CIDR,10.0.0.0/8,DIRECT,no-resolve
+GEOIP,CN,DIRECT
+DST-PORT,853,REJECT
+FINAL,PROXY`
+	set := mustSet(t, text)
+	var lines []string
+	for _, rule := range set.Rules() {
+		lines = append(lines, rule.Format())
+	}
+	if got := strings.Join(lines, "\n"); got != text {
+		t.Errorf("round trip changed the list:\n%s\n---want---\n%s", got, text)
+	}
+}
+
+// The exact-name index is an optimisation, and an optimisation that changes an
+// answer is a bug. First match still wins across the two paths: a suffix rule
+// above an exact rule for a name under it has to keep deciding.
+func TestTheExactIndexDoesNotOutrankAnEarlierRule(t *testing.T) {
+	set := mustSet(t, `
+DOMAIN-SUFFIX,example.com,DIRECT
+DOMAIN,www.example.com,REJECT
+FINAL,PROXY
+`)
+	got, rule, _ := set.Match(Flow{Domain: "www.example.com"})
+	if got != Direct || rule.Kind != KindDomainSuffix {
+		t.Errorf("got %s from %s; the DOMAIN-SUFFIX rule is first in the file and "+
+			"has to decide, whatever the index makes convenient", got, rule.Kind)
+	}
+}


### PR DESCRIPTION
Foundation for rule-based routing in the mobile clients. Nothing is wired to
it yet, so there is no user-visible change and no changelog entry; the
wiring follows in a second pull request on top of this one.

## Why

`docs/KNOWN-LIMITATIONS.md:120` records the defect this exists to fix:

> The iOS bundled China route set matches addresses, not names. DNS resolves
> through the tunnel, so a Chinese domain resolved from the gateway's vantage
> point can return addresses outside the set and still route through Queqiao.

More address rules cannot fix that. Name rules can, and the lists users
already maintain for Clash, mihomo, sing-box and Shadowrocket are all
written in one syntax.

## What is here

`internal/routerule/`, 20 tests, all in the `-short` suite.

**The matcher.** `DOMAIN`, `DOMAIN-SUFFIX`, `DOMAIN-KEYWORD`, `IP-CIDR`,
`IP-CIDR6`, `GEOIP`, `DST-PORT`, `FINAL`; `PROXY`/`DIRECT`/`REJECT`;
first-match-wins; comments, `no-resolve`, case-insensitive spellings, and a
round trip back to the source syntax.

**The GeoIP reader**, for the packed set the iOS client already ships at
`mobile/ios/PacketTunnel/Resources/cn-direct.bin`. It binary-searches the raw
bytes instead of materialising ~7500 prefixes: unlike the Swift reader, which
builds the routes once at connect and drops them before the core starts, this
stays resident to answer a rule on every flow, and `docs/MOBILE-MEMORY.md` is
the budget that makes the difference matter. An unsorted set is refused at
load, because that failure is silent -- it answers "no" for addresses it
holds, which is the original defect wearing a different hat.

It lives in `internal/` rather than in either client because both ask the
same question at the same moment: every flow the userspace stack accepts
arrives at one forwarder in `mobile/core`, on iOS and on the Android debug
VpnService alike. One matcher is one set of semantics and one set of tests.

## Decisions, each with a test that fails if reversed

- **An unmatched flow takes the tunnel.** Defaulting to direct puts traffic
  on the open path whenever a list fails to load or a `FINAL` line is
  mistyped.
- **A rule the flow cannot answer is skipped**, not counted as a miss, so one
  list serves both the lookup that has a name and no address and the
  connection that has an address and no name.
- **A line naming a proxy group is refused**, not read as `PROXY`. That file
  was written for a client with several outbounds; collapsing them onto this
  one tunnel routes through it exactly what the group existed to keep off.

## One bug caught in review

There was an exact-name index over `DOMAIN` rules.
`TestTheExactIndexDoesNotOutrankAnEarlierRule` caught it answering with *a*
matching rule rather than the *earliest* matching one, the moment a suffix
rule sits above an exact rule for a name under it -- the ordinary shape of a
real file. Removed; the test stays as the guard on whatever replaces the
scan.

## Checks

`gofmt`, `go vet`, `go build ./...`, and the package tests, which include
loading the real shipped `cn-direct.bin` and asserting Alibaba's and
Tencent's resolvers are inside the set while Google's and Cloudflare's are
outside.