### PR TITLE
feat: ask whether the gateway is on the useful side of the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ Point an application or Clash/mihomo at that SOCKS5 endpoint.
 The scripts live in this repository: clone it, or copy `deploy/` beside the
 downloaded binary. From the next release they also ship inside the archives.
 
-The [deployment guide](docs/DEPLOYING.md) is the reference for everything past
-this point -- what the scripts do, the hosts they do not cover, the manual
+[Choosing and placing a gateway](docs/CHOOSING-A-GATEWAY.md) is the decision
+that comes before all of this: whether a gateway will help at all, and where it
+has to sit. The [deployment guide](docs/DEPLOYING.md) is the reference for
+everything past this point -- what the scripts do, the hosts they do not cover, the manual
 gateway and enrollment steps for a host they do not fit, firewall and socket
 tuning, multiple users, source-interface selection, verification, upgrades, and
 rollback. To serve several providers from one client process, see
@@ -252,6 +254,15 @@ is, so it gets its own profile rather than the default one: see [the datacenter
 profile](docs/DEPLOYING-DC-PROFILE.md), and read its measured limits before
 deploying it, because on a clean path direction a one-line client-side fix
 beats it on the median request.
+
+Both ends run this software, so a destination someone else operates -- a hosted
+model API, a SaaS endpoint -- needs a gateway on a host you do control. Where
+that gateway goes decides whether any of this helps: a destination already
+served from an anycast edge near you can be made slower by a gateway placed on
+another continent. [Choosing and placing a
+gateway](docs/CHOOSING-A-GATEWAY.md) is how to settle that before spending
+anything, and it covers the free client-side fixes that on a clean path reach
+the same median this transport does.
 
 ## Project status
 

--- a/changelog.d/choosing-a-gateway-guide.added.md
+++ b/changelog.d/choosing-a-gateway-guide.added.md
@@ -1,0 +1,11 @@
+A new guide, [choosing and placing a gateway](docs/CHOOSING-A-GATEWAY.md),
+covers the decision that precedes deployment and previously had no home in
+the documentation. It states plainly that both ends run this software, so a
+destination someone else operates needs a gateway on a host the reader
+controls; it gives the placement rule that follows from the transport
+improving the client-to-gateway segment and nothing past it; it works
+through the anycast case, where a destination already served from an edge
+near the caller is made slower by a gateway on another continent; and it
+promotes the free client-side fixes out of the datacenter profile's
+appendix, where they applied to every reader but only one audience could
+find them.

--- a/changelog.d/gateway-placement-check.added.md
+++ b/changelog.d/gateway-placement-check.added.md
@@ -1,0 +1,19 @@
+`queqiaod doctor` now answers the question that decides a deployment before
+it exists: whether this gateway is on the useful side of this client's path
+to a destination it actually calls. Given `--destination host:port`, it
+establishes connections to that destination directly and through the local
+SOCKS listener, alternating the arms every round, and reports the two
+distributions beside the verdict. The gateway round trip is now sampled
+rather than dialled once, and is subtracted from the tunnelled
+establishment to leave the gateway's own hop onward, which separates a
+placement decision the operator can revisit from transit that relocating
+the client will not change. Where the drift measured between arms is larger
+than the difference between them, the check reports that the comparison did
+not resolve anything rather than offering a conclusion, which is the
+discipline `pathmeasure -mode ab` already follows and for the same reason.
+This matters most for a destination published behind an anycast edge, where
+the session already terminates near the caller and routing it through a
+distant gateway adds the whole gateway leg for nothing while every other
+check on the host still passes. The command continues to say nothing about
+what the path does, because no local check can; `pathprobe` and
+`pathmeasure` remain the instruments for that.

--- a/cmd/queqiaod/doctor.go
+++ b/cmd/queqiaod/doctor.go
@@ -9,27 +9,48 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/bojieli/queqiao/internal/identity"
 	"github.com/bojieli/queqiao/internal/profile"
 )
 
-// doctor answers one question: would this host run this profile the way the
-// deployment guide assumes it will.
+// doctor answers the two questions a deployment gets wrong before it exists:
+// whether this host is in the state the measurements assumed, and whether this
+// gateway sits on the useful side of this client's path to the destinations it
+// actually calls.
 //
-// It exists because the guide's first instruction is to do the free things
-// first, and the free things are worth more than the transport on the median
-// request. Measured on the China-US path this profile was built for, a client
-// that reuses its connection and sets tcp_slow_start_after_idle=0 takes a real
-// 355KB inference upload to 225.8ms, against 295.0ms through the tunnel. An
-// operator who deploys without doing that is paying for a tunnel to be slower
-// than a sysctl, and nothing in the system told them.
+// The host half exists because the deployment guide's first instruction is to
+// do the free things first, and on a clean path direction those are worth as
+// much as the transport. Measured on the China-US path the datacenter profile
+// was built for, a client that reuses its connection and sets
+// tcp_slow_start_after_idle=0 takes a real 355KB inference upload to 240.9ms,
+// against 236.5ms through the tunnel in the same minutes. Both are within ten
+// milliseconds of the floor a 197ms round trip and a 30ms model impose, so on a
+// warm connection over a clean direction the two are the same answer and the
+// config line is the cheaper way to get it. An operator who deploys without
+// doing that is paying for a tunnel to reach a figure a sysctl already reached,
+// and nothing in the system told them.
+//
+// Those figures replace the 225.8ms and 295.0ms this comment used to quote.
+// The originals were medians across eight audio files labelled with the size of
+// whichever request ran last, which pulled the median below the floor that size
+// has on a 200ms path, and correcting them reversed the sign of the difference.
+// See docs/PATH-CHARACTER-DC-20260826.md, "Re-measured with one fixed file".
+//
+// The placement half exists because no host check can reach it and no document
+// can answer it for a particular destination. This transport improves the
+// client-to-gateway segment and nothing past it, so a gateway sited on the
+// wrong side of the traffic's real bottleneck lengthens the path while every
+// local check still passes. See doctor_probe.go for what is measured and why
+// it stops at connection establishment.
 //
 // So the checks are the preconditions rather than the plumbing. Whether the
 // gateway answers matters less than whether the host is in the state the
-// measurements assumed, because a gateway that does not answer is obvious and
-// a kernel default is not.
+// measurements assumed and whether the gateway is where the traffic needs it,
+// because a gateway that does not answer is obvious and neither of the other
+// two is.
 
 type check struct {
 	Name   string `json:"name"`
@@ -38,13 +59,15 @@ type check struct {
 }
 
 type report struct {
-	Version   string    `json:"version"`
-	OS        string    `json:"os"`
-	Arch      string    `json:"arch"`
-	Profile   string    `json:"path_profile"`
-	CheckedAt time.Time `json:"checked_at"`
-	OK        bool      `json:"ok"`
-	Checks    []check   `json:"checks"`
+	Version      string             `json:"version"`
+	OS           string             `json:"os"`
+	Arch         string             `json:"arch"`
+	Profile      string             `json:"path_profile"`
+	CheckedAt    time.Time          `json:"checked_at"`
+	OK           bool               `json:"ok"`
+	Checks       []check            `json:"checks"`
+	Gateway      *latency           `json:"gateway_rtt,omitempty"`
+	Destinations []destinationProbe `json:"destinations,omitempty"`
 }
 
 func runDoctorCommand(args []string) error {
@@ -52,10 +75,17 @@ func runDoctorCommand(args []string) error {
 	profilePath := fs.String("profile", "", "client profile to check, for the gateway endpoint")
 	pathProfile := fs.String("path-profile", "", "path profile to check against, empty for the default")
 	endpoint := fs.String("endpoint", "", "gateway host:port, when no client profile is available")
+	socksAddr := fs.String("socks", "127.0.0.1:12080", "local SOCKS5 listener to compare destinations through")
+	rounds := fs.Int("rounds", 5, "round pairs per destination; each pair runs both arms in both orders")
 	asJSON := fs.Bool("json", false, "emit the report as JSON")
 	timeout := fs.Duration("timeout", 10*time.Second, "per-check timeout")
+	var destinations stringList
+	fs.Var(&destinations, "destination", "destination host:port to check this gateway's placement against; repeat for several")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if *rounds < 1 {
+		return errors.New("--rounds must be at least 1")
 	}
 
 	selected, err := profile.ByName(*pathProfile)
@@ -83,10 +113,15 @@ func runDoctorCommand(args []string) error {
 	if target != "" {
 		ctx, cancel := context.WithTimeout(context.Background(), *timeout)
 		r.Checks = append(r.Checks, checkReachable(ctx, target)...)
+		r.Checks = append(r.Checks, measureGateway(ctx, target, *rounds, &r)...)
 		cancel()
 	} else {
 		r.Checks = append(r.Checks, check{Name: "gateway", Status: "warn",
 			Detail: "no --profile or --endpoint given, so nothing was dialled"})
+	}
+
+	if len(destinations) > 0 {
+		r.Checks = append(r.Checks, measureDestinations(destinations, *socksAddr, *rounds, *timeout, &r)...)
 	}
 
 	for _, c := range r.Checks {
@@ -109,6 +144,50 @@ func runDoctorCommand(args []string) error {
 	return nil
 }
 
+// measureGateway records the round trip every tunnelled flow pays before it
+// reaches anything. It is reported for its own sake and kept on the report so
+// that a destination probe can subtract it and leave the gateway's own hop.
+func measureGateway(ctx context.Context, endpoint string, rounds int, r *report) []check {
+	got, err := probeGateway(ctx, endpoint, rounds)
+	if err != nil {
+		return []check{{Name: "gateway_rtt", Status: "warn",
+			Detail: fmt.Sprintf("no round trip could be measured: %v", err)}}
+	}
+	r.Gateway = &got
+	return []check{{Name: "gateway_rtt", Status: "pass",
+		Detail: fmt.Sprintf("%s, paid once per flow setup before the destination is reached", got)}}
+}
+
+// measureDestinations runs the placement comparison for each destination named.
+//
+// Each destination gets its own timeout budget rather than sharing one, because
+// a first destination that is slow to answer should delay the report rather
+// than silently truncate the samples of the ones behind it.
+func measureDestinations(targets []string, socksAddr string, rounds int, timeout time.Duration, r *report) []check {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	listener := checkSOCKSListener(ctx, socksAddr)
+	cancel()
+	out := []check{listener}
+	if listener.Status != "pass" {
+		return out
+	}
+	for _, t := range targets {
+		// Two arms, two orders, plus the discarded warm-up, each of which may
+		// have to time out on its own before the next is tried.
+		budget := timeout * time.Duration(4*rounds+2)
+		ctx, cancel := context.WithTimeout(context.Background(), budget)
+		gateway := latency{}
+		if r.Gateway != nil {
+			gateway = *r.Gateway
+		}
+		p := probeDestination(ctx, t, socksAddr, rounds, gateway)
+		cancel()
+		r.Destinations = append(r.Destinations, p)
+		out = append(out, checkPlacement(p))
+	}
+	return out
+}
+
 func printReport(r report) {
 	fmt.Printf("queqiao doctor  profile=%s  %s/%s\n\n", r.Profile, r.OS, r.Arch)
 	for _, c := range r.Checks {
@@ -119,15 +198,106 @@ func printReport(r report) {
 		case "warn":
 			mark = "warn"
 		}
-		fmt.Printf("  %s  %-24s %s\n", mark, c.Name, c.Detail)
+		// The pad is a minimum, not a maximum: a name longer than it still
+		// prints in full and the detail wraps from wherever that left the
+		// cursor, so no check is renamed to fit a column.
+		width := detailColumn
+		if len(c.Name) > width {
+			width = len(c.Name)
+		}
+		fmt.Printf("  %s  %-*s %s\n", mark, detailColumn, c.Name,
+			indentWrap(c.Detail, markColumns+width+1, markColumns+detailColumn+1, 78))
+	}
+	for _, d := range r.Destinations {
+		printDestination(d)
 	}
 	fmt.Println()
 	if r.OK {
-		fmt.Println("No failures. A pass here is a host in the state the measurements assumed,")
-		fmt.Println("not a promise about the path: run cmd/pathprobe to learn what the path does.")
+		fmt.Println("No failures. A pass here is a host in the state the measurements assumed and a")
+		fmt.Println("gateway placed where the destinations checked can use it, not a promise about")
+		fmt.Println("the path: run cmd/pathprobe to learn what the path does.")
 		return
 	}
 	fmt.Println("Something above will not behave the way the deployment guide assumes.")
+}
+
+// printDestination puts the samples beside the verdict, because a reader who
+// disagrees with the verdict should be able to see what produced it without
+// re-running the command with --json.
+func printDestination(d destinationProbe) {
+	handshake := "connect only"
+	if d.TLS {
+		handshake = "connect and TLS handshake"
+	}
+	fmt.Printf("\ndestination  %s  (%s)\n", d.Target, handshake)
+	fmt.Printf("  arm       n   min_ms   p50_ms   p99_ms\n")
+	printArm("direct", d.Direct)
+	printArm("tunnel", d.Tunneled)
+	if d.Direct.N > 0 && d.Tunneled.N > 0 {
+		fmt.Printf("  # arm effect %.1fms, order effect %.1fms\n", d.ArmEffect, d.OrderEffect)
+	}
+	if d.Decomposed {
+		fmt.Printf("  # tunnelled = %.1fms to the gateway + %.1fms onward (derived, not measured)\n",
+			d.GatewayLeg, d.FarLeg)
+	}
+}
+
+func printArm(name string, l latency) {
+	if l.N == 0 {
+		fmt.Printf("  %-8s  0       --       --       --\n", name)
+		return
+	}
+	fmt.Printf("  %-8s %2d %8.1f %8.1f %8.1f\n", name, l.N, l.Min, l.P50, l.P99)
+}
+
+// markColumns is the width of the two-space, four-character, two-space status
+// prefix each check line begins with, and detailColumn is the width the check
+// name is padded to after it. A detail begins one column past the name.
+const (
+	markColumns  = 8
+	detailColumn = 24
+)
+
+// indentWrap folds a long detail into the column its first line started in.
+//
+// The details carry the reasoning an operator needs in order to act on a
+// check, so they are long by design; a terminal that folds them at column zero
+// puts that reasoning underneath the check names, where it reads as a separate
+// check. firstCol and indent are given separately because a check whose name
+// overruns the pad starts its detail further right than the block it wraps
+// into.
+func indentWrap(s string, firstCol, indent, width int) string {
+	// A minimum usable width. A name long enough to push the first line under
+	// it gives that line up entirely and the detail starts on the next one,
+	// because a four-column ribbon down the right margin is worse to read than
+	// one wasted line.
+	const minWidth = 20
+	budget := func(col int) int {
+		if n := width - col; n >= minWidth {
+			return n
+		}
+		return minWidth
+	}
+	limit := budget(firstCol)
+	var out strings.Builder
+	line := 0
+	for i, word := range strings.Fields(s) {
+		switch {
+		case i == 0 && width-firstCol < minWidth:
+			out.WriteString("\n" + strings.Repeat(" ", indent) + word)
+			limit, line = budget(indent), len(word)
+		case i == 0:
+			out.WriteString(word)
+			line = len(word)
+		case line+1+len(word) <= limit:
+			out.WriteString(" " + word)
+			line += 1 + len(word)
+		default:
+			out.WriteString("\n" + strings.Repeat(" ", indent) + word)
+			limit, line = budget(indent), len(word)
+		}
+	}
+	return out.String()
 }
 
 // checkProfile reports what was selected and how far it has been qualified,

--- a/cmd/queqiaod/doctor_probe.go
+++ b/cmd/queqiaod/doctor_probe.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math"
+	"net"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/net/proxy"
+)
+
+// This file adds the one measurement a deployment needs before it exists and
+// cannot get from anywhere else: whether this gateway is on the useful side of
+// this client's path to a destination it actually calls.
+//
+// The rest of the doctor checks preconditions on the host. Those are worth
+// checking and they are not the question an operator gets wrong. The question
+// an operator gets wrong is placement, because the transport improves the
+// client-to-gateway segment and nothing past it, so a gateway sited on the
+// wrong side of the traffic's real bottleneck lengthens the path while every
+// local check passes. A destination fronted by an anycast edge is the ordinary
+// way this happens: the session terminates at a point of presence near the
+// client, the long haul runs inside the provider's own backbone where neither
+// end of this transport can reach it, and routing that traffic through a
+// distant gateway adds the whole gateway leg for nothing.
+//
+// What follows measures connection establishment and stops there. Establishment
+// is what placement determines, and it is the part a local instrument can hold
+// still. Throughput, loss, and completion time under load belong to
+// cmd/pathprobe and cmd/pathmeasure, which drive the path rather than sampling
+// it, and this command should not grow into a worse copy of either.
+
+// latency reduces a set of establishment samples to the three figures a
+// placement decision is read from.
+//
+// The minimum is the path's own floor -- the sample least contaminated by a
+// queue, and the reference a delay-bounded controller holds itself against. The
+// median is what a caller usually gets. The tail is what a caller held to a p99
+// is held to, and it moves independently of the median often enough that
+// reporting either alone is misleading: on the characterised path a warm
+// request sat at 240.9ms at the median and 916.7ms at p99 in a minute when the
+// path was erasing, a spread no median would have shown.
+type latency struct {
+	N   int     `json:"n"`
+	Min float64 `json:"min_ms"`
+	P50 float64 `json:"p50_ms"`
+	P99 float64 `json:"p99_ms"`
+}
+
+func (l latency) String() string {
+	if l.N == 0 {
+		return "no samples"
+	}
+	return fmt.Sprintf("min %.1fms p50 %.1fms p99 %.1fms (n=%d)", l.Min, l.P50, l.P99, l.N)
+}
+
+// summarize sorts a copy so a caller's slice keeps the order it was collected
+// in, which is what the position analysis below still needs.
+func summarize(samples []float64) latency {
+	if len(samples) == 0 {
+		return latency{}
+	}
+	s := append([]float64(nil), samples...)
+	sort.Float64s(s)
+	return latency{N: len(s), Min: s[0], P50: quantile(s, 0.50), P99: quantile(s, 0.99)}
+}
+
+// quantile reads a percentile off an already sorted sample set by nearest rank,
+// which is the same convention cmd/pathmeasure reports with. Interpolating
+// would invent a value between two measurements that were both real.
+func quantile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(p*float64(len(sorted))+0.5) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+// probeGateway establishes and discards TCP connections to the gateway.
+//
+// The figure it produces is used twice: on its own, as the round trip every
+// tunnelled flow pays before it reaches anything, and as the term subtracted
+// from a tunnelled establishment to leave the gateway's own hop to the
+// destination. A single dial cannot serve either purpose, because one sample
+// carries whatever the local stack was doing at the time.
+func probeGateway(ctx context.Context, endpoint string, rounds int) (latency, error) {
+	var samples []float64
+	var lastErr error
+	var dialer net.Dialer
+	for i := 0; i < rounds; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		start := time.Now()
+		conn, err := dialer.DialContext(ctx, "tcp", endpoint)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		samples = append(samples, float64(time.Since(start).Microseconds())/1000)
+		_ = conn.Close()
+	}
+	if len(samples) == 0 {
+		return latency{}, lastErr
+	}
+	return summarize(samples), nil
+}
+
+// destinationProbe is one destination measured both ways.
+type destinationProbe struct {
+	Target      string  `json:"target"`
+	TLS         bool    `json:"tls"`
+	Direct      latency `json:"direct"`
+	Tunneled    latency `json:"tunneled"`
+	DirectError string  `json:"direct_error,omitempty"`
+	TunnelError string  `json:"tunnel_error,omitempty"`
+	// ArmEffect and OrderEffect are the two candidate explanations for the
+	// difference between the arms, in milliseconds. The second is the noise
+	// floor of the first.
+	ArmEffect   float64 `json:"arm_effect_ms"`
+	OrderEffect float64 `json:"order_effect_ms"`
+	// GatewayLeg is the measured client-to-gateway round trip, and FarLeg is
+	// what is left of a tunnelled establishment once it is removed. FarLeg is
+	// a derivation, not a measurement, and Decomposed says whether there was
+	// enough to derive it from.
+	GatewayLeg float64 `json:"gateway_leg_ms,omitempty"`
+	FarLeg     float64 `json:"gateway_to_destination_ms,omitempty"`
+	Decomposed bool    `json:"decomposed"`
+}
+
+// probeDestination compares reaching one destination directly against reaching
+// it through the local SOCKS listener.
+//
+// It alternates the arms every round and reports the order effect beside the
+// arm effect, because this project has already paid for the lesson that a
+// comparison run one way round measures the path's drift and calls it the
+// change: on the characterised path, position in the sequence was worth 158ms
+// where the policy under test was worth 2.4ms, and sorting the arms produced a
+// 53% win that reversed when the order reversed. The same rule that governs
+// cmd/pathmeasure's ab mode governs this, for the same reason.
+func probeDestination(ctx context.Context, target, socksAddr string, rounds int, gateway latency) destinationProbe {
+	p := destinationProbe{Target: target, TLS: wantsTLS(target)}
+
+	// One establishment on each arm is thrown away before anything is
+	// recorded. It pays for the local resolver cache, the gateway's resolver
+	// cache, and a tunnel that may not yet have a lane open, none of which a
+	// steady-state comparison should be charged for. A cold tunnel is a real
+	// cost and a real advantage of this transport, but it is a completion-time
+	// question that cmd/pathmeasure answers with a workload, not something to
+	// smuggle into a placement check as a one-off outlier.
+	_, _ = establish(ctx, target, "", p.TLS)
+	_, _ = establish(ctx, target, socksAddr, p.TLS)
+
+	var direct, tunneled, first, second []float64
+	for r := 0; r < rounds; r++ {
+		if ctx.Err() != nil {
+			break
+		}
+		for _, directFirst := range []bool{true, false} {
+			firstProxy, secondProxy := "", socksAddr
+			if !directFirst {
+				firstProxy, secondProxy = socksAddr, ""
+			}
+			fs, ferr := establish(ctx, target, firstProxy, p.TLS)
+			ss, serr := establish(ctx, target, secondProxy, p.TLS)
+			d, t, derr, terr := fs, ss, ferr, serr
+			if !directFirst {
+				d, t, derr, terr = ss, fs, serr, ferr
+			}
+			if derr == nil {
+				direct = append(direct, ms(d))
+			} else if p.DirectError == "" {
+				p.DirectError = derr.Error()
+			}
+			if terr == nil {
+				tunneled = append(tunneled, ms(t))
+			} else if p.TunnelError == "" {
+				p.TunnelError = terr.Error()
+			}
+			if ferr == nil {
+				first = append(first, ms(fs))
+			}
+			if serr == nil {
+				second = append(second, ms(ss))
+			}
+		}
+	}
+
+	p.Direct, p.Tunneled = summarize(direct), summarize(tunneled)
+	if p.Direct.N > 0 && p.Tunneled.N > 0 {
+		p.ArmEffect = absDelta(p.Direct.P50, p.Tunneled.P50)
+		p.OrderEffect = absDelta(summarize(first).P50, summarize(second).P50)
+	}
+	if p.Tunneled.N > 0 && gateway.N > 0 {
+		p.GatewayLeg = gateway.P50
+		p.FarLeg = p.Tunneled.P50 - gateway.P50
+		if p.FarLeg < 0 {
+			p.FarLeg = 0
+		}
+		p.Decomposed = true
+	}
+	// Every figure here came from a microsecond clock, so a difference of two
+	// of them carries a tail of binary noise that a JSON reader would have to
+	// decide whether to trust. Rounding back to the resolution the samples
+	// actually had answers that once, here.
+	p.ArmEffect, p.OrderEffect, p.FarLeg = round3(p.ArmEffect), round3(p.OrderEffect), round3(p.FarLeg)
+	return p
+}
+
+// establish opens one connection to target and returns how long it took to
+// become usable, through the SOCKS listener when one is given.
+//
+// The tunnelled arm resolves the name at the gateway and the direct arm
+// resolves it locally, which is not a flaw in the comparison but the thing
+// being compared: an anycast name resolves to whatever is near whoever asked,
+// so a name looked up at the gateway and the same name looked up here can be
+// two different machines on two different continents. Resolving once and
+// dialling both arms at the same address would hide exactly the case this
+// check exists to find.
+//
+// TLS is included where the port says it is expected, because a handshake is a
+// second round trip on the same path and doubles the signal without doubling
+// the interpretation.
+//
+// The certificate is verified, and that is load-bearing rather than incidental.
+// The two arms resolve the name independently and may therefore reach two
+// different machines, which is the whole point of the comparison and also its
+// one way of going quietly wrong: two arms that reached two unrelated services
+// would produce a difference with no topological meaning. A chain that
+// validates for the requested name is the cheapest available evidence that
+// both arms arrived somewhere entitled to answer for it. A destination that
+// answers TCP and then fails the handshake is reported as an error rather than
+// silently measured as a bare connect.
+func establish(ctx context.Context, target, socksAddr string, useTLS bool) (time.Duration, error) {
+	start := time.Now()
+	conn, err := dialTarget(ctx, target, socksAddr)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = conn.Close() }()
+	if !useTLS {
+		return time.Since(start), nil
+	}
+	host, _, splitErr := net.SplitHostPort(target)
+	if splitErr != nil {
+		return 0, splitErr
+	}
+	tc := tls.Client(conn, &tls.Config{ServerName: host, MinVersion: tls.VersionTLS12})
+	if err := tc.HandshakeContext(ctx); err != nil {
+		return 0, err
+	}
+	return time.Since(start), nil
+}
+
+func dialTarget(ctx context.Context, target, socksAddr string) (net.Conn, error) {
+	if socksAddr == "" {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", target)
+	}
+	d, err := proxy.SOCKS5("tcp", socksAddr, nil, &net.Dialer{})
+	if err != nil {
+		return nil, err
+	}
+	cd, ok := d.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("socks5 dialer for %s does not honour a context", socksAddr)
+	}
+	return cd.DialContext(ctx, "tcp", target)
+}
+
+// checkSOCKSListener dials the local listener before any destination is
+// probed, so that a client which is simply not running is reported once as
+// itself rather than once per destination as a connection failure.
+func checkSOCKSListener(ctx context.Context, socksAddr string) check {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", socksAddr)
+	if err != nil {
+		return check{Name: "socks_listener", Status: "warn",
+			Detail: fmt.Sprintf("%v; no destination could be compared through the tunnel. "+
+				"Start the client, or name the listener with --socks", err)}
+	}
+	_ = conn.Close()
+	return check{Name: "socks_listener", Status: "pass", Detail: socksAddr}
+}
+
+// Thresholds for the placement verdict.
+//
+// A tunnel always adds a hop, so a tunnelled establishment being slower than a
+// direct one is the ordinary case and not a finding. What separates a healthy
+// deployment from a misplaced gateway is how much slower, relative to the
+// direct path: a client whose direct path to the destination is genuinely long
+// pays a small fraction extra to route through a gateway near it, while a
+// client already sitting a few milliseconds from an anycast edge pays the whole
+// gateway leg and has no erasure on that short hop to earn it back.
+//
+// The ratios are round numbers chosen to sit either side of that difference
+// rather than measured constants, and the absolute floor keeps a couple of
+// milliseconds on a short path from reading as a topology problem. The order
+// effect gates the warning as well: a difference smaller than the drift
+// measured in the same minutes has not been resolved by this comparison.
+const (
+	placementRatioClean    = 1.2
+	placementRatioMisplace = 2.0
+	placementFloorMS       = 5.0
+)
+
+// checkPlacement turns one probe into the verdict an operator can act on.
+func checkPlacement(p destinationProbe) check {
+	name := "destination:" + p.Target
+	switch {
+	case p.Direct.N == 0 && p.Tunneled.N == 0:
+		return check{Name: name, Status: "fail",
+			Detail: fmt.Sprintf("neither arm reached it. direct: %s. tunnel: %s",
+				orNone(p.DirectError), orNone(p.TunnelError))}
+	case p.Tunneled.N == 0:
+		return check{Name: name, Status: "fail",
+			Detail: fmt.Sprintf("the tunnel did not reach it (%s), though a direct connection did at %s. "+
+				"A destination the gateway cannot open is a gateway problem, not a placement one",
+				orNone(p.TunnelError), p.Direct)}
+	case p.Direct.N == 0:
+		return check{Name: name, Status: "pass",
+			Detail: fmt.Sprintf("no direct connection completed (%s), and the tunnel reached it at %s. "+
+				"Placement is not a latency question where the tunnel is the only path",
+				orNone(p.DirectError), p.Tunneled)}
+	}
+
+	ratio := p.Tunneled.P50 / max(p.Direct.P50, 0.001)
+	excess := p.Tunneled.P50 - p.Direct.P50
+	detail := fmt.Sprintf("direct %s; tunnel %s; %s", p.Direct, p.Tunneled, decomposition(p))
+
+	if p.OrderEffect >= p.ArmEffect {
+		return check{Name: name, Status: "warn",
+			Detail: fmt.Sprintf("%s. ORDER DOMINATES: the path drifted %.1fms between arms and the arms "+
+				"differ by %.1fms, so this comparison has not resolved the difference. Re-run it, "+
+				"or take the question to cmd/pathmeasure -mode ab with more rounds",
+				detail, p.OrderEffect, p.ArmEffect)}
+	}
+	if ratio > placementRatioMisplace && excess > placementFloorMS && excess > p.OrderEffect {
+		return check{Name: name, Status: "warn",
+			Detail: fmt.Sprintf("%s. The tunnel is %.1fx the direct establishment, so this destination is "+
+				"served closer to this client than the gateway is. Check whether the name is fronted by "+
+				"an anycast edge: if the session already terminates near this client, the long haul runs "+
+				"inside the provider's network where this transport cannot reach it, and the gateway leg "+
+				"is added for nothing", detail, ratio)}
+	}
+	if ratio > placementRatioClean {
+		return check{Name: name, Status: "pass",
+			Detail: fmt.Sprintf("%s. The tunnel adds %.1fms, which the transfer has to earn back. "+
+				"Whether it does is a workload question: cmd/pathmeasure -mode workload against this "+
+				"endpoint, with the direct arm tuned", detail, excess)}
+	}
+	return check{Name: name, Status: "pass",
+		Detail: fmt.Sprintf("%s. The tunnel is %.2fx the direct establishment, so the gateway is not "+
+			"costing this destination a detour", detail, ratio)}
+}
+
+// decomposition splits a tunnelled establishment into the leg this transport
+// carries and the leg it does not, which is what makes a verdict actionable:
+// a large gateway leg is a placement decision the operator can revisit, and a
+// large far leg is the gateway's own transit, which moving the client will not
+// change.
+func decomposition(p destinationProbe) string {
+	if !p.Decomposed {
+		return "the gateway leg was not measured, so the tunnelled time is not decomposed"
+	}
+	return fmt.Sprintf("of which %.1fms is the leg to the gateway and about %.1fms is the gateway's own hop "+
+		"to the destination", p.GatewayLeg, p.FarLeg)
+}
+
+// wantsTLS decides whether a handshake belongs in the measurement. Port 443 is
+// the case worth covering and guessing more widely would turn a refused
+// handshake into a reported failure on a destination that was answering fine.
+func wantsTLS(target string) bool {
+	_, port, err := net.SplitHostPort(target)
+	return err == nil && port == "443"
+}
+
+func ms(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }
+
+func round3(v float64) float64 { return math.Round(v*1000) / 1000 }
+
+func absDelta(a, b float64) float64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "no error recorded"
+	}
+	return s
+}
+
+// stringList collects a flag given more than once, so several destinations can
+// be probed in the run whose report is read as a whole.
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+
+func (s *stringList) Set(v string) error {
+	if v == "" {
+		return fmt.Errorf("empty value")
+	}
+	*s = append(*s, v)
+	return nil
+}

--- a/cmd/queqiaod/doctor_probe_test.go
+++ b/cmd/queqiaod/doctor_probe_test.go
@@ -1,0 +1,403 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/socks5"
+)
+
+func TestQuantileReadsNearestRankAndSurvivesTheEdges(t *testing.T) {
+	sorted := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	if got := quantile(sorted, 0.50); got != 5 {
+		t.Errorf("p50 of 1..10 is %v", got)
+	}
+	if got := quantile(sorted, 0.99); got != 10 {
+		t.Errorf("p99 of 1..10 is %v", got)
+	}
+	if got := quantile([]float64{7}, 0.99); got != 7 {
+		t.Errorf("p99 of a single sample is %v", got)
+	}
+	if got := quantile(nil, 0.5); got != 0 {
+		t.Errorf("p50 of nothing is %v", got)
+	}
+}
+
+// summarize must not reorder what it was given. The position analysis reads the
+// same slices afterwards, and sorting them in place would turn the order effect
+// into a comparison of two sorted lists, which is always zero.
+func TestSummarizeLeavesTheCallersOrderAlone(t *testing.T) {
+	samples := []float64{9, 1, 5}
+	got := summarize(samples)
+	if got.Min != 1 || got.P50 != 5 || got.N != 3 {
+		t.Fatalf("summary is %+v", got)
+	}
+	if samples[0] != 9 || samples[1] != 1 || samples[2] != 5 {
+		t.Fatalf("the caller's slice was reordered: %v", samples)
+	}
+}
+
+// The case this check exists for: a destination served from an edge near the
+// client, reached through a gateway on another continent. Every host check
+// passes and the tunnel is still the wrong answer for this destination.
+func TestPlacementWarnsWhenTheDestinationIsServedNearerThanTheGateway(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "api.example.com:443",
+		Direct:      latency{N: 10, Min: 4.0, P50: 4.3, P99: 5.2},
+		Tunneled:    latency{N: 10, Min: 70.9, P50: 71.3, P99: 78.4},
+		ArmEffect:   67.0,
+		OrderEffect: 1.2,
+		GatewayLeg:  68.1,
+		FarLeg:      3.2,
+		Decomposed:  true,
+	})
+	if got.Status != "warn" {
+		t.Fatalf("a gateway on the far side of the destination reported %q: %s", got.Status, got.Detail)
+	}
+	for _, want := range []string{"anycast", "16.6x", "68.1ms", "3.2ms"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Errorf("the verdict omits %q: %s", want, got.Detail)
+		}
+	}
+}
+
+// The ordinary healthy deployment. The tunnel costs one hop on a path that is
+// long either way, and saying so must not read as a problem.
+func TestPlacementAcceptsAGatewayNoFartherThanTheClient(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "inference.example.net:443",
+		Direct:      latency{N: 10, Min: 178, P50: 180, P99: 191},
+		Tunneled:    latency{N: 10, Min: 188, P50: 190, P99: 204},
+		ArmEffect:   10,
+		OrderEffect: 2,
+		GatewayLeg:  185,
+		FarLeg:      5,
+		Decomposed:  true,
+	})
+	if got.Status != "pass" {
+		t.Fatalf("one added hop on a long path reported %q: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "detour") {
+		t.Errorf("the verdict does not state what was compared: %s", got.Detail)
+	}
+}
+
+// Between the two thresholds the honest answer is that establishment got
+// slower and only a workload can say whether the transfer earns it back. The
+// check must hand that question on rather than settle it from a connect time.
+func TestPlacementSendsAModestOverheadToAWorkloadMeasurement(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "inference.example.net:443",
+		Direct:      latency{N: 10, Min: 176, P50: 180, P99: 195},
+		Tunneled:    latency{N: 10, Min: 224, P50: 230, P99: 261},
+		ArmEffect:   50,
+		OrderEffect: 3,
+		GatewayLeg:  205,
+		FarLeg:      25,
+		Decomposed:  true,
+	})
+	if got.Status != "pass" {
+		t.Fatalf("a modest overhead reported %q: %s", got.Status, got.Detail)
+	}
+	for _, want := range []string{"workload", "50.0ms", "tuned"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Errorf("the verdict omits %q: %s", want, got.Detail)
+		}
+	}
+}
+
+// A difference smaller than the drift measured in the same minutes has not been
+// resolved. This project has already paid for the lesson once, in a 53% win
+// that reversed when the order reversed, and a check that reports the drift as
+// a finding would reintroduce it in a place operators trust.
+func TestPlacementRefusesToConcludeWhenTheOrderEffectDominates(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "api.example.com:443",
+		Direct:      latency{N: 10, Min: 40, P50: 60, P99: 210},
+		Tunneled:    latency{N: 10, Min: 42, P50: 66, P99: 240},
+		ArmEffect:   6,
+		OrderEffect: 41,
+		Decomposed:  false,
+	})
+	if got.Status != "warn" {
+		t.Fatalf("an unresolved comparison reported %q: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "ORDER DOMINATES") {
+		t.Errorf("the verdict does not say the comparison failed to resolve: %s", got.Detail)
+	}
+}
+
+// Where the tunnel is the only way to reach something, its latency against a
+// direct arm that never completed is not a placement question and must not be
+// reported as one.
+func TestPlacementPassesWhenOnlyTheTunnelReachesTheDestination(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "blocked.example.com:443",
+		Direct:      latency{},
+		DirectError: "i/o timeout",
+		Tunneled:    latency{N: 10, Min: 190, P50: 194, P99: 220},
+	})
+	if got.Status != "pass" {
+		t.Fatalf("a destination only the tunnel reaches reported %q: %s", got.Status, got.Detail)
+	}
+}
+
+// The reverse is a real failure, and calling it a placement warning would file
+// a broken gateway under a topology heading.
+func TestPlacementFailsWhenTheTunnelCannotReachADestinationThatAnswersDirectly(t *testing.T) {
+	got := checkPlacement(destinationProbe{
+		Target:      "internal.example.net:443",
+		Direct:      latency{N: 10, Min: 3, P50: 3.2, P99: 4},
+		Tunneled:    latency{},
+		TunnelError: "socks5: CONNECT refused, reply 2",
+	})
+	if got.Status != "fail" {
+		t.Fatalf("a gateway that refuses a destination reported %q: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "gateway problem") {
+		t.Errorf("the verdict does not separate this from a placement result: %s", got.Detail)
+	}
+}
+
+func TestWantsTLSOnlyWhereAHandshakeIsExpected(t *testing.T) {
+	if !wantsTLS("example.com:443") {
+		t.Error("443 was not treated as a TLS port")
+	}
+	for _, target := range []string{"example.com:80", "example.com:12345", "not-a-target"} {
+		if wantsTLS(target) {
+			t.Errorf("%q was treated as a TLS port", target)
+		}
+	}
+}
+
+func TestCheckSOCKSListenerReportsAClientThatIsNotRunning(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	// Port 1 on loopback, which nothing listens on and which refuses fast.
+	got := checkSOCKSListener(ctx, "127.0.0.1:1")
+	if got.Status != "warn" {
+		t.Fatalf("a missing client reported %q: %s", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "--socks") {
+		t.Errorf("the warning does not name the flag that would fix it: %s", got.Detail)
+	}
+}
+
+// The end-to-end shape: a destination reached directly and through a SOCKS
+// listener speaking this project's own server-side parser, so the probe's
+// client is exercised against the code a real client runs.
+func TestProbeDestinationMeasuresBothArmsAndDecomposesTheTunnelledLeg(t *testing.T) {
+	destination := listenAndAccept(t)
+	socksAddr := startSOCKSProxy(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	gateway := latency{N: 4, Min: 0.4, P50: 0.5, P99: 0.9}
+	got := probeDestination(ctx, destination, socksAddr, 2, gateway)
+
+	if got.DirectError != "" {
+		t.Fatalf("the direct arm failed: %s", got.DirectError)
+	}
+	if got.TunnelError != "" {
+		t.Fatalf("the tunnelled arm failed: %s", got.TunnelError)
+	}
+	// Two round pairs, each running both orders, is four samples per arm.
+	if got.Direct.N != 4 || got.Tunneled.N != 4 {
+		t.Fatalf("sample counts are direct=%d tunnel=%d, want 4 and 4", got.Direct.N, got.Tunneled.N)
+	}
+	if !got.Decomposed {
+		t.Error("a measured gateway leg was not subtracted from the tunnelled establishment")
+	}
+	if got.GatewayLeg != gateway.P50 {
+		t.Errorf("the gateway leg is %v, want the measured %v", got.GatewayLeg, gateway.P50)
+	}
+	if got.FarLeg < 0 {
+		t.Errorf("the derived far leg is negative: %v", got.FarLeg)
+	}
+	if got.TLS {
+		t.Error("a loopback port was treated as needing a TLS handshake")
+	}
+}
+
+// A gateway leg larger than the whole tunnelled establishment would derive a
+// negative hop, which is a measurement artefact rather than a distance. It has
+// to floor at zero instead of printing a number no reader could act on.
+func TestProbeDestinationFloorsAnImpossibleFarLegAtZero(t *testing.T) {
+	destination := listenAndAccept(t)
+	socksAddr := startSOCKSProxy(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+	got := probeDestination(ctx, destination, socksAddr, 1, latency{N: 4, P50: 10_000})
+	if !got.Decomposed {
+		t.Fatal("the probe did not decompose the tunnelled leg")
+	}
+	if got.FarLeg != 0 {
+		t.Errorf("an impossible far leg is %v, want 0", got.FarLeg)
+	}
+}
+
+func TestProbeGatewayReportsADistributionRatherThanOneDial(t *testing.T) {
+	endpoint := listenAndAccept(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	got, err := probeGateway(ctx, endpoint, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.N != 5 {
+		t.Fatalf("got %d samples, want 5", got.N)
+	}
+	if got.Min > got.P50 || got.P50 > got.P99 {
+		t.Fatalf("the summary is not ordered: %+v", got)
+	}
+}
+
+func TestProbeGatewayReturnsTheErrorWhenNothingAnswers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	if _, err := probeGateway(ctx, "127.0.0.1:1", 2); err == nil {
+		t.Fatal("a gateway that refuses every dial produced no error")
+	}
+}
+
+func TestIndentWrapFoldsOntoTheColumnItStartedIn(t *testing.T) {
+	const indent, width = 33, 78
+	got := indentWrap(strings.Repeat("word ", 40), indent, indent, width)
+	lines := strings.Split(got, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("a detail of 200 columns folded into %d lines", len(lines))
+	}
+	for i, line := range lines {
+		if i > 0 && !strings.HasPrefix(line, strings.Repeat(" ", indent)) {
+			t.Fatalf("continuation line %d lost the indent: %q", i, line)
+		}
+		if got := len(line) + boolToInt(i == 0)*indent; got > width {
+			t.Fatalf("line %d reaches column %d: %q", i, got, line)
+		}
+	}
+	if strings.Contains(got, " \n") {
+		t.Errorf("a line was padded with trailing space: %q", got)
+	}
+}
+
+// A name that overruns the pad pushes its first line right, and only its first
+// line. Charging the whole block for that would waste a third of the width on
+// every line that follows the long name.
+func TestIndentWrapChargesOnlyTheFirstLineForALongName(t *testing.T) {
+	const indent, width = 33, 78
+	got := indentWrap(strings.Repeat("word ", 40), 40, indent, width)
+	lines := strings.Split(got, "\n")
+	if len(lines[0])+40 > width {
+		t.Fatalf("the first line reaches column %d: %q", len(lines[0])+40, lines[0])
+	}
+	if len(lines[1]) <= len(lines[0]) {
+		t.Fatalf("the block did not widen after the first line: %q then %q", lines[0], lines[1])
+	}
+}
+
+// Past some name length there is no first line worth having, and a detail
+// squeezed into what is left would be a ribbon down the right margin. It gives
+// the line up instead, and nothing overruns the width.
+func TestIndentWrapGivesUpTheFirstLineRatherThanOverrun(t *testing.T) {
+	const indent, width = 33, 78
+	got := indentWrap(strings.Repeat("word ", 40), 65, indent, width)
+	if !strings.HasPrefix(got, "\n"+strings.Repeat(" ", indent)) {
+		t.Fatalf("the detail did not start on its own line: %q", got[:40])
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if len(line) > width {
+			t.Fatalf("a line reaches column %d: %q", len(line), line)
+		}
+	}
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func TestDoctorRefusesRoundsBelowOne(t *testing.T) {
+	err := runDoctorCommand([]string{"--rounds", "0"})
+	if err == nil {
+		t.Fatal("zero rounds was accepted")
+	}
+	if !strings.Contains(err.Error(), "--rounds") {
+		t.Fatalf("the error does not name the flag: %v", err)
+	}
+}
+
+func TestDestinationFlagCollectsEveryValue(t *testing.T) {
+	var got stringList
+	for _, v := range []string{"a:1", "b:2"} {
+		if err := got.Set(v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := got.Set(""); err == nil {
+		t.Error("an empty destination was accepted")
+	}
+	if got.String() != "a:1,b:2" {
+		t.Fatalf("collected %q", got.String())
+	}
+}
+
+// listenAndAccept starts a listener that accepts and immediately closes, which
+// is all an establishment measurement needs on the far side.
+func listenAndAccept(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// startSOCKSProxy runs a CONNECT-only proxy on this project's own request
+// parser, so the probe's client is checked against the wire the real listener
+// speaks rather than against a second reading of the RFC.
+func startSOCKSProxy(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				request, err := socks5.ReadRequest(conn, nil)
+				if err != nil || request.Command != socks5.CommandConnect {
+					return
+				}
+				upstream, err := net.DialTimeout("tcp", request.Destination, 3*time.Second)
+				if err != nil {
+					_ = socks5.WriteReply(conn, socks5.ReplyHostUnreachable, nil)
+					return
+				}
+				defer func() { _ = upstream.Close() }()
+				_ = socks5.WriteReply(conn, socks5.ReplySucceeded, upstream.LocalAddr())
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}

--- a/docs/CHOOSING-A-GATEWAY.md
+++ b/docs/CHOOSING-A-GATEWAY.md
@@ -1,0 +1,386 @@
+# Choosing and placing a gateway
+
+> [!NOTE]
+> **Status:** Current operational guidance for public protocol 1
+> **Last reviewed:** 2026-08-28
+
+Queqiao improves one segment of a path: the segment between a client and a
+gateway, both of which the same operator controls. Every deployment decision
+that matters follows from that sentence, and the one most often decided wrongly
+is where the gateway should go. This document sets out how to decide it, how to
+establish the facts the decision depends on, and when the correct decision is to
+deploy no gateway at all.
+
+It is written for the reader who has a destination in mind and does not yet have
+a gateway. The [deployment guide](DEPLOYING.md) covers the mechanics of
+installing one; what follows is the question that precedes it.
+
+## The transport is paired
+
+Both ends of a Queqiao session run `queqiaod`, authenticate to each other with a
+provider-pinned identity and a per-device certificate, and speak protocol 1
+between them. A server operated by someone else cannot take part. This is not a
+gap in the current release: it is the assumption the control design rests on,
+since the transport measures a segment and shares one path model across the
+flows that cross it, and neither is possible without both endpoints.
+
+The consequence is direct. A reader who wishes to improve access to a hosted
+model API, a SaaS endpoint, or any other destination outside their
+administrative control must first obtain a host they do control and place a
+gateway on it. There is no configuration in which the far end is a third party,
+and no flag that relaxes the requirement.
+
+## The optimized segment ends at the gateway
+
+```mermaid
+flowchart LR
+    A[Application] --> B[SOCKS5 ingress<br/>Queqiao client]
+    B ==>|measured, coded, paced<br/>by this transport| C[Queqiao gateway]
+    C -->|ordinary TCP, on whatever<br/>transit the gateway has| D[Destination]
+```
+
+The client and the gateway share a path model, a delay bound, an erasure
+estimate, and a pacing budget. The leg from the gateway onward has none of
+these. It is an ordinary connection, subject to whatever the gateway's own
+transit gives it, and Queqiao neither measures nor repairs it.
+
+From this the placement rule follows directly. **Site the gateway on the far
+side of the segment that is actually degrading the traffic, and only where the
+remaining leg to the destination is short and unimpaired.** A gateway that
+satisfies neither condition lengthens the path. It does so silently, because
+every check that can be run on the client host will still pass: the profile is
+valid, the sysctls are set, the gateway answers, and the tunnel correctly
+carries traffic to a place the traffic did not need to go.
+
+Two questions therefore decide placement, and they are independent:
+
+1. Which segment of the path is degrading the traffic?
+2. Where does the session to this destination actually terminate?
+
+The first is the question the project was built around, and its
+[path characterization](PATH-CHARACTER-20260813.md) answers it at length. The
+second is easier to overlook and, for a large class of modern destinations, is
+the one that decides the outcome.
+
+## Where the session actually terminates
+
+The placement rule presumes that a destination is located where its address
+suggests. For a growing class of services, it is not.
+
+A service published behind an anycast edge announces the same address from many
+points of presence at once. A client's packets reach whichever presence the
+routing system considers nearest, the TCP and TLS session terminates there, and
+the request then crosses the provider's own backbone to wherever the origin
+runs. Two properties follow, and both bear on placement.
+
+First, a round trip measured from the client to such a destination describes the
+distance to an edge rather than to the origin. A client in Frankfurt that
+measures four milliseconds to an API whose origin is understood to be in
+California has not discovered a fast transatlantic path. It has discovered a
+Frankfurt edge.
+
+Second, the segment between the edge and the origin lies inside the provider's
+network. Neither end of a Queqiao session sits on that segment, and no transport
+the reader deploys can reach it. Whatever latency the long haul contributes is
+therefore not addressable from outside, by this transport or by any other.
+
+The consequence for placement is unwelcome, and it is worth stating as a worked
+case. Consider a client in Singapore calling a model API whose origin is
+understood to run in the western United States. If the API is fronted by an
+anycast edge, the client's session already terminates a few milliseconds away in
+Singapore. Interposing a gateway in Oregon replaces that short leg with two
+longer ones: roughly seventy milliseconds from Singapore to the gateway,
+followed by a further hop from the gateway out to whichever edge is nearest
+Oregon. The path has been lengthened by very nearly the whole gateway leg, and
+the traffic that was to be accelerated never crossed the segment the gateway was
+placed to improve.
+
+This outcome is not exotic. It is the ordinary result of applying the placement
+rule to a destination whose topology was assumed rather than measured, and it is
+why the first instruction below is a measurement and not a deployment.
+
+Whether a particular API is published this way, from a particular network, on a
+particular day, is not a question a document can settle. Edge footprints change,
+routing changes, and a provider may serve some endpoints from an edge and others
+from a region directly. Measure the destination to be called rather than
+reasoning about the vendor that operates it.
+
+## Establishing the facts before deploying
+
+Three instruments answer three different questions, and reaching for the wrong
+one produces a confident answer to a question nobody asked.
+
+### What a local check can settle
+
+`queqiaod doctor` establishes whether the host is in the state the published
+measurements assumed and whether a gateway is placed where a given destination
+can use it. Given one or more destinations, it compares reaching each of them
+directly against reaching them through the local SOCKS listener, alternating the
+two arms, and reports what it measured alongside what it concluded:
+
+```sh
+queqiaod doctor \
+  --profile ~/.config/queqiao/*.json \
+  --destination api.example.com:443 \
+  --destination inference.internal:443 \
+  --rounds 8
+```
+
+The report below is illustrative, not a measurement of any real service:
+
+```
+  ok    gateway_rtt              min 68.0ms p50 68.1ms p99 71.4ms (n=8), paid
+                                 once per flow setup before the destination is
+                                 reached
+  warn  destination:api.example.com:443
+                                 direct min 4.0ms p50 4.3ms p99 5.2ms (n=16);
+                                 tunnel min 70.9ms p50 71.3ms p99 78.4ms
+                                 (n=16); of which 68.1ms is the leg to the
+                                 gateway and about 3.2ms is the gateway's own
+                                 hop to the destination. The tunnel is 16.6x
+                                 the direct establishment, so this destination
+                                 is served closer to this client than the
+                                 gateway is.
+
+destination  api.example.com:443  (connect and TLS handshake)
+  arm       n   min_ms   p50_ms   p99_ms
+  direct   16      4.0      4.3      5.2
+  tunnel   16     70.9     71.3     78.4
+  # arm effect 67.0ms, order effect 1.2ms
+  # tunnelled = 68.1ms to the gateway + 3.2ms onward (derived, not measured)
+```
+
+Three features of that report deserve comment, since they determine how much
+weight it can carry.
+
+The **decomposition** subtracts the measured gateway round trip from the
+tunnelled establishment and attributes the remainder to the gateway's own hop
+onward. It is a derivation rather than a measurement, and it is labelled as one.
+Its value is that it separates a finding the operator can act on from one they
+cannot: a large gateway leg is a placement decision that can be revisited, while
+a large remainder is the gateway's own transit, which relocating the client will
+not change.
+
+The **order effect** is the noise floor of the comparison. Both arms run in both
+orders within every round, and the difference attributable to position is
+reported beside the difference attributable to the arm. The project has already
+paid for this lesson once: on the characterized path, position in the test
+sequence was worth 158ms where the policy under test was worth 2.4ms, and
+running the baseline first produced a 53% win that reversed when the order was
+reversed. Where the order effect equals or exceeds the arm effect, the check
+declines to draw a conclusion and says so, which is the correct response to a
+comparison that has not resolved the thing it was measuring.
+
+Name **resolution differs between the arms by design**. The direct arm resolves
+the destination locally; the tunnelled arm resolves it at the gateway. An
+anycast name resolves to whatever is near whoever asked, so the same name looked
+up in two places can name two machines on two continents. Resolving once and
+dialling both arms at a single address would conceal precisely the case the
+check exists to find.
+
+What the check does not do is characterize the path. It samples connection
+establishment, which is the part of the problem placement determines and the
+part a local instrument can hold still. Throughput, loss, and completion time
+under load are not establishment, and they belong to the instruments below.
+
+### What only the path can settle
+
+`pathprobe` sends open-loop at a rate nothing is permitted to adjust and counts
+what arrives, which describes the path rather than a stack's response to it. Two
+figures decide whether this transport applies at all.
+
+- **Loss that does not vary with offered rate.** Sweep the rate and watch the
+  delivered fraction. A flat loss percentage as the rate climbs is erasure,
+  which this transport repairs. Loss that appears only near a knee is
+  congestion, to which backing off is the correct response and this transport is
+  not.
+- **A knee well above the traffic to be offered.** Where offered traffic
+  approaches the path's capacity, the bottleneck is the path itself, and the
+  access-link profile's aggregate coordination is what the deployment wants.
+
+Measure both directions. They are frequently unalike: the characterized path
+dropped nothing in one direction and about fourteen percent in the other,
+minutes apart. Re-measure whenever anything is compared, because that path's
+loss moved between roughly zero and seventeen percent within minutes and the
+transport's advantage scales with how much of it there is.
+
+[Reproducing the datacenter measurements](MEASURING-A-DC-PATH.md) gives the
+commands and the analysis in full.
+
+### What only the workload can settle
+
+`pathmeasure -mode workload` measures the request the deployment actually makes,
+against the endpoint it actually calls, splitting each call into connect,
+request-to-first-byte, and download. The split matters: a call that spends
+seconds inside a model shows a small end-to-end ratio while the bytes move
+several times faster, and a headline ratio conceals which of the two happened.
+
+```sh
+pathmeasure -mode workload -rounds 20 \
+  -url https://inference.example.net/v1/audio/transcriptions \
+  -a direct -b socks5=127.0.0.1:12080 \
+  -post-file sample.wav -form-field file
+```
+
+Run the direct arm tuned. A comparison against an untuned client measures the
+configuration line described below, not the transport.
+
+## The client-side fixes that come first
+
+On a path direction that does not erase, a fully tuned direct client reaches the
+same median as this transport. Re-measured on the characterized path with one
+fixed 355KB file, a warm and tuned direct client completed a real inference
+upload at 240.9ms against 236.5ms through the tunnel, and both figures sit
+within ten milliseconds of the floor that a 197ms round trip and a 30ms model
+impose. Where that is the situation, the tunnel is an expensive way to obtain a
+result a configuration change has already obtained.
+
+Three fixes account for most of it, and the third requires care.
+
+**Reuse connections.** A new connection pays a handshake and then climbs out of
+a ten-segment initial window. On the characterized path this was the difference
+between 1185.3ms and 240.9ms on the same upload.
+
+**Set the receiving side's HTTP/2 windows.** A default receive window can bound
+a transfer well below what the path carries, and no transport beneath it can
+lift that bound.
+
+**Consider `net.ipv4.tcp_slow_start_after_idle=0`, and only for the direction
+the traffic sends into.** Linux defaults this to 1, which discards the
+congestion window after any idle gap longer than a retransmission timeout, so a
+connection held open across a pause is open without being warm. On a clean
+direction the effect is large and favorable: a 300KB burst on an idle connection
+went from 941ms to 209ms, and a real speech upload from 790ms to 241ms.
+
+On a direction that erases, the same setting is harmful, and the project
+discovered this by accident rather than by reasoning. Measured minutes apart on
+a synthesis download over a direction erasing about fourteen percent, a 100KB
+response took 827.7ms on a new connection and 2281.2ms on a warm one with the
+sysctl set; a second session put the same pair at 945.2ms and 6341.1ms. Mathis
+accounts for the direction of the effect. At fourteen percent erasure and a
+200ms round trip the predicted steady-state rate is 0.155 Mbit/s, and a cold
+flow beats its own steady state only because slow start is still ramping when
+the transfer ends. Restoring the window between requests starts the flow where
+cubic's sawtooth actually lives, with more in flight for a multiplicative
+decrease to remove.
+
+Set it where the traffic uploads into a clean direction, which is the common
+case for inference requests. Do not assume it helps the responses coming back.
+
+## When a gateway is nevertheless warranted
+
+The fixes above are free, and they are bounded. Four situations lie outside what
+they reach, and each is a reason to deploy.
+
+**A direction that erases.** Independent loss is not congestion, and no
+client-side setting repairs it, because the setting governs what happens after
+an idle gap while erasure happens during the transfer. On the characterized
+path's erasing direction, the download leg ran at 827.7ms direct against 53.4ms
+through the transport in one session, and the same comparison gave 13.9x in the
+session before. This is the case the transport exists for.
+
+**Connections that are genuinely cold.** Queqiao holds a warm pooled tunnel, so
+an application's connection terminates on loopback and the round trip has
+already been paid. Measured through a capture agent with an unmodified
+application, the connect leg fell from 187.3ms to 0.2ms and a 300KB cold request
+from 1089.3ms to 624.9ms. Anything that dials per request, has been idle past a
+retransmission timeout, or sits behind a load balancer that does not pool falls
+in this case.
+
+**A caller that cannot be reconfigured.** Connection reuse and the sysctl are
+both client-side changes. Where the client is a vendor's SDK, a customer's code,
+or a binary without source, neither is available, and the transport is the only
+remaining place to intervene.
+
+**A figure quoted at the tail rather than at the median.** The two arms converge
+at the median on a clean direction and diverge sharply when the path misbehaves.
+In a minute during which the path was dropping about twenty percent of pings,
+the same comparison put a direct client at 916.7ms at p99 against 246.4ms
+through the transport. A congestion window restored after an idle gap does
+nothing about a packet that was dropped.
+
+## Reasons unrelated to latency
+
+Three further reasons are legitimate, and each is decided without reference to
+any of the measurements above.
+
+A gateway provides a **fixed egress address**, which is what an allowlist on the
+destination requires and what a client on a residential or mobile network cannot
+otherwise supply. It fixes the **jurisdiction traffic egresses from**, which may
+be a compliance requirement rather than a performance one. And where a
+destination is not reachable from the client's network at all, the tunnel is not
+an optimization but the only path, in which case a latency comparison against an
+arm that never completes is not the relevant question. `queqiaod doctor` reports
+that case as such rather than as a placement result.
+
+## Selecting a path profile
+
+The profile is chosen from where the bottleneck is, not from where the machines
+are, and it must match on both ends: the two ends classify flows independently,
+so setting it on one side leaves the other demoting flows the first decided to
+protect.
+
+| Situation | Profile |
+| --- | --- |
+| The degraded segment is the client's own access network | `wan-shared-bottleneck`, the default and the supported one |
+| A long hop between two regions one operator runs, carrying request-shaped inference traffic | `dc-long-haul`, experimental |
+
+`dc-long-haul` is qualified on exactly one path. Everything known about it comes
+from a Guiyang-to-Irvine link, so its constants are that link's constants until
+a second path either confirms them or does not. Read
+[the datacenter profile](DEPLOYING-DC-PROFILE.md) and its
+[design rationale](DESIGN-DC-PROFILE.md) before deploying it.
+
+## A worked deployment
+
+Once the destination has been measured and a gateway is warranted, the
+installation itself is two commands. On the gateway host, as root:
+
+```sh
+sudo ./deploy/install-server.sh \
+  --binary ./queqiaod \
+  --name "US West" \
+  --endpoint gateway.example.net:443 \
+  --user singapore-edge \
+  --tune
+```
+
+The script prints one single-use invitation URI. It is a bearer credential and
+should be delivered over an authenticated private channel. On the client, as the
+account that will use the tunnel and not with `sudo`:
+
+```sh
+./deploy/install-client.sh --binary ./queqiaod --invite 'queqiao://enroll/...'
+```
+
+Applications then reach the tunnel at `127.0.0.1:12080` over SOCKS5, including
+UDP ASSOCIATE. Verify the placement decision against the running deployment
+before relying on it:
+
+```sh
+queqiaod doctor --profile ~/.config/queqiao/*.json \
+  --destination api.example.com:443 --rounds 8
+```
+
+The [deployment guide](DEPLOYING.md) is the reference for everything past this
+point, including hosts the scripts do not cover, multiple providers, service
+installation, upgrades, and rollback.
+
+## The limits of this guidance
+
+The placement rule and the anycast argument are topological, and they hold
+wherever their premises do. The numbers quoted throughout are not. They were
+measured on one China-to-United-States path and are design evidence rather than
+a prediction for another route, carrier, or hour. The
+[project status](STATUS.md) records which qualification work remains open, and
+the [known limitations](KNOWN-LIMITATIONS.md) record the operational boundaries
+of the current release.
+
+Two of those limitations bear directly on the decision described here. The
+controller has no brake on a policed path, which drops what it cannot pass and
+holds nothing, producing loss without the delay this design uses as its
+congestion signal; where the segment in question is policed, the transport will
+overdrive it. And the thresholds `queqiaod doctor` applies to a placement
+verdict are round numbers chosen to sit either side of a topological
+distinction, not constants derived from a measurement campaign. They are
+intended to prompt an investigation, not to conclude one.

--- a/docs/DEPLOYING-DC-PROFILE.md
+++ b/docs/DEPLOYING-DC-PROFILE.md
@@ -32,9 +32,20 @@ queqiaod doctor --path-profile dc-long-haul --profile ~/.config/queqiao/*.json
 ```
 
 It reports the profile's qualification level and precondition, the kernel
-settings the measurements assumed, and whether the gateway answers. It does not
-tell you what the path does, because no local check can: that is what
-`pathprobe` is for, and the two figures below are the ones to get from it.
+settings the measurements assumed, the round trip to the gateway, and, for each
+destination you name, whether routing that destination through this gateway
+makes the path shorter or longer:
+
+```sh
+queqiaod doctor --path-profile dc-long-haul --profile ~/.config/queqiao/*.json \
+  --destination inference.internal:443
+```
+
+It still does not tell you what the path does, because no local check can: that
+is what `pathprobe` is for, and the two figures below are the ones to get from
+it. [Choosing and placing a gateway](CHOOSING-A-GATEWAY.md) covers the
+placement question in full, including the case where the destination is served
+from an edge near the caller and no gateway helps.
 
 Then do the free things, because they cost a config line and two of the three
 are worth more than anything below: reuse connections, and set the receiver's

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -23,6 +23,13 @@ For a quick overview, start with the [repository README](../README.md). Use
 [known limitations](KNOWN-LIMITATIONS.md) to check whether the paired-gateway
 assumption fits your network before exposing a service.
 
+This guide assumes the placement decision has already been made. If it has not
+-- if the gateway host is not chosen yet, or the destinations are operated by
+someone else -- read [choosing and placing a
+gateway](CHOOSING-A-GATEWAY.md) first. A gateway on the wrong side of the
+traffic's real bottleneck lengthens the path while everything below still
+verifies correctly.
+
 ## Install with the scripts
 
 Two scripts perform everything below and verify the result. Read this section

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,8 @@ you choose the next document based on what you want to do.
 | If you want to… | Read |
 | --- | --- |
 | Understand the problem and the design principles | [Vision and principles](VISION.md) |
-| Decide whether Queqiao fits your network | [Project status](STATUS.md) and [known limitations](KNOWN-LIMITATIONS.md) |
+| Decide whether it fits, and where the gateway has to go | [Choosing and placing a gateway](CHOOSING-A-GATEWAY.md) |
+| Check what has been qualified and what has not | [Project status](STATUS.md) and [known limitations](KNOWN-LIMITATIONS.md) |
 | Use a provider and client | [Deployment guide](DEPLOYING.md) |
 | Understand the transport in depth | [Current design](DESIGN.md), then [architecture](ARCHITECTURE.md) |
 | Measure a path or compare a baseline | [Benchmarking](BENCHMARKING.md) |
@@ -19,6 +20,11 @@ you choose the next document based on what you want to do.
 
 ## Use and operate Queqiao
 
+- [Choosing and placing a gateway](CHOOSING-A-GATEWAY.md) — the decision that
+  precedes deployment: why both ends must run this software, where a gateway
+  has to sit to help, why a destination served from an anycast edge can be made
+  slower by one, the client-side fixes to try first, and how to measure all of
+  it before spending anything.
 - [Deployment guide](DEPLOYING.md) — provider setup, invitations, desktop
   enrollment, multi-provider clients, Clash/mihomo, service installation,
   monitoring, upgrades, and rollback.


### PR DESCRIPTION
Queqiao improves the client-to-gateway segment and nothing past it. A reader
whose destination is operated by someone else has to obtain a gateway host and
decide where to put it, and the repository answered neither question in one
place. This adds the check that settles it and the document that explains it.

## The problem

A gateway sited on the wrong side of the traffic's real bottleneck lengthens
the path *while every local check still passes*: the profile is valid, the
sysctls are set, the gateway answers, and the tunnel correctly carries traffic
to a place the traffic did not need to go.

The ordinary way this happens is a destination published behind an anycast
edge. The session terminates at a point of presence near the caller, the long
haul runs inside the provider's own backbone where neither end of this
transport can reach it, and routing through a distant gateway adds the whole
gateway leg for nothing. A client already a few milliseconds from an edge has
no erasure on that hop to earn the detour back.

## `queqiaod doctor --destination host:port`

Establishes connections to a destination directly and through the local SOCKS
listener, and reports both distributions beside the verdict.

- **Sampled gateway round trip**, not one dial. Subtracting it from a tunnelled
  establishment leaves the gateway's own hop onward, which separates a
  placement decision the operator can revisit from transit that relocating the
  client will not change. The remainder is labelled a derivation.
- **Arms alternate every round**, and the order effect is reported beside the
  arm effect. Where drift is the larger of the two, the check reports that the
  comparison resolved nothing rather than offering a conclusion — the
  discipline `pathmeasure -mode ab` already follows, and for the same reason:
  on the characterised path, position in the sequence was worth 158ms where the
  policy under test was worth 2.4ms.
- **The arms resolve the name in different places**, locally and at the
  gateway, because an anycast name resolves to whatever is near whoever asked.
  Resolving once would hide exactly the case being looked for.
- **The certificate is verified**, which is the cheapest available evidence
  that two independently resolved arms reached the same service.

It still says nothing about what the path does. It samples connection
establishment, which is what placement determines and what a local instrument
can hold still; `pathprobe` and `pathmeasure` remain the instruments for loss,
throughput, and completion time.

## `docs/CHOOSING-A-GATEWAY.md`

The reasoning existed, spread across an architecture paragraph, a
known-limitations bullet, and the "before you turn anything on" section of an
experimental profile's runbook — the last place a reader with this question
would look. The index sent "decide whether Queqiao fits your network" to a
qualification boundary and a list of caveats, neither of which is a fit test.

The guide states the paired requirement, the placement rule, the anycast case
worked through end to end, the three instruments and which question each
answers, when a gateway is warranted anyway, and the reasons unrelated to
latency. It promotes the free client-side fixes out of the datacenter
appendix — they apply to every reader, reach the same median on a clean
direction (240.9ms against 236.5ms), and only one audience could find them.

It deliberately does not name which vendors front their APIs this way. Edge
footprints and routing change, and a claim about a particular API on a
particular day is not one a document can hold.

## Also

The `doctor.go` header comment cited 225.8ms against 295.0ms, from the medians
that were mislabelled across eight audio files. Replaced with the re-measured
240.9 and 236.5, which reverses the sign of the difference the comment draws
its conclusion from.

## Checks

`go test -short ./...`, `go vet ./...`, `gofmt -l .`, the Python script suite,
`./scripts/changelog.py check`, and `staticcheck -checks=all,-U1000 ./...` all
pass. New tests cover the verdict branches, the order-dominates refusal, the
derivation floor, and the probe end to end against this project's own SOCKS5
request parser.

## Worth a second opinion

The placement thresholds (1.2x and 2.0x, with a 5ms floor) are round numbers
chosen to straddle a topological distinction, not constants from a measurement
campaign. That is stated in the code and in the document's limitations section.
If the check should only ever report figures and never a verdict, that is a
small change to `checkPlacement`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfVwMrGj4ZrpfFvV7Xxmnu