### PR TITLE
docs: a service manager redirect is a second log that nothing rotates

### DIFF
--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -271,3 +271,13 @@ Rotation is internal and does not require `logrotate`, a SIGHUP, or reopening
 the process. Do not configure an external rotator to rename the same files.
 The process fails startup rather than silently running without its configured
 file when the directory cannot be created or the file cannot be opened.
+
+Do not capture stdout or stderr to a file from the service manager either. A
+LaunchAgent `StandardOutPath` or `StandardErrorPath`, or a systemd
+`StandardOutput=file:`, stores a second copy of every line somewhere nothing
+rotates, so it grows without bound while the rotating log beside it stays
+within its five backups. Mirroring to a journal is not the same thing:
+journald applies its own retention, which is why the generated systemd unit
+leaves stderr on, while the generated LaunchAgent has no journal to write to
+and passes `--log-stderr=false` instead. A unit hand-written before that
+should drop the redirect, pass `--log-stderr=false`, or both.


### PR DESCRIPTION
A `StandardOutPath` in a hand-written LaunchAgent had quietly accumulated a
1.47 GB copy of a client log that was otherwise rotating correctly at its
32 MiB / five-backup default. The runtime log was fine; the redirect beside it
was the unbounded one.

`LOGGING.md` already carries the two facts that explain this — stderr is a
second copy, and `--log-stderr` controls it — and it already warns against
pointing an external rotator at the same files. It never says not to capture
stdout or stderr to a file from the unit itself, which is the sibling mistake
and the worse one, since an external rotator at least rotates.

This adds that paragraph to **Service operation**, next to the rotator warning.

It also records why the two generated units differ, which otherwise reads as
an oversight: `renderLaunchAgent` appends `--log-stderr=false` because a
LaunchAgent has no journal to write to, while `renderSystemdUnit` leaves
stderr on because journald applies its own retention. Mirroring to a journal
is not the failure; redirecting to a plain file is.

## Changelog

- [ ] Added a `changelog.d/<slug>.<category>.md` entry for the user-visible
      change in this pull request.
- [x] Or: this change is not user-visible (refactor, test, internal docs).

## Checks

`./scripts/changelog.py check` passes and `CHANGELOG.md` is untouched. Docs
only — no Go files changed, so the Go checks are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq6N6ScSuGSimLN7kEjUDH