### PR TITLE
fix(ios): keep the packet tunnel inside the memory ceiling iOS enforces

### DIFF
--- a/changelog.d/ios-memory-ceiling.fixed.md
+++ b/changelog.d/ios-memory-ceiling.fixed.md
@@ -1,13 +1,14 @@
 The iOS packet-tunnel extension no longer runs itself into the memory ceiling
 NetworkExtension enforces on it. The Go runtime soft limit was 40 MiB inside a
 50 MiB whole-process cap, which left too little of that cap for everything the
-Go heap does not cover: the resident text pages of the statically linked Go and
-gVisor code, runtime metadata, goroutine and thread stacks, the Swift packet
-bridge, and CoreFoundation. The collector spent whole minutes at 130-200% CPU
-defending a limit the process could not honour, and jetsam killed the extension
-anyway, twelve to twenty-one minutes into a session. Because the kill is a
-SIGKILL, the provider never ran `stopTunnel` and never recorded a diagnostic,
-so the tunnel's network settings stayed installed and the VPN went on showing
-connected while no packets moved — the failure a user sees is a stall, with an
-empty connection log behind it. The limit is now 28 MiB, and the test suite
-holds it far enough below the ceiling to leave that remainder room.
+Go heap does not cover: the resident text pages of the statically linked Go
+and gVisor code, runtime metadata, goroutine and thread stacks, the Swift
+packet bridge, and CoreFoundation. The collector spent whole minutes at
+130-200% CPU defending a limit the process could not honour, and jetsam killed
+the extension anyway, twelve to twenty-one minutes into a session. Because the
+kill is a SIGKILL, the provider never ran `stopTunnel` and never recorded a
+diagnostic, so the tunnel's network settings stayed installed and the VPN went
+on showing connected while no packets moved — the failure a user sees is a
+stall, with an empty connection log behind it. The limit is now 28 MiB, and
+the test suite holds it far enough below the ceiling to leave that remainder
+room.

--- a/changelog.d/ios-memory-ceiling.fixed.md
+++ b/changelog.d/ios-memory-ceiling.fixed.md
@@ -1,0 +1,13 @@
+The iOS packet-tunnel extension no longer runs itself into the memory ceiling
+NetworkExtension enforces on it. The Go runtime soft limit was 40 MiB inside a
+50 MiB whole-process cap, which left too little of that cap for everything the
+Go heap does not cover: the resident text pages of the statically linked Go and
+gVisor code, runtime metadata, goroutine and thread stacks, the Swift packet
+bridge, and CoreFoundation. The collector spent whole minutes at 130-200% CPU
+defending a limit the process could not honour, and jetsam killed the extension
+anyway, twelve to twenty-one minutes into a session. Because the kill is a
+SIGKILL, the provider never ran `stopTunnel` and never recorded a diagnostic,
+so the tunnel's network settings stayed installed and the VPN went on showing
+connected while no packets moved — the failure a user sees is a stall, with an
+empty connection log behind it. The limit is now 28 MiB, and the test suite
+holds it far enough below the ceiling to leave that remainder room.

--- a/docs/MOBILE-MEMORY.md
+++ b/docs/MOBILE-MEMORY.md
@@ -34,7 +34,7 @@ must not multiply retained payload memory without limit.
 
 | Resource | iOS packet extension | Android VPN service |
 | --- | ---: | ---: |
-| Go runtime soft limit | 40 MiB | 72 MiB |
+| Go runtime soft limit | 28 MiB | 72 MiB |
 | Shared retained transmit payload | 3 MiB | 8 MiB |
 | Shared out-of-order receive payload | 3 MiB | 8 MiB |
 | Per-flow transmit ceiling | 1 MiB | 2 MiB |
@@ -53,6 +53,20 @@ The limits intentionally favor survival and interactive traffic over maximum
 bandwidth-delay-product utilization. They can be changed only as a complete
 profile: raising a session or queue count requires redoing the worst-case
 memory calculation.
+
+On iOS the Go runtime limit is not the binding constraint. NetworkExtension
+enforces a 50 MiB ceiling on the whole packet-tunnel process, and
+`SetMemoryLimit` governs Go-owned memory only, so the profile leaves 22 MiB of
+that ceiling unclaimed for the resident text pages of the statically linked Go
+and gVisor code, runtime metadata, goroutine and thread stacks, the Swift packet
+bridge, and CoreFoundation. Crossing the ceiling is not a soft failure: jetsam
+SIGKILLs the extension with reason `per-process-limit`, so the provider never
+runs `stopTunnel`, never records a diagnostic, and leaves its network settings
+installed — the VPN keeps showing connected while no packets move. A Go limit
+set too close to the ceiling also makes the collector run continuously against a
+limit the process cannot honour, which burns CPU without averting the kill.
+`mobile/core/resources_test.go` holds the limit below the ceiling with that
+remainder reserved.
 
 ## Overload behavior
 

--- a/mobile/core/resources.go
+++ b/mobile/core/resources.go
@@ -23,8 +23,26 @@ type mobileResourceLimits struct {
 	memory             pep.MemoryLimits
 }
 
+// iosProcessMemoryCap is the whole-process ceiling iOS enforces on a
+// NEPacketTunnelProvider. Crossing it is not a soft failure: jetsam SIGKILLs
+// the extension with reason "per-process-limit", so the provider never runs
+// stopTunnel, never records a diagnostic, and leaves its network settings
+// installed — the VPN keeps showing connected while no packets move.
+const iosProcessMemoryCap = 50 * 1024 * 1024
+
+// iosNonHeapHeadroom is what the Go limit must leave unclaimed inside that
+// ceiling. SetMemoryLimit governs Go-owned memory only, while the resident text
+// pages of the statically linked Go and gVisor code, runtime metadata,
+// goroutine and thread stacks, the Swift packet bridge, and CoreFoundation are
+// all charged to the same process.
+const iosNonHeapHeadroom = 20 * 1024 * 1024
+
 var iosResourceLimits = mobileResourceLimits{
-	name: "ios-fixed-40m", goMemoryLimit: 40 * 1024 * 1024,
+	// Sized against iosProcessMemoryCap, not against the heap alone. At 40 MiB
+	// the runtime collected continuously against a limit the process could not
+	// honour — whole minutes at 130-200% CPU — and was killed anyway 12 to 21
+	// minutes into a session.
+	name: "ios-fixed-28m", goMemoryLimit: 28 * 1024 * 1024,
 	// Session admission is intentionally independent from the payload arenas
 	// below.  A session mostly owns a small state machine; retained bytes are
 	// charged to the shared budgets, so raising this ceiling does not multiply

--- a/mobile/core/resources_test.go
+++ b/mobile/core/resources_test.go
@@ -2,6 +2,7 @@ package mobilecore
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -25,6 +26,28 @@ func TestMobileResourceProfilesHaveFixedEndpointBudgets(t *testing.T) {
 	}
 	if iosResourceLimits.maxSessions < 1024 {
 		t.Fatalf("iOS admission capacity = %d, want at least 1024", iosResourceLimits.maxSessions)
+	}
+}
+
+// The iOS profile is bounded by the whole process, not by the Go heap. Jetsam
+// enforces iosProcessMemoryCap with SIGKILL, and everything outside the Go heap
+// is charged against the same ceiling, so the runtime limit has to stay far
+// enough below it to leave that remainder room. Raising goMemoryLimit without
+// redoing this arithmetic is how the extension came to be killed mid-session.
+func TestIOSGoMemoryLimitLeavesHeadroomBelowTheProcessCap(t *testing.T) {
+	headroom := iosProcessMemoryCap - iosResourceLimits.goMemoryLimit
+	if headroom < iosNonHeapHeadroom {
+		t.Fatalf(
+			"iOS Go memory limit = %d bytes, leaving %d bytes of the %d byte process cap "+
+				"for non-heap memory, want at least %d",
+			iosResourceLimits.goMemoryLimit, headroom, iosProcessMemoryCap, iosNonHeapHeadroom,
+		)
+	}
+	// The profile name is what a soak operator reads out of the metrics JSON, so
+	// it must not keep advertising a limit the profile no longer carries.
+	wantName := fmt.Sprintf("ios-fixed-%dm", iosResourceLimits.goMemoryLimit/(1024*1024))
+	if iosResourceLimits.name != wantName {
+		t.Fatalf("iOS profile name = %q, want %q", iosResourceLimits.name, wantName)
 	}
 }
 


### PR DESCRIPTION
## What this fixes

The iOS app stalls after some time. It isn't a stall — iOS is SIGKILLing the packet-tunnel extension for exceeding the 50 MiB whole-process cap NetworkExtension enforces on it.

`goMemoryLimit` was 40 MiB inside that 50 MiB cap. `debug.SetMemoryLimit` is a *soft* limit governing *Go-owned memory only*, so ~10 MiB was left to cover the resident text pages of the statically linked Go and gVisor code, runtime metadata, goroutine and thread stacks, the Swift packet bridge, and CoreFoundation. That isn't enough, so two things happened together: the collector ran continuously trying to defend a limit the process could not honour, and RSS crossed the cap anyway.

## Evidence

Nine `JetsamEvent-*.ips` reports pulled off a paired iPhone (`devicectl device copy from --domain-type systemCrashLogs`):

| Report | PacketTunnel RSS | Peak | CPU vs. wall | Uptime | Outcome |
|---|---:|---:|---:|---:|---|
| 08-21 16:42 | 50.3 MiB | 50.3 | 64% | 17.8 min | **killed, per-process-limit** |
| 08-22 17:08 | 39.2 MiB | 45.3 | 169% | 6.0 min | survived |
| 08-23 18:14 | 17.5 MiB | 19.6 | — | 8 sec | healthy |
| 08-24 12:19 | 50.0 MiB | 50.0 | 136% | 20.6 min | **killed, per-process-limit** |
| 08-25 01:20 | 5.8 MiB | 6.0 | 3.5% | 1.8 min | healthy |
| 08-25 14:37 | 6.2 MiB | 7.3 | 4.3% | 8.3 min | healthy |
| 08-26 15:23 | 7.9 MiB | 40.5 | 10% | 17.6 min | survived, peaked 40.5 |
| 08-27 10:21 | 50.0 MiB | 50.0 | **208%** | 12.4 min | **killed, per-process-limit** |

The threshold is exact: `rpages: 3200` × 16 KiB page = 52,428,800 bytes = 50 MiB. `runningboardd` confirms the cap is armed on the extension: `explicitJetsamBand:100 memoryLimit:Active(Hard)`.

Because the kill is a SIGKILL, the provider never runs `stopTunnel` and never writes to the `DiagnosticStore` ring, and the tunnel's network settings stay installed. The VPN keeps showing connected while no packets move — which is why this presented as a stall with an empty in-app connection log, and why there are no crash reports for the extension.

## The change

- `goMemoryLimit` 40 → 28 MiB, profile renamed `ios-fixed-28m`.
- Two named constants make the real constraint explicit: `iosProcessMemoryCap` (what jetsam enforces) and `iosNonHeapHeadroom` (what `SetMemoryLimit` does not cover).
- `TestIOSGoMemoryLimitLeavesHeadroomBelowTheProcessCap` asserts `cap - goMemoryLimit >= headroom` (22 MiB actual vs 20 MiB required), so raising the limit again without redoing the arithmetic fails CI rather than the device. Verified it fails at the old value:
  ```
  iOS Go memory limit = 41943040 bytes, leaving 10485760 bytes of the
  52428800 byte process cap for non-heap memory, want at least 20971520
  ```
- `docs/MOBILE-MEMORY.md` records why the Go limit is not the binding constraint on iOS.

## Not addressed here

`maxSessions` stays at 1024. Commit 698ad64 raised it 16× (64 → 1024) without redoing the envelope, which is what let the heap reach the old limit; iOS now permits 8× the sessions of Android on roughly a third of the memory headroom. That deserves its own change.

Separately, the extension logs multi-thread error bursts that in three of four observed cases sit within seconds of cellular/Wi-Fi path churn. Unrelated to memory, not investigated — the messages are `privacy: .private` so they're only readable in the in-app log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrdUWiiXiUbF8ALBT625Lh
