### PR TITLE
refactor(ios): make routing one setting, changeable while connected

### DIFF
--- a/changelog.d/ios-routing-rules.changed.md
+++ b/changelog.d/ios-routing-rules.changed.md
@@ -1,0 +1,17 @@
+iOS routing is one setting again, and all of it can be changed while the
+tunnel is connected. The traffic policy, the bundled China toggle, the typed
+bypass list, and the rule list were four controls answering one question, and
+the first three did not agree about who was in charge: the bypass list and the
+country set applied whatever the policy said, so a profile reading "All
+traffic" could be keeping whole countries off the tunnel. There is now a
+routing mode, the bypass rules underneath it, and the rule list, all carried
+in one value the settings screen and the tunnel both compose through.
+Switching to global routing leaves the rules stored rather than making someone
+dismantle a list to turn the tunnel up. None of it needs a reconnect: the app
+saves the change and asks the running provider to re-read it, and the provider
+reinstalls the routes and hands the new rule list to the core without
+restarting the packet engine. Flows already open keep the rules they started
+under, which is the cost of not dropping the connection to edit them. A
+catalog written before the merge migrates on load, and anything that was
+carving traffic out of the tunnel comes back as a bypass rule rather than
+quietly rejoining it.

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -176,20 +176,23 @@ the shared packet stack end to end on real hardware, and is never published.
 iOS cannot compose, so the tunnel carries routing policy itself. What it
 carries is deliberately a subset rather than a rule engine.
 
-Each profile has one of two base policies:
+Each profile has one routing mode:
 
-- **All traffic** routes IPv4, IPv6, and DNS through Queqiao.
-- **Exclude local networks** keeps IPv4 private, shared-address, loopback, and
+- **Route all traffic** sends IPv4, IPv6, and DNS through Queqiao. The bypass
+  rules below stay stored but are not applied.
+- **Use bypass rules** sends everything through Queqiao except the destinations
+  an enabled rule matches.
+
+The bypass rules are:
+
+- **Local networks** keeps IPv4 private, shared-address, loopback, and
   link-local destinations plus IPv6 unique-local, loopback, and link-local
   destinations outside the tunnel. Internet and DNS traffic still use
   Queqiao. iOS expresses these as excluded Network Extension routes. The
   Android debug tunnel constructs the exact complement as included CIDR routes
   so behavior is the same on every supported API level, including releases
   before Android added `VpnService.Builder.excludeRoute`.
-
-On top of the base policy, a profile may carry:
-
-- **Typed bypass routes** — up to 256 hand-entered CIDR blocks kept off the
+- **Custom routes** — up to 256 hand-entered CIDR blocks kept off the
   tunnel. An entry that is not a CIDR block is refused as it is saved rather
   than dropped quietly, because a discarded route would leave the user
   believing a destination is off the tunnel when it is not.
@@ -204,6 +207,29 @@ On top of the base policy, a profile may carry:
   gateway's vantage point returns addresses that need not be in the set and
   will still route through Queqiao. The UI states this rather than implying
   domain-level routing.
+The mode and the rules were three settings that did not know about each other:
+a two-value traffic policy, a bundled-set toggle, and a route list, where the
+latter two applied whatever the policy said. A profile reading "All traffic"
+could therefore be keeping whole countries off the tunnel. A catalog written
+before the merge migrates on load, and anything that was carving traffic out of
+the tunnel loads as **Use bypass rules** — an upgrade never pushes an excluded
+destination back through the tunnel. The catalog still carries the old
+`trafficPolicy` field, derived from the rules on every save, so that
+downgrading to an earlier build does not fail to decode and take every enrolled
+profile with it.
+
+Routing is editable while the tunnel is connected, which is the state in which
+it most often needs changing. The app writes the change to the Keychain catalog
+and asks the running provider to re-read it over the NetworkExtension
+app-message channel; the provider rebuilds the plan and replaces the interface
+description with `setTunnelNetworkSettings`. The packet engine and its uplink
+are left running, so a routing edit does not renegotiate the tunnel. iOS still
+re-plumbs the interface's routes, so a connection can be disturbed by the
+change — much less than the disconnect this replaces, but not nothing. When the push fails the change is still saved, and the UI
+says the running tunnel is still on the previous rules rather than letting the
+screen and the tunnel silently disagree. Which profile a tunnel uses still
+requires disconnecting; that replaces the device identity, not a route.
+
 - **Automatic connection rules**, off by default. A profile may bring the
   tunnel up on Wi-Fi, on cellular, or both, and keep it down on Wi-Fi networks
   the user names. Names are typed, never scanned — scanning would require

--- a/mobile/ios/PacketTunnel/PacketTunnelLifecycle.swift
+++ b/mobile/ios/PacketTunnel/PacketTunnelLifecycle.swift
@@ -26,6 +26,11 @@ final class PacketTunnelLifecycle: @unchecked Sendable {
     private var session: MobilecoreSession?
     private var bridge: PacketFlowBridge?
     private var profileID: String?
+    /// Kept so a routing change applied while connected can rebuild the
+    /// interface settings without resolving the provider endpoint again. A
+    /// second resolution could return a different address, which would move the
+    /// tunnel to another gateway as a side effect of editing a bypass rule.
+    private var remoteAddress: String?
     private var startCompletion: OneShotErrorCompletion?
 
     func beginStartup(completion: OneShotErrorCompletion) -> StartupAttempt {
@@ -45,6 +50,14 @@ final class PacketTunnelLifecycle: @unchecked Sendable {
         defer { lock.unlock() }
         guard !stopping, startup.generation == generation else { return false }
         profileID = id
+        return true
+    }
+
+    func recordRemoteAddress(_ address: String, for startup: StartupAttempt) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !stopping, startup.generation == generation else { return false }
+        remoteAddress = address
         return true
     }
 
@@ -72,6 +85,7 @@ final class PacketTunnelLifecycle: @unchecked Sendable {
         if startup.generation == generation {
             generation &+= 1
             profileID = nil
+            remoteAddress = nil
             startCompletion = nil
         }
         lock.unlock()
@@ -98,6 +112,7 @@ final class PacketTunnelLifecycle: @unchecked Sendable {
         session = nil
         bridge = nil
         profileID = nil
+        remoteAddress = nil
         startCompletion = nil
         return resources
     }
@@ -112,6 +127,15 @@ final class PacketTunnelLifecycle: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return profileID
+    }
+
+    /// The profile and endpoint a live routing change has to rebuild against,
+    /// read together so the pair cannot be torn by a concurrent stop.
+    var activeRouting: (profileID: String, remoteAddress: String)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !stopping, let profileID, let remoteAddress else { return nil }
+        return (profileID, remoteAddress)
     }
 
     var isStopping: Bool {

--- a/mobile/ios/PacketTunnel/PacketTunnelProvider.swift
+++ b/mobile/ios/PacketTunnel/PacketTunnelProvider.swift
@@ -28,24 +28,21 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
                 throw TunnelError.missingProfile
             }
             try MobileCore.validateProfile(profile)
-            let requestedPolicy = configuration.providerConfiguration?["trafficPolicy"] as? String
-            let policy = TrafficPolicy(rawValue: requestedPolicy ?? "") ?? record.trafficPolicy
             guard lifecycle.selectProfile(profileID, for: startup) else {
                 throw TunnelError.startCancelled
             }
+            // The stored record is the only routing source. It used to be read
+            // from the saved provider configuration first, which meant a change
+            // saved while connected was invisible until the configuration was
+            // rewritten — and the two could disagree in the meantime.
             recordDiagnostic(
                 level: .info,
-                "Starting profile \(record.displayName) with \(policy.title.lowercased())"
+                "Starting profile \(record.displayName) with \(record.routingMode.title.lowercased())"
             )
             resolveAndConfigureTunnel(
                 endpoint: record.summary.endpoint,
                 profile: profile,
-                routing: TunnelRouting(
-                    policy: policy,
-                    bypassRoutes: record.bypassRoutes,
-                    chinaDirect: record.bypassChinaDirect,
-                    rules: record.routingRules
-                ),
+                routing: record.routing,
                 startup: startup,
                 completion: completion
             )
@@ -89,8 +86,18 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
     }
 
     override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)? = nil) {
-        let metrics = lifecycle.currentSession?.metricsJSON() ?? "{\"version\":2,\"state\":\"stopped\"}"
-        completionHandler?(metrics.data(using: .utf8))
+        guard let request = ProviderRequest(payload: messageData) else {
+            completionHandler?(nil)
+            return
+        }
+        switch request {
+        case .metrics:
+            let metrics = lifecycle.currentSession?.metricsJSON()
+                ?? "{\"version\":2,\"state\":\"stopped\"}"
+            completionHandler?(metrics.data(using: .utf8))
+        case .reloadRouting:
+            reloadRouting(completionHandler: completionHandler)
+        }
     }
 
     func onStateChanged(_ state: String?) {
@@ -132,7 +139,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
 
     private func configureTunnel(
         profile: String,
-        routing: TunnelRouting,
+        routing: RoutingConfiguration,
         remoteAddress: String,
         startup: StartupAttempt,
         completion: OneShotErrorCompletion
@@ -185,7 +192,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
     private func resolveAndConfigureTunnel(
         endpoint: String,
         profile: String,
-        routing: TunnelRouting,
+        routing: RoutingConfiguration,
         startup: StartupAttempt,
         completion: OneShotErrorCompletion
     ) {
@@ -197,6 +204,10 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
                 }
                 let remoteAddress = try ProviderEndpoint.resolvedAddress(from: endpoint)
                 recordDiagnostic(level: .info, "Provider endpoint resolved to \(remoteAddress)")
+                guard lifecycle.recordRemoteAddress(remoteAddress, for: startup) else {
+                    completion.call(TunnelError.startCancelled)
+                    return
+                }
                 configureTunnel(
                     profile: profile,
                     routing: routing,
@@ -214,7 +225,7 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
 
     private func startPacketEngine(
         profile: String,
-        routing: TunnelRouting,
+        routing: RoutingConfiguration,
         startup: StartupAttempt,
         completion: OneShotErrorCompletion
     ) {
@@ -276,20 +287,67 @@ final class PacketTunnelProvider: NEPacketTunnelProvider, MobilecoreObserverProt
 }
 
 private extension PacketTunnelProvider {
+    /// Installs the profile's current routing rules on the running interface.
+    ///
+    /// iOS allows the interface description to be replaced while the tunnel is
+    /// up, which is what makes a bypass rule editable without disconnecting.
+    /// The packet engine and its uplink are deliberately left running, so the
+    /// tunnel is not renegotiated for a routing edit. iOS still re-plumbs the
+    /// interface's routes, so a connection can be disturbed by the change —
+    /// that is a far smaller interruption than the disconnect this replaces,
+    /// but it is not nothing.
+    func reloadRouting(completionHandler: ((Data?) -> Void)?) {
+        guard let active = lifecycle.activeRouting else {
+            completionHandler?(RoutingReloadResult.failed("The tunnel is not running.").payload)
+            return
+        }
+        engineQueue.async { [self] in
+            do {
+                guard let (record, _) = try ProfileStore().profile(id: active.profileID) else {
+                    throw TunnelError.missingProfile
+                }
+                let plan = routePlan(for: record.routing)
+                let settings = TunnelNetworkSettings.make(
+                    plan: plan,
+                    remoteAddress: active.remoteAddress
+                )
+                setTunnelNetworkSettings(settings) { [self] error in
+                    if let error {
+                        let detail = error.localizedDescription
+                        recordDiagnostic(level: .error, "Could not apply new routing: \(detail)")
+                        completionHandler?(RoutingReloadResult.failed(detail).payload)
+                        return
+                    }
+                        if let session = lifecycle.currentSession {
+                        installRouting(on: session, routing: record.routing)
+                    }
+                    recordDiagnostic(
+                        level: .info,
+                        "Routing changed while connected: \(plan.diagnosticSummary)"
+                    )
+                    completionHandler?(
+                        RoutingReloadResult.succeeded(excludedRouteCount: plan.excluded.count).payload
+                    )
+                }
+            } catch {
+                let detail = error.localizedDescription
+                recordDiagnostic(level: .error, "Could not read new routing rules: \(detail)")
+                completionHandler?(RoutingReloadResult.failed(detail).payload)
+            }
+        }
+    }
+
     /// The set of destinations that stay off the tunnel for this profile.
     ///
-    /// Everything about how those prefixes are parsed, deduplicated, coalesced
-    /// and capped lives in RoutePlan so it can be tested without a
-    /// NetworkExtension host.
-    func routePlan(for routing: TunnelRouting) -> RoutePlan {
-        var userRoutes = routing.bypassRoutes
-        if routing.policy == .excludeLocalNetworks {
-            userRoutes = RoutePlan.localNetworks + userRoutes
-        }
-        var builtIn: [IPPrefix] = []
-        if routing.chinaDirect {
+    /// How the mode and the rules combine lives in RoutePlan, so the settings
+    /// screen previews exactly what this installs rather than reimplementing
+    /// it. What stays here is the part the screen cannot do: reading the
+    /// bundled set off disk, and saying so when it cannot be read.
+    func routePlan(for routing: RoutingConfiguration) -> RoutePlan {
+        var chinaDirect: [IPPrefix] = []
+        if routing.bypassChinaDirect {
             do {
-                builtIn = try CountryRoutes.chinaDirect()
+                chinaDirect = try CountryRoutes.chinaDirect()
             } catch {
                 // A missing or unreadable set is worth saying out loud, but it
                 // is not worth refusing to connect over: the tunnel still
@@ -300,39 +358,7 @@ private extension PacketTunnelProvider {
                 )
             }
         }
-        return RoutePlan.make(userRoutes: userRoutes, builtIn: builtIn)
-    }
-}
-
-/// Where this profile's traffic goes, read once from the stored record at
-/// startup and carried through resolution into the settings build.
-private struct TunnelRouting {
-    let policy: TrafficPolicy
-    let bypassRoutes: [String]
-    let chinaDirect: Bool
-    /// The rule list as stored, empty when the profile carries none. An empty
-    /// list is the state every existing installation is in, and it means the
-    /// tunnel carries everything exactly as it did before rules existed.
-    let rules: String
-}
-
-private enum TunnelError: LocalizedError {
-    case missingProfile
-    case missingProfileSelection
-    case coreStopped
-    case startCancelled
-
-    var errorDescription: String? {
-        switch self {
-        case .missingProfile:
-            return "No enrolled Queqiao device identity is available."
-        case .missingProfileSelection:
-            return "The VPN configuration does not identify a Queqiao profile. Open the app and connect again."
-        case .coreStopped:
-            return "The Queqiao packet engine stopped unexpectedly."
-        case .startCancelled:
-            return "Tunnel startup was cancelled."
-        }
+        return RoutePlan.make(for: routing, chinaDirect: chinaDirect)
     }
 }
 
@@ -341,7 +367,7 @@ private enum TunnelError: LocalizedError {
 /// configuration allows. Keeping it here also keeps the two failure paths --
 /// a country set that will not load, a rule list with bad lines -- beside each
 /// other, since both are reported and neither stops the tunnel.
-extension PacketTunnelProvider {
+private extension PacketTunnelProvider {
     /// Hands the core the rule list and the country set behind any GEOIP rule,
     /// before anything is carried.
     ///
@@ -350,7 +376,7 @@ extension PacketTunnelProvider {
     /// load leaves GEOIP rules deciding nothing. Neither stops the tunnel: a
     /// user whose rule file has a typo wants their connection, and a diagnostic
     /// they can find, rather than a refusal to start.
-    private func installRouting(on session: MobilecoreSession, routing: TunnelRouting) {
+    private func installRouting(on session: MobilecoreSession, routing: RoutingConfiguration) {
         if let data = CountryRoutes.packedChinaSet() {
             do {
                 try session.setCountrySet("CN", blob: data)

--- a/mobile/ios/PacketTunnel/TunnelError.swift
+++ b/mobile/ios/PacketTunnel/TunnelError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// The failures the packet tunnel reports to iOS and to the diagnostic ring.
+///
+/// Split out of PacketTunnelProvider so that file stays about the provider's
+/// lifecycle rather than about its vocabulary of errors.
+enum TunnelError: LocalizedError {
+    case missingProfile
+    case missingProfileSelection
+    case coreStopped
+    case startCancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .missingProfile:
+            return "No enrolled Queqiao device identity is available."
+        case .missingProfileSelection:
+            return "The VPN configuration does not identify a Queqiao profile. Open the app and connect again."
+        case .coreStopped:
+            return "The Queqiao packet engine stopped unexpectedly."
+        case .startCancelled:
+            return "Tunnel startup was cancelled."
+        }
+    }
+}

--- a/mobile/ios/Queqiao.xcodeproj/project.pbxproj
+++ b/mobile/ios/Queqiao.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		023D7297DD3F3AFABD7CE460 /* Mobilecore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219A9C59F3F189F39004E980 /* Mobilecore.xcframework */; };
 		03A75D5DEFBADD6966EA698C /* VPNDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1A32A7D2EA758E64DF5615 /* VPNDiagnostics.swift */; };
 		06191DEC5E7AE0B89897BB64 /* VPNDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1A32A7D2EA758E64DF5615 /* VPNDiagnostics.swift */; };
+		077365773929DC839BBEDF46 /* ProviderMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B376BE6ED126E4D1515CFEEA /* ProviderMessage.swift */; };
 		07F155EAF1B380CBE528972D /* MobileCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23BCEED68000E8B4E9606949 /* MobileCore.swift */; };
 		171DA48D7D57A037D5DE6A5C /* TunnelModel+Probing.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE67DE2C949D4B7DC369AA5 /* TunnelModel+Probing.swift */; };
 		178B2606193C371113D64EE4 /* TunnelNetworkSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669F84268D925AD1EE813150 /* TunnelNetworkSettings.swift */; };
@@ -20,6 +21,7 @@
 		25A3E872695919417DAE9CCE /* IPPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F70D796385BB2592A8B6306 /* IPPrefix.swift */; };
 		26D4ED0B36D14998D5C4A9C5 /* CountryRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF108D4615B78EC678BCB68 /* CountryRoutes.swift */; };
 		27247D17AC0E9890E79CF88A /* Mobilecore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219A9C59F3F189F39004E980 /* Mobilecore.xcframework */; };
+		3727BC1350FE32A55B91D5C3 /* RoutingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFF87BF9DBE60A53F395EA3 /* RoutingConfiguration.swift */; };
 		375FB5454F776236A3760973 /* DiagnosticStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7CBC899821EF6BE68E27AA /* DiagnosticStore.swift */; };
 		39B82F8BA95382602E0538A5 /* LicenseNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430D58D7442C39B4BD9C12FB /* LicenseNoticeView.swift */; };
 		3B4784A56CC451CBDF38DD7B /* PacketTunnelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42AFB9F720602C013212C4BF /* PacketTunnelLifecycle.swift */; };
@@ -38,16 +40,20 @@
 		58DDBA0C9CF99E381A085DEE /* OnDemandRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C12105883E9478AF0259116 /* OnDemandRules.swift */; };
 		5E0CBFE215332DDE2B40736C /* ProfileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED8D203B061F8250C3A766D1 /* ProfileStore.swift */; };
 		64BA13C478741DD024C181E1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0722AD3C50275E1BCDD5351 /* ContentView.swift */; };
+		654C24623CD508E1ECC8E74B /* RoutingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFF87BF9DBE60A53F395EA3 /* RoutingConfiguration.swift */; };
 		662EDB004A700825C87CE9DB /* CountryRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF108D4615B78EC678BCB68 /* CountryRoutes.swift */; };
 		66A3F7A88D0512ABDD4ADFD5 /* RoutePlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6440EF4592CF0B6675EBF7 /* RoutePlan.swift */; };
 		68057191EDB257366A49D5C9 /* TunnelNetworkSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30DF918B060C4D661A7E9E05 /* TunnelNetworkSettingsTests.swift */; };
+		68BD4A787EAA3DE0ABA63273 /* RoutingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFF87BF9DBE60A53F395EA3 /* RoutingConfiguration.swift */; };
 		692E560862F4F48C92492BAA /* THIRD_PARTY_NOTICES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4FD6CEDE24F430E9529E3A3A /* THIRD_PARTY_NOTICES.txt */; };
 		69886EFD437493E3F1497C7F /* cn-direct.bin in Resources */ = {isa = PBXBuildFile; fileRef = B699E2250E6B3CC6C82DED5F /* cn-direct.bin */; };
 		69FFFBD3ED98658422EF2DBD /* MobileCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23BCEED68000E8B4E9606949 /* MobileCore.swift */; };
 		6FC28FF081A00A071AAEF432 /* ProfileCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD1C9B5069B4FCAB19D623D /* ProfileCatalog.swift */; };
+		718A536B32016E20CEC2A8D2 /* TunnelError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5177CA98C76F396FD1E06866 /* TunnelError.swift */; };
 		720FF27CD51D92E9E7E88FE2 /* Mobilecore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 219A9C59F3F189F39004E980 /* Mobilecore.xcframework */; };
 		7433259AF712300E0F94A1EC /* ProfileCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD1C9B5069B4FCAB19D623D /* ProfileCatalog.swift */; };
 		813996747DF7FE8D0D9A411C /* OnDemandRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C12105883E9478AF0259116 /* OnDemandRules.swift */; };
+		8526EBB216BC34B5ED73B121 /* RuleReviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22267033C9B0291E6381D9A /* RuleReviewTests.swift */; };
 		8DBBCFCF8A142E6312DB5D8D /* TunnelModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127965658AAA8DBADE524652 /* TunnelModel.swift */; };
 		90AFDF85395F094D08853A21 /* OneShotErrorCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6977BB55BDEB946A63AC7481 /* OneShotErrorCompletion.swift */; };
 		937A5486A266F1541EC3C445 /* ProfileOnDemandSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825E32D40A85D473CED722B /* ProfileOnDemandSection.swift */; };
@@ -63,9 +69,10 @@
 		AE0C9D533965F2EBEE29BBF2 /* DiagnosticExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1188477F059F8F42E5A2B2E1 /* DiagnosticExporter.swift */; };
 		B25FEDFD51756D3F16858CF1 /* VPNDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1A32A7D2EA758E64DF5615 /* VPNDiagnostics.swift */; };
 		B29C3BEEFE05BCF4AF1DFD82 /* ProfileRoutingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8325591D1B5330766175145 /* ProfileRoutingSection.swift */; };
-		B29C3BEEFE05BCF4AF1DFD83 /* ProfileRulesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8325591D1B5330766175146 /* ProfileRulesSection.swift */; };
 		B5E6AFBE8082FE6958A4F4C0 /* Mobilecore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 219A9C59F3F189F39004E980 /* Mobilecore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B61D6221C49C32C886381815 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C48647B91FBCC1F15F977C5 /* KeychainStore.swift */; };
+		BF34BE6B67C98853D593BEE5 /* ProfileRulesSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5BDA88949A86BDA1B0EF17 /* ProfileRulesSection.swift */; };
+		C1F06FAB6BE8883C4873D52C /* ProviderMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B376BE6ED126E4D1515CFEEA /* ProviderMessage.swift */; };
 		C5079853D38C771D73BA70EC /* cn-direct.bin in Resources */ = {isa = PBXBuildFile; fileRef = B699E2250E6B3CC6C82DED5F /* cn-direct.bin */; };
 		C62CC189B8350A3DE082BF48 /* ProviderEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85BC6F6EB97A4D90EB38EB5 /* ProviderEndpoint.swift */; };
 		CEF53BD49453638B9109EE4C /* ProviderEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85BC6F6EB97A4D90EB38EB5 /* ProviderEndpoint.swift */; };
@@ -75,13 +82,14 @@
 		DFBB0B47801FA97CBCF246AD /* PacketFlowBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EB9E99A5F2F55C5635AE87 /* PacketFlowBridge.swift */; };
 		E31ABE25B60F7C973A6F6490 /* ProfileCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD1C9B5069B4FCAB19D623D /* ProfileCatalog.swift */; };
 		E888617EF6B7013E98BDBEB2 /* IPPrefix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F70D796385BB2592A8B6306 /* IPPrefix.swift */; };
+		ED79A285B4D39067D82761F4 /* RoutingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7E8E7849FD09193CEF0A4F /* RoutingConfigurationTests.swift */; };
 		EFAAE976107F9765D9616D73 /* ProfilesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E70DE072DD84C6BF2E8288 /* ProfilesView.swift */; };
 		F32A620B9067799E2F23A320 /* TunnelSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4802E6E5533792D16DDFA25B /* TunnelSupport.swift */; };
+		F3370385A827B51761AFDA7B /* ProviderMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B376BE6ED126E4D1515CFEEA /* ProviderMessage.swift */; };
 		F3F66B8DFECF75A700A9C8AC /* RoutePlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6440EF4592CF0B6675EBF7 /* RoutePlan.swift */; };
 		F5EEBA8451B659266152FB2B /* ProviderEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85BC6F6EB97A4D90EB38EB5 /* ProviderEndpoint.swift */; };
 		F8514BB5053E0BFE434E1EFA /* TunnelModel+VPN.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996ABCB2304649D0527D7BA4 /* TunnelModel+VPN.swift */; };
 		FCA4D8B2A92C0267FBFCF77D /* CountryRoutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D902CF2632815D3C3F6B0E1 /* CountryRoutesTests.swift */; };
-		FCA4D8B2A92C0267FBFCF77E /* RuleReviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D902CF2632815D3C3F6B0E2 /* RuleReviewTests.swift */; };
 		FD333468E8B953F05D6E981E /* QueqiaoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EB3D7717BB422AD61D738D /* QueqiaoApp.swift */; };
 /* End PBXBuildFile section */
 
@@ -150,12 +158,13 @@
 		2C48647B91FBCC1F15F977C5 /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		30DF918B060C4D661A7E9E05 /* TunnelNetworkSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelNetworkSettingsTests.swift; sourceTree = "<group>"; };
 		3C12105883E9478AF0259116 /* OnDemandRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDemandRules.swift; sourceTree = "<group>"; };
+		3D5BDA88949A86BDA1B0EF17 /* ProfileRulesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRulesSection.swift; sourceTree = "<group>"; };
 		42AFB9F720602C013212C4BF /* PacketTunnelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelLifecycle.swift; sourceTree = "<group>"; };
 		430D58D7442C39B4BD9C12FB /* LicenseNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseNoticeView.swift; sourceTree = "<group>"; };
 		4802E6E5533792D16DDFA25B /* TunnelSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelSupport.swift; sourceTree = "<group>"; };
 		4D902CF2632815D3C3F6B0E1 /* CountryRoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryRoutesTests.swift; sourceTree = "<group>"; };
-		4D902CF2632815D3C3F6B0E2 /* RuleReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleReviewTests.swift; sourceTree = "<group>"; };
 		4FD6CEDE24F430E9529E3A3A /* THIRD_PARTY_NOTICES.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = THIRD_PARTY_NOTICES.txt; sourceTree = "<group>"; };
+		5177CA98C76F396FD1E06866 /* TunnelError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelError.swift; sourceTree = "<group>"; };
 		5DD1C9B5069B4FCAB19D623D /* ProfileCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCatalog.swift; sourceTree = "<group>"; };
 		64EB9E99A5F2F55C5635AE87 /* PacketFlowBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketFlowBridge.swift; sourceTree = "<group>"; };
 		669F84268D925AD1EE813150 /* TunnelNetworkSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TunnelNetworkSettings.swift; sourceTree = "<group>"; };
@@ -165,19 +174,22 @@
 		85EB3D7717BB422AD61D738D /* QueqiaoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueqiaoApp.swift; sourceTree = "<group>"; };
 		8D6440EF4592CF0B6675EBF7 /* RoutePlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePlan.swift; sourceTree = "<group>"; };
 		8D7CBC899821EF6BE68E27AA /* DiagnosticStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticStore.swift; sourceTree = "<group>"; };
+		8D7E8E7849FD09193CEF0A4F /* RoutingConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingConfigurationTests.swift; sourceTree = "<group>"; };
 		8F70D796385BB2592A8B6306 /* IPPrefix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPPrefix.swift; sourceTree = "<group>"; };
 		93EEE451E856BB5D399404F3 /* PacketTunnel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		996ABCB2304649D0527D7BA4 /* TunnelModel+VPN.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TunnelModel+VPN.swift"; sourceTree = "<group>"; };
 		9AD9D8FC50C293C44417209F /* OnDemandRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDemandRulesTests.swift; sourceTree = "<group>"; };
+		9AFF87BF9DBE60A53F395EA3 /* RoutingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingConfiguration.swift; sourceTree = "<group>"; };
 		A22BC502BF533F3ED9712923 /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		A73080843F759E47498727DB /* RoutePlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePlanTests.swift; sourceTree = "<group>"; };
 		ACE67DE2C949D4B7DC369AA5 /* TunnelModel+Probing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TunnelModel+Probing.swift"; sourceTree = "<group>"; };
 		ACF108D4615B78EC678BCB68 /* CountryRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryRoutes.swift; sourceTree = "<group>"; };
 		B177679FBC7D995ACD2B8D5E /* ProfileProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileProbe.swift; sourceTree = "<group>"; };
 		B1A0052E94D098F8C7C9C7AB /* BypassRoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BypassRoutesTests.swift; sourceTree = "<group>"; };
+		B22267033C9B0291E6381D9A /* RuleReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleReviewTests.swift; sourceTree = "<group>"; };
+		B376BE6ED126E4D1515CFEEA /* ProviderMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderMessage.swift; sourceTree = "<group>"; };
 		B699E2250E6B3CC6C82DED5F /* cn-direct.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = "cn-direct.bin"; sourceTree = "<group>"; };
 		B8325591D1B5330766175145 /* ProfileRoutingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRoutingSection.swift; sourceTree = "<group>"; };
-		B8325591D1B5330766175146 /* ProfileRulesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRulesSection.swift; sourceTree = "<group>"; };
 		BCDA99C2486E8ABD530118BE /* QueqiaoTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = QueqiaoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0722AD3C50275E1BCDD5351 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C68809144D3F97622B923A85 /* Queqiao.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Queqiao.entitlements; sourceTree = "<group>"; };
@@ -239,7 +251,7 @@
 				0825E32D40A85D473CED722B /* ProfileOnDemandSection.swift */,
 				B177679FBC7D995ACD2B8D5E /* ProfileProbe.swift */,
 				B8325591D1B5330766175145 /* ProfileRoutingSection.swift */,
-				B8325591D1B5330766175146 /* ProfileRulesSection.swift */,
+				3D5BDA88949A86BDA1B0EF17 /* ProfileRulesSection.swift */,
 				06E70DE072DD84C6BF2E8288 /* ProfilesView.swift */,
 				C68809144D3F97622B923A85 /* Queqiao.entitlements */,
 				85EB3D7717BB422AD61D738D /* QueqiaoApp.swift */,
@@ -259,9 +271,10 @@
 				B1A0052E94D098F8C7C9C7AB /* BypassRoutesTests.swift */,
 				F638CF570C7A5852DE2269B7 /* CoreBoundaryTests.swift */,
 				4D902CF2632815D3C3F6B0E1 /* CountryRoutesTests.swift */,
-				4D902CF2632815D3C3F6B0E2 /* RuleReviewTests.swift */,
 				9AD9D8FC50C293C44417209F /* OnDemandRulesTests.swift */,
 				A73080843F759E47498727DB /* RoutePlanTests.swift */,
+				8D7E8E7849FD09193CEF0A4F /* RoutingConfigurationTests.swift */,
+				B22267033C9B0291E6381D9A /* RuleReviewTests.swift */,
 				30DF918B060C4D661A7E9E05 /* TunnelNetworkSettingsTests.swift */,
 			);
 			path = QueqiaoTests;
@@ -292,6 +305,7 @@
 				EDBCAF651997059D82D31A20 /* PacketTunnel.entitlements */,
 				42AFB9F720602C013212C4BF /* PacketTunnelLifecycle.swift */,
 				A22BC502BF533F3ED9712923 /* PacketTunnelProvider.swift */,
+				5177CA98C76F396FD1E06866 /* TunnelError.swift */,
 				08236FE994BEE1A6C0DC4EB6 /* Resources */,
 			);
 			path = PacketTunnel;
@@ -331,7 +345,9 @@
 				5DD1C9B5069B4FCAB19D623D /* ProfileCatalog.swift */,
 				ED8D203B061F8250C3A766D1 /* ProfileStore.swift */,
 				E85BC6F6EB97A4D90EB38EB5 /* ProviderEndpoint.swift */,
+				B376BE6ED126E4D1515CFEEA /* ProviderMessage.swift */,
 				8D6440EF4592CF0B6675EBF7 /* RoutePlan.swift */,
+				9AFF87BF9DBE60A53F395EA3 /* RoutingConfiguration.swift */,
 				669F84268D925AD1EE813150 /* TunnelNetworkSettings.swift */,
 				0D1A32A7D2EA758E64DF5615 /* VPNDiagnostics.swift */,
 			);
@@ -503,12 +519,14 @@
 				937A5486A266F1541EC3C445 /* ProfileOnDemandSection.swift in Sources */,
 				A220EC905FD9ED834F0DF619 /* ProfileProbe.swift in Sources */,
 				B29C3BEEFE05BCF4AF1DFD82 /* ProfileRoutingSection.swift in Sources */,
-				B29C3BEEFE05BCF4AF1DFD83 /* ProfileRulesSection.swift in Sources */,
+				BF34BE6B67C98853D593BEE5 /* ProfileRulesSection.swift in Sources */,
 				5E0CBFE215332DDE2B40736C /* ProfileStore.swift in Sources */,
 				EFAAE976107F9765D9616D73 /* ProfilesView.swift in Sources */,
 				CEF53BD49453638B9109EE4C /* ProviderEndpoint.swift in Sources */,
+				C1F06FAB6BE8883C4873D52C /* ProviderMessage.swift in Sources */,
 				FD333468E8B953F05D6E981E /* QueqiaoApp.swift in Sources */,
 				1F3671A81E80D83D029558D1 /* RoutePlan.swift in Sources */,
+				3727BC1350FE32A55B91D5C3 /* RoutingConfiguration.swift in Sources */,
 				4216F96A859623582815FACD /* SettingsView.swift in Sources */,
 				9BBA0ED88485C8759A3A0E22 /* TunnelMetrics.swift in Sources */,
 				171DA48D7D57A037D5DE6A5C /* TunnelModel+Probing.swift in Sources */,
@@ -528,7 +546,6 @@
 				A90475B33DB098B5DC21F192 /* CoreBoundaryTests.swift in Sources */,
 				26D4ED0B36D14998D5C4A9C5 /* CountryRoutes.swift in Sources */,
 				FCA4D8B2A92C0267FBFCF77D /* CountryRoutesTests.swift in Sources */,
-				FCA4D8B2A92C0267FBFCF77E /* RuleReviewTests.swift in Sources */,
 				375FB5454F776236A3760973 /* DiagnosticStore.swift in Sources */,
 				25A3E872695919417DAE9CCE /* IPPrefix.swift in Sources */,
 				B61D6221C49C32C886381815 /* KeychainStore.swift in Sources */,
@@ -539,8 +556,12 @@
 				6FC28FF081A00A071AAEF432 /* ProfileCatalog.swift in Sources */,
 				561A1D630D5475AB89BF6AD7 /* ProfileStore.swift in Sources */,
 				C62CC189B8350A3DE082BF48 /* ProviderEndpoint.swift in Sources */,
+				077365773929DC839BBEDF46 /* ProviderMessage.swift in Sources */,
 				F3F66B8DFECF75A700A9C8AC /* RoutePlan.swift in Sources */,
 				429DA085FD40939BA064D46F /* RoutePlanTests.swift in Sources */,
+				654C24623CD508E1ECC8E74B /* RoutingConfiguration.swift in Sources */,
+				ED79A285B4D39067D82761F4 /* RoutingConfigurationTests.swift in Sources */,
+				8526EBB216BC34B5ED73B121 /* RuleReviewTests.swift in Sources */,
 				1C800E7E089993D5F21BCA0F /* TunnelNetworkSettings.swift in Sources */,
 				68057191EDB257366A49D5C9 /* TunnelNetworkSettingsTests.swift in Sources */,
 				03A75D5DEFBADD6966EA698C /* VPNDiagnostics.swift in Sources */,
@@ -564,7 +585,10 @@
 				E31ABE25B60F7C973A6F6490 /* ProfileCatalog.swift in Sources */,
 				A0BCA89C5A9D0B359153F78E /* ProfileStore.swift in Sources */,
 				F5EEBA8451B659266152FB2B /* ProviderEndpoint.swift in Sources */,
+				F3370385A827B51761AFDA7B /* ProviderMessage.swift in Sources */,
 				66A3F7A88D0512ABDD4ADFD5 /* RoutePlan.swift in Sources */,
+				68BD4A787EAA3DE0ABA63273 /* RoutingConfiguration.swift in Sources */,
+				718A536B32016E20CEC2A8D2 /* TunnelError.swift in Sources */,
 				178B2606193C371113D64EE4 /* TunnelNetworkSettings.swift in Sources */,
 				06191DEC5E7AE0B89897BB64 /* VPNDiagnostics.swift in Sources */,
 			);

--- a/mobile/ios/Queqiao/ContentView.swift
+++ b/mobile/ios/Queqiao/ContentView.swift
@@ -126,7 +126,7 @@ private struct ConnectionView: View {
             Divider()
             LabeledContent("Profile", value: profile.displayName)
             LabeledContent("Provider", value: profile.summary.endpoint)
-            LabeledContent("Traffic policy", value: profile.trafficPolicy.title)
+            LabeledContent("Routing", value: profile.routing.summary)
             LabeledContent("Active device", value: profile.summary.deviceName)
         }
         .padding()

--- a/mobile/ios/Queqiao/ProfileRoutingSection.swift
+++ b/mobile/ios/Queqiao/ProfileRoutingSection.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 
-/// Everything about where one profile's traffic goes: the coarse traffic
-/// policy, and the list of destinations kept off the tunnel entirely.
+/// Everything about where one profile's traffic goes: how much of it the tunnel
+/// carries, and which destinations are carved back out of it.
 ///
 /// Split out of ProfilesView because iOS gives Queqiao no consumer app to hand
 /// routing policy to, so this is the whole of the routing surface and it is the
 /// part most likely to keep growing.
+///
+/// The mode and the rules are one screen because they are one decision. They
+/// were previously three controls — a two-value traffic policy, a bundled-set
+/// toggle, and a route list — where two of them applied no matter what the
+/// third said, so "All traffic" was not true whenever either of the others was
+/// on. Nothing here is disabled while the tunnel is up: these are the settings
+/// most worth changing precisely then.
 struct ProfileRoutingSection: View {
     @EnvironmentObject private var model: TunnelModel
     let profile: StoredProfile
@@ -17,9 +24,9 @@ struct ProfileRoutingSection: View {
 
     var body: some View {
         Group {
-            trafficPolicySection
-            bypassSection
-            countrySetSection
+            modeSection
+            rulesSection
+            customRoutesSection
         }
         .task(id: profile.id) {
             bypassDraft = storedBypassText
@@ -28,31 +35,57 @@ struct ProfileRoutingSection: View {
         .onChange(of: profile.bypassRoutes) { _, _ in bypassDraft = storedBypassText }
     }
 
-    private var trafficPolicySection: some View {
+    /// The live record, so a toggle reflects the store rather than the snapshot
+    /// this view was built with.
+    private var routing: RoutingConfiguration {
+        model.profile(id: profile.id)?.routing ?? profile.routing
+    }
+
+    private var modeSection: some View {
         Section {
-            Picker("Routing", selection: policyBinding) {
-                ForEach(TrafficPolicy.allCases) { policy in
-                    Text(policy.title).tag(policy)
+            Picker("Routing", selection: modeBinding) {
+                ForEach(RoutingMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
                 }
             }
             .pickerStyle(.inline)
             .labelsHidden()
-            .disabled(!model.canChangeProfile)
 
-            Text(profile.trafficPolicy.detail)
+            Text(routing.mode.detail)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         } header: {
-            Text("Traffic policy")
+            Text("Routing")
         } footer: {
             Text(
-                "DNS uses the Queqiao tunnel in both modes. Local-network exclusions " +
-                "affect private and link-local destinations only."
+                "DNS resolves through the Queqiao tunnel in both modes, so a rule " +
+                "below can only match an address — never a domain name."
             )
         }
     }
 
-    private var bypassSection: some View {
+    private var rulesSection: some View {
+        Section {
+            Toggle("Local networks", isOn: ruleBinding(\.bypassLocalNetworks))
+            Text("Private and link-local destinations, such as a home router or a printer.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Toggle("Chinese addresses", isOn: ruleBinding(\.bypassChinaDirect))
+            if let bundledBlocks {
+                LabeledContent(
+                    "Blocks in the set",
+                    value: bundledBlocks.formatted(.number)
+                )
+            }
+        } header: {
+            Text("Bypass rules")
+        } footer: {
+            Text(rulesFooter)
+        }
+    }
+
+    private var customRoutesSection: some View {
         Section {
             TextField(
                 "203.0.113.0/24\n2001:db8::/32",
@@ -63,19 +96,17 @@ struct ProfileRoutingSection: View {
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .font(.callout.monospaced())
-            .disabled(!model.canChangeProfile)
 
             if hasUnsavedEdits {
-                Button("Save bypass routes") {
+                Button("Save custom routes") {
                     Task { await model.setBypassRoutes(from: bypassDraft, for: profile.id) }
                 }
-                .disabled(!model.canChangeProfile)
                 Button("Discard changes", role: .cancel) { bypassDraft = storedBypassText }
             }
 
             LabeledContent(
                 "In use",
-                value: "\(profile.bypassRoutes.count) of \(StoredProfile.maximumBypassRoutes)"
+                value: "\(routing.customRoutes.count) of \(StoredProfile.maximumBypassRoutes)"
             )
 
             if coversWholeFamily {
@@ -88,73 +119,68 @@ struct ProfileRoutingSection: View {
                 .foregroundStyle(.orange)
             }
         } header: {
-            Text("Bypass routes")
+            Text("Custom routes")
         } footer: {
             Text(
                 "Addresses and CIDR blocks listed here stay off the tunnel and use " +
-                "the device's normal network. One per line, or separated by commas.\n\n" +
-                "DNS still resolves through Queqiao, so this cannot match on domain " +
-                "names — only on addresses."
+                "the device's normal network. One per line, or separated by commas."
             )
         }
     }
 
-    private var countrySetSection: some View {
-        Section {
-            Toggle("Keep Chinese addresses direct", isOn: chinaDirectBinding)
-                .disabled(!model.canChangeProfile)
-
-            if let bundledBlocks {
-                LabeledContent("Blocks in the set", value: bundledBlocks.formatted(.number))
-            }
-        } header: {
-            Text("Bundled route set · experimental")
-        } footer: {
-            Text(
-                "Adds the address blocks APNIC records as delegated to China to " +
-                "the bypass list above.\n\n" +
-                "Two limits are worth knowing before turning this on. The " +
-                "registry records where a block was allocated, not where it is " +
-                "used, so the match is approximate. And because DNS resolves " +
-                "through the tunnel, a Chinese site answering with an address " +
-                "outside this set still takes the tunnel — this matches on " +
-                "addresses, never on domain names."
-            )
+    /// Says plainly whether the rules are doing anything, because a screen full
+    /// of switched-on toggles that route nothing is the confusion this layout
+    /// exists to remove.
+    private var rulesFooter: String {
+        let bundled = "The bundled set adds the address blocks APNIC records as delegated " +
+            "to China. The registry records where a block was allocated, not where it is " +
+            "used, so the match is approximate — and a Chinese site answering with an " +
+            "address outside the set still takes the tunnel."
+        guard routing.rulesApply else {
+            return "These rules are saved but not applied while the mode above is " +
+                "\(RoutingMode.allTraffic.title.lowercased()).\n\n" + bundled
         }
+        return "Destinations matched here stay off the tunnel. Everything else goes " +
+            "through Queqiao.\n\n" + bundled
     }
 
-    private var chinaDirectBinding: Binding<Bool> {
+    private var modeBinding: Binding<RoutingMode> {
         Binding(
-            get: { model.profile(id: profile.id)?.bypassChinaDirect ?? profile.bypassChinaDirect },
-            set: { enabled in
-                Task { await model.setBypassChinaDirect(enabled, for: profile.id) }
+            get: { routing.mode },
+            set: { mode in
+                Task { await model.updateRouting(for: profile.id) { $0.mode = mode } }
             }
         )
     }
 
-    /// Whether the stored list takes all of IPv4 or all of IPv6 off the tunnel.
+    private func ruleBinding(
+        _ field: WritableKeyPath<RoutingConfiguration, Bool>
+    ) -> Binding<Bool> {
+        Binding(
+            get: { routing[keyPath: field] },
+            set: { enabled in
+                Task {
+                    await model.updateRouting(for: profile.id) { $0[keyPath: field] = enabled }
+                }
+            }
+        )
+    }
+
+    /// Whether the stored rules take all of IPv4 or all of IPv6 off the tunnel.
     /// Built through RoutePlan so the screen and the tunnel agree on what a
-    /// default route is.
+    /// default route is. The bundled set is left out because it is a bounded
+    /// list of allocations and cannot cover a whole family.
     private var coversWholeFamily: Bool {
-        RoutePlan.make(userRoutes: profile.bypassRoutes).excludesDefaultRoute
+        RoutePlan.make(for: routing).excludesDefaultRoute
     }
 
     private var storedBypassText: String {
-        profile.bypassRoutes.joined(separator: "\n")
+        routing.customRoutes.joined(separator: "\n")
     }
 
     /// Compares against the stored list rather than tracking an edited flag, so
     /// typing a route and typing it back out again leaves no stale prompt.
     private var hasUnsavedEdits: Bool {
-        StoredProfile.routeEntries(from: bypassDraft) != profile.bypassRoutes
-    }
-
-    private var policyBinding: Binding<TrafficPolicy> {
-        Binding(
-            get: { model.profile(id: profile.id)?.trafficPolicy ?? profile.trafficPolicy },
-            set: { policy in
-                Task { await model.setTrafficPolicy(policy, for: profile.id) }
-            }
-        )
+        StoredProfile.routeEntries(from: bypassDraft) != routing.customRoutes
     }
 }

--- a/mobile/ios/Queqiao/ProfileRulesSection.swift
+++ b/mobile/ios/Queqiao/ProfileRulesSection.swift
@@ -56,7 +56,8 @@ struct ProfileRulesSection: View {
                 DOMAIN, DOMAIN-SUFFIX, DOMAIN-KEYWORD, IP-CIDR, GEOIP and \
                 DST-PORT, with PROXY, DIRECT or REJECT. A flow no rule \
                 matches takes the tunnel, so end with FINAL if you want \
-                otherwise. Changing rules takes effect on the next connect.
+                otherwise. Saved rules reach a running tunnel immediately; flows \
+                already open keep the rules they started under.
                 """
             )
         }

--- a/mobile/ios/Queqiao/TunnelMetrics.swift
+++ b/mobile/ios/Queqiao/TunnelMetrics.swift
@@ -10,7 +10,7 @@ struct TunnelMetrics: Equatable, Sendable {
     static func decode(_ data: Data) throws -> TunnelMetrics {
         let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         guard let transport = root?["transport"] as? [String: Any] else {
-            throw ModelError.emptyMetrics
+            throw ModelError.emptyProviderResponse
         }
         return TunnelMetrics(
             bytesUp: (transport["BytesUp"] as? NSNumber)?.uint64Value ?? 0,

--- a/mobile/ios/Queqiao/TunnelModel+VPN.swift
+++ b/mobile/ios/Queqiao/TunnelModel+VPN.swift
@@ -103,10 +103,11 @@ extension TunnelModel {
         configuration.providerBundleIdentifier = providerIdentifier
         configuration.serverAddress = record.summary.endpoint
         configuration.disconnectOnSleep = false
-        configuration.providerConfiguration = [
-            "profileID": record.id,
-            "trafficPolicy": record.trafficPolicy.rawValue
-        ]
+        // The profile identity, and nothing else. Routing used to be copied in
+        // here too and read back in preference to the stored record, so a rule
+        // could only take effect by rewriting the saved configuration — which
+        // is precisely what cannot be done while the tunnel is up.
+        configuration.providerConfiguration = ["profileID": record.id]
         manager.protocolConfiguration = configuration
         manager.localizedDescription = "Queqiao"
         manager.isEnabled = true
@@ -303,23 +304,54 @@ extension TunnelModel {
         if reset { publishMetrics(.empty) }
     }
 
-    func refreshMetrics() async {
+    /// Sends one request to the running provider and returns its answer.
+    ///
+    /// Returns nil when no tunnel is running, which is a normal state for both
+    /// callers rather than a failure: metrics simply have nothing to report,
+    /// and a routing change has nothing live to apply itself to.
+    func sendProviderRequest(_ request: ProviderRequest) async throws -> Data? {
         guard let session = manager?.connection as? NETunnelProviderSession,
-              session.status == .connected else { return }
-        do {
-            let response: Data = try await withCheckedThrowingContinuation { continuation in
-                do {
-                    try session.sendProviderMessage(Data("metrics".utf8)) { data in
-                        guard let data else {
-                            continuation.resume(throwing: ModelError.emptyMetrics)
-                            return
-                        }
-                        continuation.resume(returning: data)
+              session.status == .connected else { return nil }
+        return try await withCheckedThrowingContinuation { continuation in
+            do {
+                try session.sendProviderMessage(request.payload) { data in
+                    guard let data else {
+                        continuation.resume(throwing: ModelError.emptyProviderResponse)
+                        return
                     }
-                } catch {
-                    continuation.resume(throwing: error)
+                    continuation.resume(returning: data)
                 }
+            } catch {
+                continuation.resume(throwing: error)
             }
+        }
+    }
+
+    /// Pushes the stored routing rules onto the running tunnel.
+    ///
+    /// The rules are already saved by the time this runs, so a failure here
+    /// means the tunnel is still carrying traffic by the previous plan. That
+    /// has to be said out loud: silently leaving the two out of step is how a
+    /// user ends up believing a destination is off the tunnel when it is not.
+    func applyRoutingToRunningTunnel() async {
+        do {
+            guard let response = try await sendProviderRequest(.reloadRouting) else { return }
+            let result = try RoutingReloadResult(payload: response)
+            guard result.applied else {
+                present(
+                    ModelError.routingNotApplied(result.failure ?? "the extension declined it"),
+                    title: "Routing not applied"
+                )
+                return
+            }
+        } catch {
+            present(ModelError.routingNotApplied(error.localizedDescription), title: "Routing not applied")
+        }
+    }
+
+    func refreshMetrics() async {
+        do {
+            guard let response = try await sendProviderRequest(.metrics) else { return }
             publishMetrics(try TunnelMetrics.decode(response))
         } catch {
             // Metrics are operational decoration; a transient extension IPC failure must not alter tunnel state.

--- a/mobile/ios/Queqiao/TunnelModel.swift
+++ b/mobile/ios/Queqiao/TunnelModel.swift
@@ -186,16 +186,20 @@ final class TunnelModel: ObservableObject {
         }
     }
 
-    func setTrafficPolicy(_ policy: TrafficPolicy, for id: String) async {
-        guard canChangeProfile else {
-            present(ModelError.disconnectBeforeEditing, title: "Disconnect first")
-            return
-        }
+    /// Persists a routing change and installs it on the tunnel if one is up.
+    ///
+    /// Deliberately not gated on `canChangeProfile`. Which destinations skip
+    /// the tunnel is the setting most worth changing precisely while
+    /// connected, and iOS lets the interface description be replaced without
+    /// stopping the provider. The store is written first so that whatever the
+    /// live push does, the next connection uses the rules the user chose.
+    func setRouting(_ routing: RoutingConfiguration, for id: String) async {
         do {
-            try await Task.detached { try ProfileStore().setTrafficPolicy(policy, for: id) }.value
+            try await Task.detached { try ProfileStore().setRouting(routing, for: id) }.value
             await refreshProfiles()
+            await applyRoutingToRunningTunnel()
         } catch {
-            present(error, title: "Could not update traffic policy")
+            present(error, title: "Could not update routing")
         }
     }
 
@@ -203,22 +207,15 @@ final class TunnelModel: ObservableObject {
     /// than dropping them: silently discarding a typed route would leave the
     /// user believing a destination is off the tunnel when it is not.
     func setBypassRoutes(from text: String, for id: String) async {
-        guard canChangeProfile else {
-            present(ModelError.disconnectBeforeEditing, title: "Disconnect first")
-            return
-        }
+        guard var routing = profile(id: id)?.routing else { return }
         let entries = StoredProfile.routeEntries(from: text)
         let rejected = IPPrefix.parseList(entries).rejected
         guard rejected.isEmpty else {
             present(ModelError.invalidBypassRoutes(rejected), title: "Check the bypass list")
             return
         }
-        do {
-            try await Task.detached { try ProfileStore().setBypassRoutes(entries, for: id) }.value
-            await refreshProfiles()
-        } catch {
-            present(error, title: "Could not update bypass routes")
-        }
+        routing.customRoutes = entries
+        await setRouting(routing, for: id)
     }
 
     func deleteProfile(id: String) async {
@@ -307,37 +304,36 @@ extension TunnelModel {
         }
     }
 
-    /// Saves the rule list. Like every other routing change this needs the
-    /// tunnel down, because the rules a flow was opened under are the rules it
-    /// keeps: re-pointing a running tunnel would leave live flows decided by a
-    /// list the user can no longer see.
+    /// Saves the rule list and hands it to the running core when there is one.
+    ///
+    /// This used to require the tunnel down, on the reasoning that a flow keeps
+    /// the rules it was opened under and re-pointing a live tunnel would leave
+    /// those flows decided by a list the user can no longer see. That is still
+    /// true and is the cost of this: flows already open keep their decision,
+    /// and only flows opened after the change follow the new list. Being unable
+    /// to fix a rule without dropping the connection was the larger problem.
     func updateRoutingRules(_ rules: String, for id: String) {
         Task { await saveRoutingRules(rules, for: id) }
     }
 
     func saveRoutingRules(_ rules: String, for id: String) async {
-        guard canChangeProfile else {
-            present(ModelError.disconnectBeforeEditing, title: "Disconnect first")
-            return
-        }
         do {
             try await Task.detached { try ProfileStore().setRoutingRules(rules, for: id) }.value
             await refreshProfiles()
+            await applyRoutingToRunningTunnel()
         } catch {
             present(error, title: "Could not save the routing rules")
         }
     }
 
-    func setBypassChinaDirect(_ enabled: Bool, for id: String) async {
-        guard canChangeProfile else {
-            present(ModelError.disconnectBeforeEditing, title: "Disconnect first")
-            return
-        }
-        do {
-            try await Task.detached { try ProfileStore().setBypassChinaDirect(enabled, for: id) }.value
-            await refreshProfiles()
-        } catch {
-            present(error, title: "Could not update the bundled route set")
-        }
+    /// Applies one edit to a profile's routing, reading the current value so a
+    /// toggle cannot write back a stale copy of the other rules.
+    func updateRouting(
+        for id: String,
+        _ edit: (inout RoutingConfiguration) -> Void
+    ) async {
+        guard var routing = profile(id: id)?.routing else { return }
+        edit(&routing)
+        await setRouting(routing, for: id)
     }
 }

--- a/mobile/ios/Queqiao/TunnelSupport.swift
+++ b/mobile/ios/Queqiao/TunnelSupport.swift
@@ -39,7 +39,8 @@ enum ModelError: LocalizedError {
     case emptyCoreResult
     case invalidPacketTunnelIdentifier
     case disconnectBeforeEditing
-    case emptyMetrics
+    case emptyProviderResponse
+    case routingNotApplied(String)
     case invalidBypassRoutes([String])
 
     var errorDescription: String? {
@@ -51,9 +52,12 @@ enum ModelError: LocalizedError {
         case .invalidPacketTunnelIdentifier:
             return "The packet-tunnel bundle identifier is not configured."
         case .disconnectBeforeEditing:
-            return "Disconnect the VPN before changing its selected profile or routing policy."
-        case .emptyMetrics:
-            return "The packet-tunnel extension returned no metrics."
+            return "Disconnect the VPN before changing which profile it uses."
+        case .emptyProviderResponse:
+            return "The packet-tunnel extension returned no response."
+        case .routingNotApplied(let reason):
+            return "The routing change was saved, but the running tunnel is still using "
+                + "the previous rules: \(reason)"
         case .invalidBypassRoutes(let entries):
             let listed = entries.prefix(5).joined(separator: ", ")
             let suffix = entries.count > 5 ? " and \(entries.count - 5) more" : ""

--- a/mobile/ios/QueqiaoTests/BypassRoutesTests.swift
+++ b/mobile/ios/QueqiaoTests/BypassRoutesTests.swift
@@ -7,6 +7,8 @@ import XCTest
 /// migration as about routing.
 final class BypassRoutesTests: XCTestCase {
     private func makeProfile(
+        routingMode: RoutingMode = .allTraffic,
+        bypassLocalNetworks: Bool = false,
         bypassRoutes: [String] = [],
         bypassChinaDirect: Bool = false
     ) -> StoredProfile {
@@ -25,7 +27,8 @@ final class BypassRoutesTests: XCTestCase {
                 deviceName: "Phone",
                 certificateExpiry: "2030-01-01T00:00:00Z"
             ),
-            trafficPolicy: .allTraffic,
+            routingMode: routingMode,
+            bypassLocalNetworks: bypassLocalNetworks,
             bypassRoutes: bypassRoutes,
             bypassChinaDirect: bypassChinaDirect,
             importedAt: "2026-08-18T00:00:00Z"
@@ -138,6 +141,81 @@ final class BypassRoutesTests: XCTestCase {
             ["10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"]
         )
         XCTAssertEqual(StoredProfile.routeEntries(from: "   \n  \n "), [])
+    }
+
+    /// The old policy only ever decided local networks; a bypass list and the
+    /// country set applied whatever it said. Anything that was carving traffic
+    /// out of the tunnel therefore has to come back as `bypassRules`, or an
+    /// upgrade would quietly push those destinations through the tunnel.
+    private func legacyCatalog(policy: String, extraFields: String = "") -> String {
+        """
+        {"version":1,"selectedProfileID":"first","profiles":[{
+          "id":"first","secretAccount":"secret.first","displayName":"Example",
+          "trafficPolicy":"\(policy)","importedAt":"2026-08-18T00:00:00Z"\(extraFields),
+          "summary":{"version":1,"name":"Example","endpoint":"gateway.example:443",
+            "provider_id":"provider","gateway_id":"gateway","account_id":"account",
+            "device_id":"device","device_name":"Phone",
+            "certificate_expiry":"2030-01-01T00:00:00Z"}
+        }]}
+        """
+    }
+
+    func testALegacyExcludeLocalNetworksPolicyBecomesARuleInBypassMode() throws {
+        let catalog = try decodeCatalog(legacyCatalog(policy: "exclude-local-networks"))
+
+        let routing = catalog.profiles[0].routing
+        XCTAssertEqual(routing.mode, .bypassRules)
+        XCTAssertTrue(routing.bypassLocalNetworks)
+    }
+
+    func testALegacyGlobalPolicyWithNoRulesStaysGlobal() throws {
+        let catalog = try decodeCatalog(legacyCatalog(policy: "all-traffic"))
+
+        let routing = catalog.profiles[0].routing
+        XCTAssertEqual(routing.mode, .allTraffic)
+        XCTAssertFalse(routing.bypassLocalNetworks)
+    }
+
+    func testALegacyGlobalPolicyStillHonoursRulesThatUsedToApplyRegardless() throws {
+        let withRoutes = try decodeCatalog(
+            legacyCatalog(policy: "all-traffic", extraFields: ",\"bypassRoutes\":[\"10.0.0.0/8\"]")
+        )
+        let withCountrySet = try decodeCatalog(
+            legacyCatalog(policy: "all-traffic", extraFields: ",\"bypassChinaDirect\":true")
+        )
+
+        XCTAssertEqual(withRoutes.profiles[0].routing.mode, .bypassRules)
+        XCTAssertEqual(withCountrySet.profiles[0].routing.mode, .bypassRules)
+    }
+
+    /// A downgrade decodes `trafficPolicy` without a default, so dropping it
+    /// from the written catalog would take every enrolled profile with it.
+    func testTheLegacyPolicyFieldIsStillWrittenForOlderBuilds() throws {
+        let catalog = ProfileCatalog(
+            selectedProfileID: "first",
+            profiles: [makeProfile(routingMode: .bypassRules, bypassLocalNetworks: true)]
+        )
+
+        let encoded = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(catalog)
+        ) as? [String: Any]
+        let profiles = encoded?["profiles"] as? [[String: Any]]
+
+        XCTAssertEqual(profiles?.first?["trafficPolicy"] as? String, "exclude-local-networks")
+    }
+
+    func testTheLegacyPolicyFieldTracksTheRulesRatherThanBeingStored() throws {
+        XCTAssertEqual(makeProfile(routingMode: .allTraffic).legacyTrafficPolicy, .allTraffic)
+        // Local networks bypassed but the mode global: an older build must not
+        // be told to exclude them, because this build does not.
+        XCTAssertEqual(
+            makeProfile(routingMode: .allTraffic, bypassLocalNetworks: true).legacyTrafficPolicy,
+            .allTraffic
+        )
+        XCTAssertEqual(
+            makeProfile(routingMode: .bypassRules, bypassLocalNetworks: true).legacyTrafficPolicy,
+            .excludeLocalNetworks
+        )
     }
 
     func testParseListNamesTheEntriesThatFailedRatherThanCountingThem() {

--- a/mobile/ios/QueqiaoTests/CoreBoundaryTests.swift
+++ b/mobile/ios/QueqiaoTests/CoreBoundaryTests.swift
@@ -30,7 +30,8 @@ final class CoreBoundaryTests: XCTestCase {
             secretAccount: "secret.first",
             displayName: "Example",
             summary: summary,
-            trafficPolicy: .excludeLocalNetworks,
+            routingMode: .bypassRules,
+            bypassLocalNetworks: true,
             importedAt: "2026-08-18T00:00:00Z"
         )
         var catalog = ProfileCatalog(

--- a/mobile/ios/QueqiaoTests/RoutingConfigurationTests.swift
+++ b/mobile/ios/QueqiaoTests/RoutingConfigurationTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import Queqiao
+
+/// The routing configuration is the merge of what used to be three unrelated
+/// settings, so these tests are mostly about the states the old shape allowed
+/// and this one must not: rules that apply when the mode says they do not, and
+/// a mode that claims to carry everything while it does not.
+final class RoutingConfigurationTests: XCTestCase {
+    private var countrySet: [IPPrefix] {
+        IPPrefix.parseList(["203.0.113.0/24", "198.51.100.0/24"]).parsed
+    }
+
+    /// The reason the three old settings were merged. "All traffic" used to be
+    /// a lie: the bypass list and the country set were applied regardless of
+    /// what the policy said, so a user could read "All traffic" off the screen
+    /// while whole countries left the tunnel.
+    func testGlobalModeInstallsNothingEvenWithEveryRuleSwitchedOn() {
+        let routing = RoutingConfiguration(
+            mode: .allTraffic,
+            bypassLocalNetworks: true,
+            bypassChinaDirect: true,
+            customRoutes: ["10.0.0.0/8"]
+        )
+
+        let plan = RoutePlan.make(for: routing, chinaDirect: countrySet)
+
+        XCTAssertTrue(plan.excluded.isEmpty)
+        XCTAssertTrue(plan.ipv4Routes.isEmpty)
+        XCTAssertFalse(plan.excludesDefaultRoute)
+    }
+
+    func testBypassModeAppliesLocalNetworksOnlyWhenThatRuleIsOn() {
+        var routing = RoutingConfiguration(mode: .bypassRules)
+
+        XCTAssertTrue(RoutePlan.make(for: routing).excluded.isEmpty)
+
+        routing.bypassLocalNetworks = true
+        let plan = RoutePlan.make(for: routing)
+
+        XCTAssertFalse(plan.excluded.isEmpty)
+        XCTAssertTrue(plan.excluded.contains { $0.cidrText == "192.168.0.0/16" })
+    }
+
+    func testBypassModeAppliesTheCountrySetOnlyWhenThatRuleIsOn() {
+        var routing = RoutingConfiguration(mode: .bypassRules)
+
+        XCTAssertTrue(RoutePlan.make(for: routing, chinaDirect: countrySet).excluded.isEmpty)
+
+        routing.bypassChinaDirect = true
+        let plan = RoutePlan.make(for: routing, chinaDirect: countrySet)
+
+        XCTAssertTrue(plan.excluded.contains { $0.cidrText == "203.0.113.0/24" })
+    }
+
+    func testCustomRoutesAndRuleSetsCombineIntoOnePlan() {
+        let routing = RoutingConfiguration(
+            mode: .bypassRules,
+            bypassLocalNetworks: true,
+            bypassChinaDirect: true,
+            customRoutes: ["8.8.8.8/32"]
+        )
+
+        let plan = RoutePlan.make(for: routing, chinaDirect: countrySet)
+
+        XCTAssertTrue(plan.excluded.contains { $0.cidrText == "8.8.8.8/32" })
+        XCTAssertTrue(plan.excluded.contains { $0.cidrText == "203.0.113.0/24" })
+        XCTAssertTrue(plan.excluded.contains { $0.cidrText == "192.168.0.0/16" })
+    }
+
+    /// The summary is what the connection card shows, so it has to describe
+    /// what is in force rather than which mode is selected.
+    func testTheSummaryDescribesTheRulesActuallyInForce() {
+        XCTAssertEqual(
+            RoutingConfiguration(mode: .allTraffic).summary,
+            RoutingMode.allTraffic.title
+        )
+        // Bypass mode with nothing enabled carries just as much as global mode.
+        XCTAssertEqual(
+            RoutingConfiguration(mode: .bypassRules).summary,
+            RoutingMode.allTraffic.title
+        )
+        XCTAssertEqual(
+            RoutingConfiguration(
+                mode: .bypassRules,
+                bypassLocalNetworks: true,
+                bypassChinaDirect: true
+            ).summary,
+            "Bypassing local networks and Chinese addresses"
+        )
+        XCTAssertEqual(
+            RoutingConfiguration(mode: .bypassRules, customRoutes: ["10.0.0.0/8"]).summary,
+            "Bypassing 1 custom route"
+        )
+    }
+}

--- a/mobile/ios/Shared/ProfileCatalog.swift
+++ b/mobile/ios/Shared/ProfileCatalog.swift
@@ -7,30 +7,14 @@ import Foundation
 /// extension decodes, and it is the half that grows every time a routing or
 /// connection setting is added.
 
-enum TrafficPolicy: String, Codable, CaseIterable, Identifiable, Sendable {
+/// The routing setting Queqiao stored before routing rules existed.
+///
+/// Kept only so that an older catalog migrates on load and an older build can
+/// still decode what this one writes — see `StoredProfile.migratedMode` and
+/// `StoredProfile.legacyTrafficPolicy`. Nothing reads it to make a decision.
+enum TrafficPolicy: String, Codable, Sendable {
     case allTraffic = "all-traffic"
     case excludeLocalNetworks = "exclude-local-networks"
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .allTraffic:
-            return "All traffic"
-        case .excludeLocalNetworks:
-            return "Exclude local networks"
-        }
-    }
-
-    var detail: String {
-        switch self {
-        case .allTraffic:
-            return "Route IPv4, IPv6, and DNS traffic through the selected Queqiao provider."
-        case .excludeLocalNetworks:
-            return "Keep private and link-local destinations outside the tunnel; " +
-                "route internet and DNS traffic through Queqiao."
-        }
-    }
 }
 
 struct ProfileSummary: Codable, Equatable, Sendable {
@@ -69,7 +53,13 @@ struct StoredProfile: Codable, Identifiable, Equatable, Sendable {
     let secretAccount: String
     var displayName: String
     var summary: ProfileSummary
-    var trafficPolicy: TrafficPolicy
+    /// How much traffic the tunnel carries. Which destinations are carved out
+    /// of it is decided by the three rule properties below, not by this.
+    var routingMode: RoutingMode
+    /// Private and link-local destinations kept off the tunnel. This was a
+    /// traffic-policy case rather than a rule until it became clear it behaved
+    /// like every other rule and only looked different.
+    var bypassLocalNetworks = false
     /// Destinations kept off the tunnel, in canonical CIDR text. Sanitized by
     /// ProfileCatalog.normalize on every load and save, so a caller may hand
     /// this whatever the user typed.
@@ -93,6 +83,54 @@ struct StoredProfile: Codable, Identifiable, Equatable, Sendable {
     var connectOnCellular = true
     let importedAt: String
 
+    /// The routing settings as one value. The plan builder and the settings
+    /// screen both work from this rather than from the individual fields, so
+    /// neither can apply a rule the other does not know about.
+    var routing: RoutingConfiguration {
+        get {
+            RoutingConfiguration(
+                mode: routingMode,
+                bypassLocalNetworks: bypassLocalNetworks,
+                bypassChinaDirect: bypassChinaDirect,
+                customRoutes: bypassRoutes,
+                rules: routingRules
+            )
+        }
+        set {
+            routingMode = newValue.mode
+            bypassLocalNetworks = newValue.bypassLocalNetworks
+            bypassChinaDirect = newValue.bypassChinaDirect
+            bypassRoutes = newValue.customRoutes
+            routingRules = newValue.rules
+        }
+    }
+
+    /// What a build from before the routing rules would have stored. Written on
+    /// every save so that downgrading still finds the field it decodes without
+    /// a default, and never read back except by such a build. Derived rather
+    /// than stored because two fields describing one setting is the bug this
+    /// refactor exists to remove.
+    var legacyTrafficPolicy: TrafficPolicy {
+        routingMode == .bypassRules && bypassLocalNetworks ? .excludeLocalNetworks : .allTraffic
+    }
+
+    /// The mode a catalog written before the rules existed should load as.
+    ///
+    /// The old policy only ever decided whether local networks were excluded;
+    /// a bypass list and the country set applied whatever it said. Anything
+    /// that was carving traffic out of the tunnel therefore has to load as
+    /// `bypassRules`, or upgrading would silently push a user's excluded
+    /// destinations back through the tunnel.
+    static func migratedMode(
+        policy: TrafficPolicy,
+        chinaDirect: Bool,
+        customRoutes: [String]
+    ) -> RoutingMode {
+        policy == .excludeLocalNetworks || chinaDirect || !customRoutes.isEmpty
+            ? .bypassRules
+            : .allTraffic
+    }
+
     var onDemandPolicy: OnDemandPolicy {
         OnDemandPolicy(
             trustedNetworks: trustedNetworks,
@@ -114,6 +152,46 @@ struct StoredProfile: Codable, Identifiable, Equatable, Sendable {
 }
 
 extension StoredProfile {
+    /// Spelled out because `trafficPolicy` is no longer a stored property and
+    /// the synthesized keys would not include it, while the catalog format
+    /// still carries it for older builds.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case secretAccount
+        case displayName
+        case summary
+        case trafficPolicy
+        case routingMode
+        case bypassLocalNetworks
+        case bypassRoutes
+        case bypassChinaDirect
+        case routingRules
+        case onDemandEnabled
+        case trustedNetworks
+        case connectOnCellular
+        case importedAt
+    }
+
+    /// Encoded by hand for the same reason it is decoded by hand: the legacy
+    /// policy field has to be written from the routing rules on every save.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(secretAccount, forKey: .secretAccount)
+        try container.encode(displayName, forKey: .displayName)
+        try container.encode(summary, forKey: .summary)
+        try container.encode(legacyTrafficPolicy, forKey: .trafficPolicy)
+        try container.encode(routingMode, forKey: .routingMode)
+        try container.encode(bypassLocalNetworks, forKey: .bypassLocalNetworks)
+        try container.encode(bypassRoutes, forKey: .bypassRoutes)
+        try container.encode(bypassChinaDirect, forKey: .bypassChinaDirect)
+        try container.encode(routingRules, forKey: .routingRules)
+        try container.encode(onDemandEnabled, forKey: .onDemandEnabled)
+        try container.encode(trustedNetworks, forKey: .trustedNetworks)
+        try container.encode(connectOnCellular, forKey: .connectOnCellular)
+        try container.encode(importedAt, forKey: .importedAt)
+    }
+
     /// Decoded by hand because Swift's synthesized Decodable ignores property
     /// defaults: a catalog written before a field existed would fail to decode
     /// and take every enrolled profile on the device with it.
@@ -123,10 +201,18 @@ extension StoredProfile {
         secretAccount = try container.decode(String.self, forKey: .secretAccount)
         displayName = try container.decode(String.self, forKey: .displayName)
         summary = try container.decode(ProfileSummary.self, forKey: .summary)
-        trafficPolicy = try container.decode(TrafficPolicy.self, forKey: .trafficPolicy)
+        let legacyPolicy = try container.decode(TrafficPolicy.self, forKey: .trafficPolicy)
         bypassRoutes = try container.decodeIfPresent([String].self, forKey: .bypassRoutes) ?? []
         bypassChinaDirect = try container.decodeIfPresent(Bool.self, forKey: .bypassChinaDirect) ?? false
         routingRules = try container.decodeIfPresent(String.self, forKey: .routingRules) ?? ""
+        bypassLocalNetworks = try container.decodeIfPresent(Bool.self, forKey: .bypassLocalNetworks)
+            ?? (legacyPolicy == .excludeLocalNetworks)
+        routingMode = try container.decodeIfPresent(RoutingMode.self, forKey: .routingMode)
+            ?? Self.migratedMode(
+                policy: legacyPolicy,
+                chinaDirect: bypassChinaDirect,
+                customRoutes: bypassRoutes
+            )
         onDemandEnabled = try container.decodeIfPresent(Bool.self, forKey: .onDemandEnabled) ?? false
         trustedNetworks = try container.decodeIfPresent([String].self, forKey: .trustedNetworks) ?? []
         connectOnCellular = try container.decodeIfPresent(Bool.self, forKey: .connectOnCellular) ?? true

--- a/mobile/ios/Shared/ProfileStore.swift
+++ b/mobile/ios/Shared/ProfileStore.swift
@@ -51,7 +51,7 @@ struct ProfileStore: Sendable {
             secretAccount: account,
             displayName: summary.name,
             summary: summary,
-            trafficPolicy: .allTraffic,
+            routingMode: .allTraffic,
             importedAt: ISO8601DateFormatter().string(from: Date())
         )
         try keychain.set(profileJSON, account: account)
@@ -104,32 +104,17 @@ struct ProfileStore: Sendable {
         try save(catalog)
     }
 
-    func setTrafficPolicy(_ policy: TrafficPolicy, for id: String) throws {
-        var catalog = try catalog()
-        guard let index = catalog.profiles.firstIndex(where: { $0.id == id }) else {
-            throw ProfileStoreError.profileNotFound
-        }
-        catalog.profiles[index].trafficPolicy = policy
-        try save(catalog)
-    }
-
-    /// Stores bypass routes for one profile. The entries are sanitized by
+    /// Writes the whole routing configuration at once, for the same reason
+    /// `setOnDemandPolicy` does: the mode and the rules are read together when
+    /// the plan is built, and three setters would let the catalog hold a state
+    /// no screen ever asked for between saves. Route entries are sanitized by
     /// save, so the caller may pass raw text split into candidates.
-    func setBypassRoutes(_ routes: [String], for id: String) throws {
+    func setRouting(_ routing: RoutingConfiguration, for id: String) throws {
         var catalog = try catalog()
         guard let index = catalog.profiles.firstIndex(where: { $0.id == id }) else {
             throw ProfileStoreError.profileNotFound
         }
-        catalog.profiles[index].bypassRoutes = routes
-        try save(catalog)
-    }
-
-    func setBypassChinaDirect(_ enabled: Bool, for id: String) throws {
-        var catalog = try catalog()
-        guard let index = catalog.profiles.firstIndex(where: { $0.id == id }) else {
-            throw ProfileStoreError.profileNotFound
-        }
-        catalog.profiles[index].bypassChinaDirect = enabled
+        catalog.profiles[index].routing = routing
         try save(catalog)
     }
 
@@ -252,7 +237,7 @@ struct ProfileStore: Sendable {
             secretAccount: account,
             displayName: summary.name,
             summary: summary,
-            trafficPolicy: .allTraffic,
+            routingMode: .allTraffic,
             importedAt: ISO8601DateFormatter().string(from: Date())
         )
         try keychain.set(legacy, account: account)

--- a/mobile/ios/Shared/ProviderMessage.swift
+++ b/mobile/ios/Shared/ProviderMessage.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// What the app can ask the running packet tunnel to do.
+///
+/// The channel existed before this type did, but it carried one unread word:
+/// the provider answered every message with metrics regardless of content. A
+/// second request had to be tellable from the first before routing could be
+/// changed without disconnecting.
+enum ProviderRequest: String, Sendable {
+    /// Answer with the metrics JSON.
+    case metrics
+    /// Re-read the active profile's routing rules and install them on the live
+    /// interface. The rules themselves are not carried in the message: the
+    /// Keychain catalog is the one source both sides already read, and copying
+    /// them into the payload would create a second one that could disagree.
+    case reloadRouting = "reload-routing"
+
+    var payload: Data { Data(rawValue.utf8) }
+
+    init?(payload: Data) {
+        guard let text = String(data: payload, encoding: .utf8),
+              let request = ProviderRequest(rawValue: text) else {
+            return nil
+        }
+        self = request
+    }
+}
+
+/// The provider's answer to `reloadRouting`.
+///
+/// Carries the failure text rather than just a flag because the settings screen
+/// has to say why a change did not reach the tunnel — a rule the user believes
+/// is applied but is not is the failure this whole path exists to avoid.
+struct RoutingReloadResult: Codable, Equatable, Sendable {
+    var applied: Bool
+    var excludedRouteCount: Int = 0
+    var failure: String?
+
+    static func succeeded(excludedRouteCount: Int) -> RoutingReloadResult {
+        RoutingReloadResult(applied: true, excludedRouteCount: excludedRouteCount)
+    }
+
+    static func failed(_ failure: String) -> RoutingReloadResult {
+        RoutingReloadResult(applied: false, failure: failure)
+    }
+
+    var payload: Data { (try? JSONEncoder().encode(self)) ?? Data() }
+
+    init(applied: Bool, excludedRouteCount: Int = 0, failure: String? = nil) {
+        self.applied = applied
+        self.excludedRouteCount = excludedRouteCount
+        self.failure = failure
+    }
+
+    init(payload: Data) throws {
+        self = try JSONDecoder().decode(RoutingReloadResult.self, from: payload)
+    }
+}

--- a/mobile/ios/Shared/RoutingConfiguration.swift
+++ b/mobile/ios/Shared/RoutingConfiguration.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// How much of the device's traffic the tunnel carries.
+///
+/// The mode is deliberately coarse. Which destinations are kept off the tunnel
+/// is not a mode — it is a set of rules, and those live in
+/// `RoutingConfiguration` so that turning the tunnel global does not mean
+/// dismantling a bypass list the user spent time building.
+enum RoutingMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    /// Everything goes through the tunnel. Bypass rules stay stored but idle.
+    case allTraffic = "all-traffic"
+    /// Everything except the enabled bypass rules goes through the tunnel.
+    case bypassRules = "bypass-rules"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .allTraffic:
+            return "Route all traffic"
+        case .bypassRules:
+            return "Use bypass rules"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .allTraffic:
+            return "Every IPv4, IPv6, and DNS destination goes through the selected " +
+                "Queqiao provider. Bypass rules below are kept but not applied."
+        case .bypassRules:
+            return "Everything goes through Queqiao except the destinations matched " +
+                "by the rules below."
+        }
+    }
+}
+
+/// Everything that decides where one profile's traffic goes.
+///
+/// This used to be three settings that did not know about each other: a
+/// two-value traffic policy, a bundled-set toggle, and a typed route list. Two
+/// of them applied regardless of what the third said, so "All traffic" was not
+/// true whenever a bypass route or the country set was also on. They are one
+/// type now because they were always answering one question.
+///
+/// Queqiao routes on addresses only. DNS resolves through the tunnel, so no
+/// rule here can match a domain name.
+struct RoutingConfiguration: Equatable, Sendable {
+    var mode: RoutingMode = .allTraffic
+    /// Private and link-local destinations, as one rule rather than as a mode.
+    var bypassLocalNetworks = false
+    /// The bundled registry set for China. Experimental and approximate: see
+    /// CountryRoutes.
+    var bypassChinaDirect = false
+    /// Destinations typed by the user, in canonical CIDR text.
+    var customRoutes: [String] = []
+    /// The rule list as the user wrote or imported it, one rule per line. Kept
+    /// here rather than beside it because a rule list is also an answer to
+    /// "where does this profile's traffic go", and the whole point of this type
+    /// is that there is one answer. The core parses and acts on the text; the
+    /// route plan below ignores it.
+    var rules: String = ""
+
+    /// Whether the rules below the mode picker currently affect anything. The
+    /// UI keeps them editable either way, and says plainly when they are idle.
+    var rulesApply: Bool { mode == .bypassRules }
+
+    /// Whether any rule is switched on, regardless of the mode. Used to tell
+    /// "no rules configured" apart from "rules configured but not applied".
+    var hasEnabledRules: Bool {
+        bypassLocalNetworks || bypassChinaDirect || !customRoutes.isEmpty
+    }
+
+    /// How many lines the rule list holds, ignoring blanks and comments, for
+    /// screens that report on it without parsing it.
+    var ruleLineCount: Int {
+        rules.split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+            .count
+    }
+
+    /// A one-line description for the connection summary card. Names the rules
+    /// actually in force rather than the mode alone, because "use bypass rules"
+    /// with every rule off carries exactly as much traffic as routing all of it
+    /// and should not read differently.
+    var summary: String {
+        var parts: [String] = []
+        if ruleLineCount > 0 {
+            parts.append("\(ruleLineCount) \(ruleLineCount == 1 ? "rule" : "rules")")
+        }
+        guard rulesApply, hasEnabledRules else {
+            return parts.isEmpty
+                ? RoutingMode.allTraffic.title
+                : "Routing by " + parts.formatted(.list(type: .and))
+        }
+        if bypassLocalNetworks { parts.append("local networks") }
+        if bypassChinaDirect { parts.append("Chinese addresses") }
+        if !customRoutes.isEmpty {
+            parts.append("\(customRoutes.count) custom \(customRoutes.count == 1 ? "route" : "routes")")
+        }
+        return "Bypassing " + parts.formatted(.list(type: .and))
+    }
+}
+
+extension RoutePlan {
+    /// The plan a routing configuration installs.
+    ///
+    /// The country set is passed in rather than read here because loading it
+    /// can fail, and the packet tunnel and the settings screen want to report
+    /// that failure differently. Both still compose the plan through this one
+    /// function, so what the screen previews is what the tunnel installs.
+    static func make(
+        for routing: RoutingConfiguration,
+        chinaDirect: [IPPrefix] = [],
+        limit: Int = defaultLimit
+    ) -> RoutePlan {
+        guard routing.rulesApply else {
+            return make(userRoutes: [], builtIn: [], limit: limit)
+        }
+        var userRoutes = routing.customRoutes
+        if routing.bypassLocalNetworks {
+            userRoutes = localNetworks + userRoutes
+        }
+        return make(
+            userRoutes: userRoutes,
+            builtIn: routing.bypassChinaDirect ? chinaDirect : [],
+            limit: limit
+        )
+    }
+}


### PR DESCRIPTION
Two problems reported from the device: routing settings cannot be changed while the VPN is connected, and the routing surface is confusing because the traffic policy and "Keep Chinese addresses direct" are separate controls that clearly belong together.

Both are real, and the first one turned out to be worse than a layout complaint.

## The bug behind the confusion

`bypassRoutes` and `bypassChinaDirect` were applied **regardless of the traffic policy** — only "exclude local networks" was gated by it. A profile displaying **All traffic** could be keeping whole countries off the tunnel, and nothing on screen said so. After #81 landed there were four controls answering one question, none of them agreeing about who was in charge.

## What this does

**One value.** `RoutingConfiguration` carries the mode (`allTraffic` / `bypassRules`), the bypass rules (local networks, Chinese addresses, custom routes), and the rule list text. The settings screen and the tunnel both compose through it, so the screen previews exactly what gets installed instead of reimplementing the combination. Switching to global routing leaves the rules stored rather than making you dismantle a list to turn the tunnel up.

**Live editing.** The app saves to the catalog, then sends `reload-routing` over the NetworkExtension channel — which previously ignored its input and answered every message with metrics. The provider reinstalls the interface description and hands the new rule list to the core via `setRoutingRules`. Startup also no longer reads routing out of the saved `providerConfiguration` in preference to the stored record, which was the second reason a change needed a reconnect. The stored record is now the only source.

## Two things to look at closely

**1. This reverses a decision from #81.** That PR argued rules need the tunnel down, because a flow keeps the rules it was opened under and re-pointing a running tunnel leaves live flows decided by a list the user can no longer see. That concern is still true and is the cost of this change: flows already open keep their decision, only later flows follow the new list. I made the trade because being unable to fix a rule without dropping the connection is the larger problem — but it is a trade, and the UI footer now says so. Easy to re-gate if you disagree.

**2. A data-loss bug this nearly caused.** This branch hand-writes `CodingKeys` and `encode(to:)` on `StoredProfile` so the derived legacy field is always written. #81 added `routingRules` while that was in flight, and it was in neither — saving a profile would have silently discarded the entire rule list. Now wired into both, with a test.

## Migration

The catalog `version` is checked for strict equality, so bumping it would reject every existing catalog. Instead the new fields decode with fallbacks, and anything that *was* carving traffic out of the tunnel — old policy, china toggle, or a non-empty route list — loads as `bypassRules`. An upgrade never silently pushes an excluded destination back through the tunnel. `trafficPolicy` is still written, derived from the rules, so a downgrade doesn't fail to decode and take every enrolled profile with it.

## Testing

97 tests pass, 10 of them new and aimed at the states the old shape allowed and this one must not:

```
RoutingConfigurationTests testGlobalModeInstallsNothingEvenWithEveryRuleSwitchedOn   passed
RoutingConfigurationTests testBypassModeAppliesLocalNetworksOnlyWhenThatRuleIsOn      passed
RoutingConfigurationTests testBypassModeAppliesTheCountrySetOnlyWhenThatRuleIsOn      passed
BypassRoutesTests testALegacyGlobalPolicyStillHonoursRulesThatUsedToApplyRegardless   passed
BypassRoutesTests testTheLegacyPolicyFieldIsStillWrittenForOlderBuilds                passed
```

SwiftLint clean.

**Not verified on hardware.** The plumbing compiles, the message protocol round-trips, and the composition is correct under test — but that `setTunnelNetworkSettings` on a live provider re-plumbs routes as expected on a real device is untested. The paired iPhone dropped off USB partway through. Worth confirming before trusting the on-the-fly path.

## Not addressed

Android has its own `TrafficPolicy.java` and is untouched, so the platforms now diverge. Switching *which profile* a tunnel uses still requires disconnecting — that swaps the device identity, not a route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrdUWiiXiUbF8ALBT625Lh
