### PR TITLE
feat(portmux): reactive UDP port hopping, fixed to actually hop

### DIFF
--- a/changelog.d/port-hopping-mux-bypass.fixed.md
+++ b/changelog.d/port-hopping-mux-bypass.fixed.md
@@ -1,0 +1,11 @@
+Port hopping actually hops now. The client and server port muxes implemented
+quic-go's OOB socket interface, so quic-go bypassed them with recvmmsg on the
+raw file descriptor: the server never read hop-port sockets at all, and the
+client never rewrote reply addresses nor counted receives, which also made
+the loss detector hop on phantom evidence. Both muxes now use the plain
+packet path they can control. The client also walks the hop pool in a
+shuffled order that persists across dials — previously every dial restarted
+on the primary port and could hop only once before the dial timeout, so 98
+of the 100 configured ports were never tried — and the detector waits for a
+full measurement window before firing instead of hopping seconds after
+connect.

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -508,6 +508,7 @@ type runtimeOptions struct {
 	aggregateBytesPerSec, interactiveReserveBytesPerSec         uint64
 	fallbackDelay, fallbackGrace, udpCooldown                   time.Duration
 	udpFailureThreshold                                         int
+	hopPortCount                                                int
 	allowPrivate                                                bool
 	logLevel, logFile, logFormat                                string
 	jsonLogs                                                    bool
@@ -538,6 +539,7 @@ func bindRuntimeFlags(fs *flag.FlagSet, opts *runtimeOptions, client bool) {
 	fs.StringVar(&opts.transport, "transport", string(pep.TransportAuto), "transport: auto, quic, or tcp")
 	fs.IntVar(&opts.tcpFallbackLanes, "tcp-fallback-lanes", 0, "TCP lanes per bulk flow (0 uses role default)")
 	fs.BoolVar(&opts.udpOnStream, "udp-on-stream", false, "carry UDP packets on streams instead of QUIC datagrams")
+	fs.IntVar(&opts.hopPortCount, "hop-port-count", 0, "number of UDP ports to listen on for port hopping (0/1 = disabled)")
 	fs.StringVar(&opts.congestion, "congestion", string(pep.CongestionErasure), "QUIC congestion controller")
 	fs.Uint64Var(&opts.brutalBytesPerSec, "brutal-bytes-per-sec", 0, "Brutal fixed byte rate")
 	fs.Uint64Var(&opts.adaptiveMinBytesSec, "adaptive-min-bytes-per-sec", 64*1024, "Adaptive minimum byte rate")
@@ -794,6 +796,7 @@ func runServer(args []string) (returnErr error) {
 		AdaptiveMinBytesSec: opts.adaptiveMinBytesSec, AdaptiveMaxBytesSec: opts.adaptiveMaxBytesSec,
 		AggregateBytesPerSec: opts.aggregateBytesPerSec, InteractiveReserveBytesPerSec: opts.interactiveReserveBytesPerSec,
 		Logger: logger, UDPOnStream: opts.udpOnStream, Profile: serverProfile,
+		HopPortCount: opts.hopPortCount,
 	})
 	if err != nil {
 		return err

--- a/cmd/queqiaod/providers.go
+++ b/cmd/queqiaod/providers.go
@@ -202,6 +202,7 @@ func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtim
 		Budget:             budget,
 		FallbackDelay:      opts.fallbackDelay, FallbackGrace: opts.fallbackGrace,
 		UDPFailureThreshold: opts.udpFailureThreshold, UDPCooldown: opts.udpCooldown,
+		HopPortCount: profile.HopPortCount,
 		Metrics: registry, Logger: logger,
 	})
 }

--- a/internal/identity/profile.go
+++ b/internal/identity/profile.go
@@ -52,6 +52,11 @@ type ClientProfile struct {
 	DeviceCertificate string `json:"device_certificate_pem"`
 	DevicePrivateKey  string `json:"device_private_key_pem"`
 	CreatedAt         string `json:"created_at"`
+	// HopPortCount enables UDP port hopping to evade per-port GFW blocking.
+	// 0 and 1 both mean disabled (single port). Values ≥ 2 cause the client
+	// to maintain a list of that many ports and hop among them reactively when
+	// sustained packet loss is detected on the current port.
+	HopPortCount int `json:"hop_port_count,omitempty"`
 }
 
 func (p *Provider) CreateInvitation(account string, ttl time.Duration, now time.Time) (string, Invitation, error) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -41,6 +41,7 @@ type Registry struct {
 	udpRescueFailures      atomic.Uint64
 	completionTimeouts     atomic.Uint64
 	flowTimeouts           atomic.Uint64
+	portHops               atomic.Uint64
 	// The authorization counters below describe the gateway's own state
 	// rather than any flow. A store that cannot be re-read leaves the last
 	// snapshot in force, which keeps established devices connecting while
@@ -276,6 +277,7 @@ type Snapshot struct {
 	UDPAssociationReconnects, UDPAssociationRescueFailures        uint64
 	CompletionTimeouts                                            uint64
 	FlowTimeouts                                                  uint64
+	PortHops                                                      uint64
 	AuthorizationRefreshFailures, AuthorizationReloads            uint64
 	AuthorizationConsecutiveRefreshFailures                       uint64
 	AuthorizationLastGoodUnix                                     int64
@@ -563,6 +565,7 @@ func (r *Registry) PeerProtocolViolation() { r.peerProtocolViolations.Add(1) }
 
 func (r *Registry) CompletionTimeout() { r.completionTimeouts.Add(1) }
 func (r *Registry) FlowTimeout()       { r.flowTimeouts.Add(1) }
+func (r *Registry) PortHop()           { r.portHops.Add(1) }
 
 // AuthorizationRefreshFailed records one failed attempt to re-read the
 // authorization store, carrying how many have now failed in a row so a chronic
@@ -650,6 +653,7 @@ func (r *Registry) Snapshot() Snapshot {
 		UDPAssociationRescueFailures:            r.udpRescueFailures.Load(),
 		CompletionTimeouts:                      r.completionTimeouts.Load(),
 		FlowTimeouts:                            r.flowTimeouts.Load(),
+		PortHops:                                r.portHops.Load(),
 		AuthorizationRefreshFailures:            r.authorizationRefreshFailures.Load(),
 		AuthorizationReloads:                    r.authorizationReloads.Load(),
 		AuthorizationConsecutiveRefreshFailures: r.authorizationConsecutiveFailures.Load(),
@@ -832,6 +836,7 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "queqiao_udp_association_rescue_failures_total %d\n", s.UDPAssociationRescueFailures)
 	fmt.Fprintf(w, "queqiao_completion_timeouts_total %d\n", s.CompletionTimeouts)
 	fmt.Fprintf(w, "queqiao_flow_timeouts_total %d\n", s.FlowTimeouts)
+	fmt.Fprintf(w, "queqiao_port_hops_total %d\n", s.PortHops)
 	// A non-zero consecutive count means the gateway is enforcing a snapshot
 	// it can no longer re-read: established devices keep working while every
 	// enrollment fails. Alert on the consecutive count, and use

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -184,7 +184,12 @@ type ClientConfig struct {
 	FallbackGrace       time.Duration
 	UDPFailureThreshold int
 	UDPCooldown         time.Duration
-	Logger              *slog.Logger
+	// HopPortCount enables reactive UDP port hopping to evade per-port GFW
+	// blocking. 0 and 1 both mean disabled. Values ≥ 2 cause the client to
+	// maintain a pool of that many ports derived from the provider ID and hop
+	// reactively when sustained zero-receive loss is detected.
+	HopPortCount int
+	Logger       *slog.Logger
 }
 
 type Client struct {
@@ -1122,6 +1127,21 @@ func (c *Client) observeUDPPath(evidence quicPathEvidence, quicErr error) {
 
 const transientUDPSendLogInterval = 5 * time.Second
 
+// hopDialConfig builds the port-hopping configuration for this client's QUIC
+// dials from ClientConfig. A zero HopPortCount returns a zero hopDialConfig,
+// which disables port hopping in dialQUICConnection.
+func (c *Client) hopDialConfig() hopDialConfig {
+	if c.cfg.HopPortCount < 2 {
+		return hopDialConfig{}
+	}
+	return hopDialConfig{
+		portCount:  c.cfg.HopPortCount,
+		providerID: c.cfg.Credentials.ProviderID,
+		metrics:    c.cfg.Metrics,
+		logger:     c.cfg.Logger,
+	}
+}
+
 func (c *Client) observeTransientUDPSendFailure(err error) {
 	if c.metrics != nil {
 		c.metrics.TransientUDPSendError()
@@ -1365,7 +1385,7 @@ func (c *Client) dialLaneMode(ctx context.Context, kind TransportKind, sessionID
 			outer, err = c.dialPooledQUICLane(ctx, ccfg)
 			reserveControl = true
 		} else {
-			outer, err = dialQUIC(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, ccfg, c.windows())
+			outer, err = dialQUIC(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, ccfg, c.windows(), c.hopDialConfig())
 		}
 	default:
 		return nil, fmt.Errorf("cannot dial transport %q", kind)
@@ -1467,7 +1487,7 @@ func (c *Client) acquireControlQUICGeneration(ctx context.Context, ccfg congesti
 }
 
 func (c *Client) runControlQUICDial(ctx context.Context, attempt *controlQUICDial, ccfg congestionConfig) {
-	conn, packet, err := dialQUICConnection(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, c.windows())
+	conn, packet, err := dialQUICConnection(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, c.windows(), c.hopDialConfig())
 	var generation *controlQUICGeneration
 	if err == nil {
 		generation = &controlQUICGeneration{
@@ -1734,7 +1754,7 @@ func (c *Client) bulkConnCount() int {
 
 func (c *Client) dialBulkConn(ctx context.Context) (*bulkConn, error) {
 	started := time.Now()
-	conn, packet, err := dialQUICConnection(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, c.windows())
+	conn, packet, err := dialQUICConnection(ctx, c.cfg.RemoteAddr, c.currentCredentials(), c.cfg.DialTimeout, c.cfg.LocalAddress, c.cfg.SocketControl, c.observeTransientUDPSendFailure, c.windows(), c.hopDialConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bojieli/queqiao/internal/limiter"
 	"github.com/bojieli/queqiao/internal/memlimit"
 	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/portmux"
 	"github.com/bojieli/queqiao/internal/profile"
 	"github.com/bojieli/queqiao/internal/protocol"
 	"github.com/bojieli/queqiao/internal/session"
@@ -220,6 +221,10 @@ type Client struct {
 	// transientUDPLogNS rate-limits an otherwise synchronized burst of local
 	// route errors while still counting every suppressed send in metrics.
 	transientUDPLogNS atomic.Int64
+	// hopWalk is the client-wide hop port selection state, built lazily on
+	// the first hop-enabled dial so all dials share one walk.
+	hopWalkOnce sync.Once
+	hopWalk     *portmux.HopWalk
 	// openFlowForTest stands in for one flow-open attempt, so the retry policy
 	// can be tested without a network that loses things on demand.
 	openFlowForTest func() (*openedFlow, error)
@@ -1129,14 +1134,19 @@ const transientUDPSendLogInterval = 5 * time.Second
 
 // hopDialConfig builds the port-hopping configuration for this client's QUIC
 // dials from ClientConfig. A zero HopPortCount returns a zero hopDialConfig,
-// which disables port hopping in dialQUICConnection.
+// which disables port hopping in dialQUICConnection. All dials share one
+// HopWalk so port selection persists across connection attempts.
 func (c *Client) hopDialConfig() hopDialConfig {
 	if c.cfg.HopPortCount < 2 {
 		return hopDialConfig{}
 	}
+	c.hopWalkOnce.Do(func() {
+		c.hopWalk = portmux.NewHopWalk(c.cfg.HopPortCount)
+	})
 	return hopDialConfig{
 		portCount:  c.cfg.HopPortCount,
 		providerID: c.cfg.Credentials.ProviderID,
+		walk:       c.hopWalk,
 		metrics:    c.cfg.Metrics,
 		logger:     c.cfg.Logger,
 	}

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bojieli/queqiao/internal/identity"
 	"github.com/bojieli/queqiao/internal/limiter"
 	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/portmux"
 	"github.com/bojieli/queqiao/internal/profile"
 	"github.com/bojieli/queqiao/internal/protocol"
 	"github.com/bojieli/queqiao/internal/session"
@@ -67,6 +68,13 @@ type ServerConfig struct {
 	// it is a measurement control, and both endpoints must agree for the
 	// comparison to mean anything.
 	UDPOnStream bool
+	// HopPortCount enables the server to accept QUIC connections on multiple
+	// UDP ports simultaneously. It must match the client's hop_port_count in
+	// the profile. 0 and 1 both disable port hopping. Values ≥ 2 cause the
+	// server to listen on that many ports derived from the provider ID and
+	// route responses back through whichever port each client most recently
+	// used.
+	HopPortCount int
 	// testLaneWriteHook is intentionally unexported and nil in production. It
 	// lets package integration tests reproduce loss of a specific logical
 	// frame without depending on encrypted QUIC packet layout.
@@ -477,11 +485,36 @@ func (s *Server) handleTCP(ctx context.Context, conn *tls.Conn) {
 }
 
 func (s *Server) serveQUIC(ctx context.Context) error {
-	packetConn, err := net.ListenPacket("udp", s.cfg.ListenAddr)
+	if s.cfg.HopPortCount < 2 {
+		// Fast path: single port, no mux overhead.
+		packetConn, err := net.ListenPacket("udp", s.cfg.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen on remote QUIC address: %w", err)
+		}
+		return s.ServePacketConn(ctx, packetConn)
+	}
+
+	// Port-hopping path: bind the primary socket, derive the port list, then
+	// open secondary sockets and hand everything to a ServerPortMux.
+	listenAddr, err := net.ResolveUDPAddr("udp", s.cfg.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("resolve QUIC listen address: %w", err)
+	}
+	primaryConn, err := net.ListenUDP("udp", listenAddr)
 	if err != nil {
 		return fmt.Errorf("listen on remote QUIC address: %w", err)
 	}
-	return s.ServePacketConn(ctx, packetConn)
+	primaryPort := primaryConn.LocalAddr().(*net.UDPAddr).Port
+	ports := portmux.HopPorts(s.cfg.Credentials.ProviderID, primaryPort, s.cfg.HopPortCount)
+	mux, err := portmux.NewServerPortMux(primaryConn, ports)
+	if err != nil {
+		_ = primaryConn.Close()
+		return fmt.Errorf("create server port mux: %w", err)
+	}
+	s.cfg.Logger.Info("port hop listener ready",
+		"primary_addr", primaryConn.LocalAddr(),
+		"hop_port_count", len(ports))
+	return s.ServePacketConn(ctx, mux)
 }
 
 // ServePacketConn runs the QUIC listener on an already-bound UDP socket.

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -104,8 +104,12 @@ type udpHealth struct {
 type hopDialConfig struct {
 	portCount  int    // 0 or 1 = disabled; ≥2 = enabled
 	providerID string // for deterministic HopPorts derivation
-	metrics    *metrics.Registry
-	logger     *slog.Logger
+	// walk is the client-wide port selection state, shared by all dials so
+	// each attempt continues where the previous one left off instead of
+	// restarting on the primary port.
+	walk    *portmux.HopWalk
+	metrics *metrics.Registry
+	logger  *slog.Logger
 }
 
 // quicPathEvidence is deliberately narrower than "a QUIC operation ended".
@@ -761,7 +765,18 @@ func dialQUICConnection(ctx context.Context, remote string, credentials identity
 		rawUDP := packetConn.(*net.UDPConn)
 		ports := portmux.HopPorts(hop.providerID, remoteAddr.Port, hop.portCount)
 		mux := portmux.NewClientPortMux(rawUDP, remoteAddr, ports)
+		if hop.walk != nil {
+			// Start the dial on the next walked port rather than the
+			// primary: the primary is the port a blocker watches, and
+			// restarting there every dial strands the pool's other ports.
+			idx := hop.walk.Next()
+			from, to := mux.Hop(idx)
+			if hop.logger != nil {
+				hop.logger.Debug("QUIC dial starting on walked hop port", "from_port", from, "to_port", to)
+			}
+		}
 		ctrl := portmux.NewHopController(mux, portmux.HopConfig{
+			Walk:    hop.walk,
 			Metrics: hop.metrics,
 			Logger:  hop.logger,
 		})

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -16,8 +17,10 @@ import (
 	"github.com/bojieli/queqiao/internal/coded"
 	wancongestion "github.com/bojieli/queqiao/internal/congestion"
 	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/metrics"
 	"github.com/bojieli/queqiao/internal/netbind"
 	"github.com/bojieli/queqiao/internal/pathmodel"
+	"github.com/bojieli/queqiao/internal/portmux"
 	"github.com/bojieli/queqiao/internal/protocol"
 )
 
@@ -94,6 +97,15 @@ type udpHealth struct {
 	threshold int
 	cooldown  time.Duration
 	blockedTo time.Time
+}
+
+// hopDialConfig carries port-hopping configuration for dialQUICConnection.
+// A zero value disables port hopping.
+type hopDialConfig struct {
+	portCount  int    // 0 or 1 = disabled; ≥2 = enabled
+	providerID string // for deterministic HopPorts derivation
+	metrics    *metrics.Registry
+	logger     *slog.Logger
 }
 
 // quicPathEvidence is deliberately narrower than "a QUIC operation ended".
@@ -581,8 +593,8 @@ func quicConfig(windows flowWindows) *quic.Config {
 	}
 }
 
-func dialQUIC(ctx context.Context, remote string, credentials identity.ClientCredentials, dialTimeout time.Duration, localAddress string, control func(string, string, syscall.RawConn) error, observeTransientWrite func(error), ccfg congestionConfig, windows flowWindows) (streamConn, error) {
-	conn, packetConn, err := dialQUICConnection(ctx, remote, credentials, dialTimeout, localAddress, control, observeTransientWrite, windows)
+func dialQUIC(ctx context.Context, remote string, credentials identity.ClientCredentials, dialTimeout time.Duration, localAddress string, control func(string, string, syscall.RawConn) error, observeTransientWrite func(error), ccfg congestionConfig, windows flowWindows, hop hopDialConfig) (streamConn, error) {
+	conn, packetConn, err := dialQUICConnection(ctx, remote, credentials, dialTimeout, localAddress, control, observeTransientWrite, windows, hop)
 	if err != nil {
 		return nil, err
 	}
@@ -706,7 +718,13 @@ func transientRouteWriteError(err error) bool {
 // dialQUICConnection establishes only the QUIC connection. Keeping this
 // separate from stream creation allows the client to pool one connection and
 // open a stream for each logical flow without paying another handshake.
-func dialQUICConnection(ctx context.Context, remote string, credentials identity.ClientCredentials, dialTimeout time.Duration, localAddress string, control func(string, string, syscall.RawConn) error, observeTransientWrite func(error), windows flowWindows) (*quic.Conn, net.PacketConn, error) {
+//
+// When hop.portCount ≥ 2, the raw UDP socket is wrapped in a ClientPortMux
+// before being handed to quic-go, and a HopController goroutine is started to
+// monitor for the per-port blocking pattern caused by GFW and trigger port
+// hops reactively. The mux's context is cancelled when the PacketConn is
+// closed, which stops the goroutine.
+func dialQUICConnection(ctx context.Context, remote string, credentials identity.ClientCredentials, dialTimeout time.Duration, localAddress string, control func(string, string, syscall.RawConn) error, observeTransientWrite func(error), windows flowWindows, hop hopDialConfig) (*quic.Conn, net.PacketConn, error) {
 	dialCtx := ctx
 	var cancel context.CancelFunc
 	if dialTimeout > 0 {
@@ -734,6 +752,21 @@ func dialQUICConnection(ctx context.Context, remote string, credentials identity
 	packetConn, err := (&net.ListenConfig{Control: composed}).ListenPacket(dialCtx, "udp", listenAddress)
 	if err != nil {
 		return nil, nil, err
+	}
+	if hop.portCount >= 2 {
+		// Wrap the raw UDP socket with bidirectional port rewriting. The mux
+		// is transparent to quic-go: outgoing packets are redirected to the
+		// active hop port and incoming packets appear to originate from the
+		// primary port.
+		rawUDP := packetConn.(*net.UDPConn)
+		ports := portmux.HopPorts(hop.providerID, remoteAddr.Port, hop.portCount)
+		mux := portmux.NewClientPortMux(rawUDP, remoteAddr, ports)
+		ctrl := portmux.NewHopController(mux, portmux.HopConfig{
+			Metrics: hop.metrics,
+			Logger:  hop.logger,
+		})
+		go ctrl.Run(mux.Context())
+		packetConn = mux
 	}
 	packetConn = tolerateTransientRouteErrors(packetConn, observeTransientWrite)
 	conn, err := quic.Dial(dialCtx, packetConn, remoteAddr, tlsCfg, quicConfig(windows))

--- a/internal/portmux/hop.go
+++ b/internal/portmux/hop.go
@@ -3,8 +3,46 @@ package portmux
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
+	"sync"
 	"time"
 )
+
+// HopWalk is the client-wide port-walking state shared by every dial. Each
+// new dial and each reactive hop consumes the next index from a shuffled
+// permutation of the hop port list, so successive dials neither restart on
+// the (typically burned) primary port nor repeat one another, and ports are
+// tried in an order an observer cannot predict from the derivation hash.
+type HopWalk struct {
+	mu    sync.Mutex
+	order []int
+	pos   int
+}
+
+// NewHopWalk returns a walk over the port-list indices [0, count) in a
+// freshly shuffled order.
+func NewHopWalk(count int) *HopWalk {
+	order := make([]int, count)
+	for i := range order {
+		order[i] = i
+	}
+	rand.Shuffle(count, func(i, j int) { order[i], order[j] = order[j], order[i] })
+	return &HopWalk{order: order}
+}
+
+// Next returns the next port-list index to try, reshuffling whenever the
+// current permutation is exhausted so no long-term order is observable.
+func (w *HopWalk) Next() int32 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.pos >= len(w.order) {
+		rand.Shuffle(len(w.order), func(i, j int) { w.order[i], w.order[j] = w.order[j], w.order[i] })
+		w.pos = 0
+	}
+	idx := w.order[w.pos]
+	w.pos++
+	return int32(idx)
+}
 
 // HopMetrics is the narrow interface the HopController needs from the metrics
 // registry. Using an interface avoids a direct import of the metrics package
@@ -16,21 +54,27 @@ type HopMetrics interface {
 // HopConfig controls the loss-detection and cooldown behaviour.
 type HopConfig struct {
 	// DetectWindow is how long a zero-receive window must persist before a
-	// hop is triggered. Default 10 s. The GFW blocking window is measured at
-	// 10+ minutes, so any value from 5–15 s balances false-positive risk
-	// (congestion) against detection latency.
+	// hop is triggered. Default 4 s: short enough that a 10 s dial timeout
+	// still allows several hops per dial, long enough that a slow but
+	// working path (which keeps receiving) never trips it.
 	DetectWindow time.Duration
 	// MinSent is the minimum number of packets that must have been sent in the
 	// detect window before loss is considered actionable. A quiet connection
 	// should not hop just because it sent nothing and received nothing.
 	MinSent uint64
-	// Cooldown is the minimum interval between successive hops. Default 15 s.
-	// This prevents thrashing when all ports are blocked.
+	// Cooldown is the minimum interval between successive hops. Default 3 s.
+	// It must stay well below the QUIC dial timeout so one dial can walk
+	// several ports; it also bounds thrash when every port is blocked.
 	Cooldown time.Duration
 	// PollInterval is how often the controller samples the counters.
 	// Default 2 s. Lower values improve detection latency at the cost of
 	// slightly more CPU; values below 1 s are clamped to 1 s.
 	PollInterval time.Duration
+	// Walk selects which port to hop to. It is shared across all dials of a
+	// client so port choices accumulate across connection attempts instead
+	// of restarting at the primary port every dial. Nil installs a private
+	// shuffled walk (used by tests).
+	Walk *HopWalk
 
 	Metrics HopMetrics
 	Logger  *slog.Logger
@@ -39,13 +83,13 @@ type HopConfig struct {
 func (c *HopConfig) resolved() HopConfig {
 	r := *c
 	if r.DetectWindow <= 0 {
-		r.DetectWindow = 10 * time.Second
+		r.DetectWindow = 4 * time.Second
 	}
 	if r.MinSent == 0 {
 		r.MinSent = 5
 	}
 	if r.Cooldown <= 0 {
-		r.Cooldown = 15 * time.Second
+		r.Cooldown = 3 * time.Second
 	}
 	if r.PollInterval <= 0 {
 		r.PollInterval = 2 * time.Second
@@ -70,28 +114,27 @@ func (c *HopConfig) resolved() HopConfig {
 // harmless (the new port shares the same bottleneck) but the guard keeps churn
 // low on paths that are merely slow.
 //
-// Cooldown: successive hops are separated by at least Cooldown. If all ports
-// are exhausted the controller wraps around; the number of ports (typically
-// 100) makes wrap-around negligible.
+// Cooldown: successive hops are separated by at least Cooldown. Ports are
+// chosen from the shared HopWalk (shuffled, persistent across dials), so the
+// pool is walked in random order rather than scanned predictably from the
+// primary port.
 type HopController struct {
 	mux  *ClientPortMux
 	cfg  HopConfig
-	// nextIdx is the next port index to try; wraps modulo len(ports).
-	nextIdx int32
+	walk *HopWalk
 }
 
 // NewHopController creates a controller for mux using cfg.
 func NewHopController(mux *ClientPortMux, cfg HopConfig) *HopController {
 	cfg = cfg.resolved()
-	// Start at index 1 (skip the primary, which is index 0).
-	var startIdx int32
-	if len(mux.ports) > 1 {
-		startIdx = 1
+	walk := cfg.Walk
+	if walk == nil {
+		walk = NewHopWalk(len(mux.ports))
 	}
 	return &HopController{
-		mux:     mux,
-		cfg:     cfg,
-		nextIdx: startIdx,
+		mux:  mux,
+		cfg:  cfg,
+		walk: walk,
 	}
 }
 
@@ -113,6 +156,10 @@ func (h *HopController) Run(ctx context.Context) {
 	}
 	ring := make([]sample, samplesPerWindow)
 	ringPos := 0
+	// filled counts recorded samples up to a full window. Triggering on a
+	// partially filled window hops on as little as one poll interval of
+	// evidence, which made every fresh dial hop almost immediately.
+	filled := 0
 
 	var (
 		lastSend uint64
@@ -141,6 +188,9 @@ func (h *HopController) Run(ctx context.Context) {
 		lastSend = sent
 		lastRecv = recv
 		ringPos = (ringPos + 1) % samplesPerWindow
+		if filled < samplesPerWindow {
+			filled++
+		}
 
 		// Sum the entire window.
 		var windowSent, windowRecv uint64
@@ -149,8 +199,9 @@ func (h *HopController) Run(ctx context.Context) {
 			windowRecv += s.recv
 		}
 
-		// Trigger condition: we are actively sending but receiving nothing.
-		if windowSent < cfg.MinSent || windowRecv > 0 {
+		// Trigger condition: a full window of actively sending but receiving
+		// nothing.
+		if filled < samplesPerWindow || windowSent < cfg.MinSent || windowRecv > 0 {
 			continue
 		}
 
@@ -160,17 +211,15 @@ func (h *HopController) Run(ctx context.Context) {
 			continue
 		}
 
-		// Choose the next port index, wrapping around the list.
-		ports := h.mux.ports
-		if len(ports) <= 1 {
+		if len(h.mux.ports) <= 1 {
 			continue // no alternative ports
 		}
-		// Advance to the next index, skipping the current one.
-		idx := h.nextIdx
-		if idx >= int32(len(ports)) {
-			idx = 1 // wrap, skipping primary at index 0
+		// Draw until the walk offers a different port: hopping "to" the port
+		// already in use wastes a cooldown on no change.
+		idx := h.walk.Next()
+		for idx == h.mux.CurrentIndex() {
+			idx = h.walk.Next()
 		}
-		h.nextIdx = idx + 1
 
 		fromPort, toPort := h.mux.Hop(idx)
 		lastHop = now
@@ -179,6 +228,7 @@ func (h *HopController) Run(ctx context.Context) {
 		for i := range ring {
 			ring[i] = sample{}
 		}
+		filled = 0
 
 		if cfg.Metrics != nil {
 			cfg.Metrics.PortHop()

--- a/internal/portmux/hop.go
+++ b/internal/portmux/hop.go
@@ -1,0 +1,190 @@
+package portmux
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// HopMetrics is the narrow interface the HopController needs from the metrics
+// registry. Using an interface avoids a direct import of the metrics package
+// from portmux and keeps the dependency graph clean.
+type HopMetrics interface {
+	PortHop()
+}
+
+// HopConfig controls the loss-detection and cooldown behaviour.
+type HopConfig struct {
+	// DetectWindow is how long a zero-receive window must persist before a
+	// hop is triggered. Default 10 s. The GFW blocking window is measured at
+	// 10+ minutes, so any value from 5–15 s balances false-positive risk
+	// (congestion) against detection latency.
+	DetectWindow time.Duration
+	// MinSent is the minimum number of packets that must have been sent in the
+	// detect window before loss is considered actionable. A quiet connection
+	// should not hop just because it sent nothing and received nothing.
+	MinSent uint64
+	// Cooldown is the minimum interval between successive hops. Default 15 s.
+	// This prevents thrashing when all ports are blocked.
+	Cooldown time.Duration
+	// PollInterval is how often the controller samples the counters.
+	// Default 2 s. Lower values improve detection latency at the cost of
+	// slightly more CPU; values below 1 s are clamped to 1 s.
+	PollInterval time.Duration
+
+	Metrics HopMetrics
+	Logger  *slog.Logger
+}
+
+func (c *HopConfig) resolved() HopConfig {
+	r := *c
+	if r.DetectWindow <= 0 {
+		r.DetectWindow = 10 * time.Second
+	}
+	if r.MinSent == 0 {
+		r.MinSent = 5
+	}
+	if r.Cooldown <= 0 {
+		r.Cooldown = 15 * time.Second
+	}
+	if r.PollInterval <= 0 {
+		r.PollInterval = 2 * time.Second
+	}
+	if r.PollInterval < time.Second {
+		r.PollInterval = time.Second
+	}
+	return r
+}
+
+// HopController monitors the send/receive ratio on a ClientPortMux and
+// triggers a port hop when it detects the characteristic zero-receive pattern
+// caused by per-port GFW blocking.
+//
+// Detection logic: sample (sendCount, recvCount) every PollInterval. Maintain
+// a sliding window of duration DetectWindow. If totalSent > MinSent and
+// totalReceived == 0 over the window, trigger a hop.
+//
+// RTT guard: GFW blocking produces total loss; congestion produces partial
+// loss. The zero-receive threshold implicitly distinguishes them: even a path
+// with 99% congestion loss receives something. A hop under congestion is
+// harmless (the new port shares the same bottleneck) but the guard keeps churn
+// low on paths that are merely slow.
+//
+// Cooldown: successive hops are separated by at least Cooldown. If all ports
+// are exhausted the controller wraps around; the number of ports (typically
+// 100) makes wrap-around negligible.
+type HopController struct {
+	mux  *ClientPortMux
+	cfg  HopConfig
+	// nextIdx is the next port index to try; wraps modulo len(ports).
+	nextIdx int32
+}
+
+// NewHopController creates a controller for mux using cfg.
+func NewHopController(mux *ClientPortMux, cfg HopConfig) *HopController {
+	cfg = cfg.resolved()
+	// Start at index 1 (skip the primary, which is index 0).
+	var startIdx int32
+	if len(mux.ports) > 1 {
+		startIdx = 1
+	}
+	return &HopController{
+		mux:     mux,
+		cfg:     cfg,
+		nextIdx: startIdx,
+	}
+}
+
+// Run starts the monitoring loop. It returns when ctx is cancelled, which
+// happens when the associated ClientPortMux is closed.
+func (h *HopController) Run(ctx context.Context) {
+	cfg := h.cfg
+
+	// ringSize is the number of samples kept in the sliding window.
+	// Each sample covers PollInterval; the window is DetectWindow.
+	samplesPerWindow := int(cfg.DetectWindow / cfg.PollInterval)
+	if samplesPerWindow < 2 {
+		samplesPerWindow = 2
+	}
+
+	type sample struct {
+		sent uint64
+		recv uint64
+	}
+	ring := make([]sample, samplesPerWindow)
+	ringPos := 0
+
+	var (
+		lastSend uint64
+		lastRecv uint64
+		lastHop  time.Time
+	)
+
+	ticker := time.NewTicker(cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		sent := h.mux.sendCount.Load()
+		recv := h.mux.recvCount.Load()
+
+		// Record the delta since the last sample.
+		ring[ringPos] = sample{
+			sent: sent - lastSend,
+			recv: recv - lastRecv,
+		}
+		lastSend = sent
+		lastRecv = recv
+		ringPos = (ringPos + 1) % samplesPerWindow
+
+		// Sum the entire window.
+		var windowSent, windowRecv uint64
+		for _, s := range ring {
+			windowSent += s.sent
+			windowRecv += s.recv
+		}
+
+		// Trigger condition: we are actively sending but receiving nothing.
+		if windowSent < cfg.MinSent || windowRecv > 0 {
+			continue
+		}
+
+		// Respect cooldown: don't hop again too soon.
+		now := time.Now()
+		if !lastHop.IsZero() && now.Sub(lastHop) < cfg.Cooldown {
+			continue
+		}
+
+		// Choose the next port index, wrapping around the list.
+		ports := h.mux.ports
+		if len(ports) <= 1 {
+			continue // no alternative ports
+		}
+		// Advance to the next index, skipping the current one.
+		idx := h.nextIdx
+		if idx >= int32(len(ports)) {
+			idx = 1 // wrap, skipping primary at index 0
+		}
+		h.nextIdx = idx + 1
+
+		fromPort, toPort := h.mux.Hop(idx)
+		lastHop = now
+
+		// Reset the window so the new port gets a fresh evaluation.
+		for i := range ring {
+			ring[i] = sample{}
+		}
+
+		if cfg.Metrics != nil {
+			cfg.Metrics.PortHop()
+		}
+		if cfg.Logger != nil {
+			cfg.Logger.Info("port hop", "from_port", fromPort, "to_port", toPort)
+		}
+	}
+}

--- a/internal/portmux/portmux.go
+++ b/internal/portmux/portmux.go
@@ -1,0 +1,500 @@
+// Package portmux implements UDP port-hopping for QUIC connections.
+//
+// When the GFW or an ISP blocks a specific UDP port for a window of time,
+// the client detects the loss and hops to a different pre-agreed port.
+// The server listens on all ports simultaneously and treats packets from
+// any of those ports as belonging to the same QUIC connection. QUIC
+// identifies connections by connection ID, not by the 5-tuple, so the
+// server's QUIC stack never observes the port change.
+//
+// Port transparency is achieved by bidirectional address rewriting:
+//   - Outgoing (client → server): destination port rewritten primary → current hop port.
+//   - Incoming (server → client): source port rewritten any hop port → primary port.
+//
+// Neither connection migration nor reconnection occurs. The server simply
+// begins receiving QUIC packets on a new socket, and the QUIC connection ID
+// ensures they land on the right connection.
+package portmux
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// muxOOBSize is enough room for ECN / DSCP ancillary data on all platforms.
+const muxOOBSize = 128
+
+// HopPorts derives a reproducible, collision-free set of count UDP ports for
+// the given provider and primary port. The primary port is always first;
+// the remaining count−1 ports are pseudo-randomly distributed across
+// [1024, 65535) using SHA-256 so both client and server independently reach
+// the same list from the same inputs.
+//
+// The derivation key is providerID + NUL + "queqiao-hop-v1" + NUL + counter
+// encoded big-endian. Using SHA-256 rather than a simple modulus avoids
+// clustering ports in a blockable consecutive range.
+func HopPorts(providerID string, primaryPort, count int) []int {
+	if count <= 1 {
+		return []int{primaryPort}
+	}
+
+	// Pre-build the stable prefix of the hash input to avoid rebuilding it
+	// inside the loop.
+	prefix := make([]byte, 0, len(providerID)+17)
+	prefix = append(prefix, providerID...)
+	prefix = append(prefix, 0) // NUL separator
+	prefix = append(prefix, "queqiao-hop-v1"...)
+	prefix = append(prefix, 0) // NUL separator
+
+	seen := make(map[int]bool, count)
+	ports := make([]int, 0, count)
+	ports = append(ports, primaryPort)
+	seen[primaryPort] = true
+
+	var counter [4]byte
+	for i := 0; len(ports) < count; i++ {
+		binary.BigEndian.PutUint32(counter[:], uint32(i))
+		h := sha256.New()
+		h.Write(prefix)
+		h.Write(counter[:])
+		sum := h.Sum(nil)
+		// Map the first two bytes to [1024, 65535).
+		raw := binary.BigEndian.Uint16(sum[:2])
+		port := 1024 + int(raw)%(65535-1024)
+		if !seen[port] {
+			seen[port] = true
+			ports = append(ports, port)
+		}
+	}
+	return ports
+}
+
+// ClientPortMux wraps a single UDP socket with bidirectional port rewriting so
+// that port hops are invisible to quic-go. It implements net.PacketConn,
+// quic.OOBCapablePacketConn, and net.Conn so it composes cleanly with the
+// existing tolerateTransientRouteErrors wrapper.
+//
+// Thread safety: all exported methods are safe for concurrent use. Hop() is
+// the only writer of currentIdx and is called at most once per cooldown
+// window.
+type ClientPortMux struct {
+	conn        *net.UDPConn
+	primaryAddr *net.UDPAddr
+	ports       []int
+	currentIdx  atomic.Int32
+
+	// sendCount and recvCount are incremented on every outgoing / incoming
+	// datagram respectively. HopController samples them to detect zero-receive
+	// windows indicative of per-port GFW blocking.
+	sendCount atomic.Uint64
+	recvCount atomic.Uint64
+
+	// ctx/cancel signal the HopController goroutine to stop when the socket
+	// is closed.
+	ctx       context.Context
+	cancel    context.CancelFunc
+	closeOnce sync.Once
+}
+
+// NewClientPortMux creates a mux on conn. primaryAddr must match ports[0].
+// The mux starts on the primary port; call HopController.Run to begin loss
+// monitoring.
+func NewClientPortMux(conn *net.UDPConn, primaryAddr *net.UDPAddr, ports []int) *ClientPortMux {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ClientPortMux{
+		conn:        conn,
+		primaryAddr: primaryAddr,
+		ports:       ports,
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+// Context returns a context that is cancelled when Close is called.
+// HopController uses this to know when to stop its monitoring goroutine.
+func (m *ClientPortMux) Context() context.Context { return m.ctx }
+
+// Ports returns the full ordered port list. The caller must not modify it.
+func (m *ClientPortMux) Ports() []int { return m.ports }
+
+// PrimaryAddr returns the primary (quic-go-visible) peer address.
+func (m *ClientPortMux) PrimaryAddr() *net.UDPAddr { return m.primaryAddr }
+
+// CurrentPort returns the currently active hop port.
+func (m *ClientPortMux) CurrentPort() int {
+	return m.ports[m.currentIdx.Load()]
+}
+
+// Hop atomically switches to ports[idx], returning the old and new ports.
+// The caller (HopController) is responsible for bounds-checking idx.
+func (m *ClientPortMux) Hop(idx int32) (fromPort, toPort int) {
+	old := m.currentIdx.Swap(idx)
+	return m.ports[old], m.ports[idx]
+}
+
+// SendCount and RecvCount are the total datagram counts since the mux was
+// created. HopController takes snapshots to compute the rate over a window.
+func (m *ClientPortMux) SendCount() uint64 { return m.sendCount.Load() }
+func (m *ClientPortMux) RecvCount() uint64 { return m.recvCount.Load() }
+
+// hopTarget rewrites addr to target the current hop port when it matches the
+// primary address. It returns addr unchanged for any other destination.
+func (m *ClientPortMux) hopTarget(addr net.Addr) net.Addr {
+	u, ok := addr.(*net.UDPAddr)
+	if !ok {
+		return addr
+	}
+	hopPort := m.ports[m.currentIdx.Load()]
+	if u.Port == m.primaryAddr.Port && hopPort != m.primaryAddr.Port {
+		return &net.UDPAddr{IP: u.IP, Port: hopPort, Zone: u.Zone}
+	}
+	return addr
+}
+
+// normSrc rewrites the source address of an incoming packet from any hop port
+// back to the primary port so quic-go sees a stable peer address.
+func (m *ClientPortMux) normSrc(addr *net.UDPAddr) *net.UDPAddr {
+	if addr == nil || addr.Port == m.primaryAddr.Port {
+		return addr
+	}
+	if !addr.IP.Equal(m.primaryAddr.IP) {
+		return addr
+	}
+	// Linear scan is fine: port lists are small (≤100 elements).
+	for _, p := range m.ports {
+		if p == addr.Port {
+			return &net.UDPAddr{IP: addr.IP, Port: m.primaryAddr.Port, Zone: addr.Zone}
+		}
+	}
+	return addr
+}
+
+// — net.PacketConn —
+
+func (m *ClientPortMux) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, addr, err := m.conn.ReadFrom(b)
+	if err == nil {
+		m.recvCount.Add(1)
+		if u, ok := addr.(*net.UDPAddr); ok {
+			addr = m.normSrc(u)
+		}
+	}
+	return n, addr, err
+}
+
+func (m *ClientPortMux) WriteTo(b []byte, addr net.Addr) (int, error) {
+	m.sendCount.Add(1)
+	return m.conn.WriteTo(b, m.hopTarget(addr))
+}
+
+func (m *ClientPortMux) Close() error {
+	var err error
+	m.closeOnce.Do(func() {
+		m.cancel()
+		err = m.conn.Close()
+	})
+	return err
+}
+
+func (m *ClientPortMux) LocalAddr() net.Addr           { return m.conn.LocalAddr() }
+func (m *ClientPortMux) SetDeadline(t time.Time) error { return m.conn.SetDeadline(t) }
+func (m *ClientPortMux) SetReadDeadline(t time.Time) error {
+	return m.conn.SetReadDeadline(t)
+}
+func (m *ClientPortMux) SetWriteDeadline(t time.Time) error {
+	return m.conn.SetWriteDeadline(t)
+}
+
+// — net.Conn (required by transientRouteOOBPacketConn's type assertion) —
+
+func (m *ClientPortMux) Read(b []byte) (int, error)  { return m.conn.Read(b) }
+func (m *ClientPortMux) Write(b []byte) (int, error) { return m.conn.Write(b) }
+func (m *ClientPortMux) RemoteAddr() net.Addr        { return m.primaryAddr }
+
+// — quic.OOBCapablePacketConn (preserves ECN / GSO fast path) —
+
+func (m *ClientPortMux) SyscallConn() (syscall.RawConn, error) {
+	return m.conn.SyscallConn()
+}
+
+func (m *ClientPortMux) SetReadBuffer(bytes int) error {
+	return m.conn.SetReadBuffer(bytes)
+}
+
+func (m *ClientPortMux) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	n, oobn, flags, addr, err = m.conn.ReadMsgUDP(b, oob)
+	if err == nil {
+		m.recvCount.Add(1)
+		addr = m.normSrc(addr)
+	}
+	return n, oobn, flags, addr, err
+}
+
+func (m *ClientPortMux) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	m.sendCount.Add(1)
+	target := addr
+	if addr != nil {
+		hopPort := m.ports[m.currentIdx.Load()]
+		if addr.Port == m.primaryAddr.Port && hopPort != m.primaryAddr.Port {
+			target = &net.UDPAddr{IP: addr.IP, Port: hopPort, Zone: addr.Zone}
+		}
+	}
+	return m.conn.WriteMsgUDP(b, oob, target)
+}
+
+// — ServerPortMux —
+
+// serverPacket carries one UDP datagram received by any of the server's
+// listening sockets.
+type serverPacket struct {
+	data  []byte
+	oob   []byte // ECN / ancillary data; empty for non-primary sockets
+	flags int
+	src   *net.UDPAddr
+	conn  *net.UDPConn // socket the datagram arrived on
+}
+
+// ServerPortMux listens on N UDP ports simultaneously and presents them as a
+// single net.PacketConn to quic.Listen. It remembers which socket each client
+// address most recently used and routes responses back through that socket so
+// the client's address-rewriting stays consistent.
+//
+// Thread safety: all exported methods are safe for concurrent use.
+type ServerPortMux struct {
+	primary     *net.UDPConn
+	secondaries []*net.UDPConn
+	// incoming is the merged receive queue. It is sized large enough to absorb
+	// bursts across all sockets without a secondary blocking a primary read.
+	incoming  chan serverPacket
+	routes    sync.Map // string(client addr) → *net.UDPConn
+	done      chan struct{}
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+// NewServerPortMux binds additional sockets on ports[1:] on the same IP as
+// primary, starts per-socket reader goroutines, and returns the multiplexed
+// PacketConn. primary must already be bound to ports[0].
+//
+// On error, any successfully opened extra sockets are closed before returning.
+func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error) {
+	primaryAddr, ok := primary.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		return nil, fmt.Errorf("server portmux: primary socket has non-UDP local address")
+	}
+
+	secondaries := make([]*net.UDPConn, 0, len(ports)-1)
+	for _, port := range ports[1:] {
+		addr := &net.UDPAddr{IP: primaryAddr.IP, Port: port}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			for _, s := range secondaries {
+				_ = s.Close()
+			}
+			return nil, fmt.Errorf("server portmux: listen on hop port %d: %w", port, err)
+		}
+		secondaries = append(secondaries, conn)
+	}
+
+	// Buffer depth: 4096 slots shared across all sockets. At 1500 B/packet
+	// this is ~6 MB peak, bounded by the OS receive buffers in practice.
+	m := &ServerPortMux{
+		primary:     primary,
+		secondaries: secondaries,
+		incoming:    make(chan serverPacket, 4096),
+		done:        make(chan struct{}),
+	}
+
+	m.wg.Add(1)
+	go m.readPrimary()
+	for _, sec := range secondaries {
+		m.wg.Add(1)
+		go m.readSecondary(sec)
+	}
+
+	return m, nil
+}
+
+// readPrimary reads from the primary socket using ReadMsgUDP to capture ECN /
+// DSCP ancillary data. Packets are forwarded to the incoming channel together
+// with their OOB data so the upper layer receives full ECN information for
+// primary-socket traffic.
+func (m *ServerPortMux) readPrimary() {
+	defer m.wg.Done()
+	buf := make([]byte, 1500)
+	oob := make([]byte, muxOOBSize)
+	for {
+		n, oobn, flags, src, err := m.primary.ReadMsgUDP(buf, oob)
+		if err != nil {
+			return // socket closed
+		}
+		data := make([]byte, n)
+		copy(data, buf[:n])
+		oobCopy := make([]byte, oobn)
+		copy(oobCopy, oob[:oobn])
+		pkt := serverPacket{data: data, oob: oobCopy, flags: flags, src: src, conn: m.primary}
+		select {
+		case m.incoming <- pkt:
+		case <-m.done:
+			return
+		}
+	}
+}
+
+// readSecondary reads from a secondary socket using ReadFrom. OOB data is not
+// captured on secondary sockets, so ECN is not propagated for packets that
+// arrive on a hop port. This is an acceptable trade-off: secondary sockets
+// are used only after the client has hopped away from the primary port, and
+// the server's ECN feedback is less critical than correctness of routing.
+func (m *ServerPortMux) readSecondary(conn *net.UDPConn) {
+	defer m.wg.Done()
+	buf := make([]byte, 1500)
+	for {
+		n, addr, err := conn.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		src, _ := addr.(*net.UDPAddr)
+		data := make([]byte, n)
+		copy(data, buf[:n])
+		pkt := serverPacket{data: data, src: src, conn: conn}
+		select {
+		case m.incoming <- pkt:
+		case <-m.done:
+			return
+		}
+	}
+}
+
+// pickConn returns the socket most recently used by addr, falling back to the
+// primary socket if no mapping exists.
+func (m *ServerPortMux) pickConn(addr *net.UDPAddr) *net.UDPConn {
+	if v, ok := m.routes.Load(addr.String()); ok {
+		return v.(*net.UDPConn)
+	}
+	return m.primary
+}
+
+// — net.PacketConn —
+
+// ReadFrom returns the next datagram from the merged receive queue and updates
+// the routing table so responses go back through the correct socket.
+func (m *ServerPortMux) ReadFrom(b []byte) (int, net.Addr, error) {
+	pkt, ok := <-m.incoming
+	if !ok {
+		return 0, nil, net.ErrClosed
+	}
+	n := copy(b, pkt.data)
+	m.routes.Store(pkt.src.String(), pkt.conn)
+	return n, pkt.src, nil
+}
+
+func (m *ServerPortMux) WriteTo(b []byte, addr net.Addr) (int, error) {
+	u, ok := addr.(*net.UDPAddr)
+	if !ok {
+		return 0, fmt.Errorf("server portmux: WriteTo addr is not *net.UDPAddr")
+	}
+	return m.pickConn(u).WriteTo(b, addr)
+}
+
+func (m *ServerPortMux) Close() error {
+	var err error
+	m.closeOnce.Do(func() {
+		close(m.done)
+		err = m.primary.Close()
+		for _, s := range m.secondaries {
+			if e := s.Close(); e != nil && err == nil {
+				err = e
+			}
+		}
+		m.wg.Wait()
+	})
+	return err
+}
+
+func (m *ServerPortMux) LocalAddr() net.Addr {
+	return m.primary.LocalAddr()
+}
+
+func (m *ServerPortMux) SetDeadline(t time.Time) error {
+	if err := m.primary.SetDeadline(t); err != nil {
+		return err
+	}
+	for _, s := range m.secondaries {
+		if err := s.SetDeadline(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ServerPortMux) SetReadDeadline(t time.Time) error {
+	if err := m.primary.SetReadDeadline(t); err != nil {
+		return err
+	}
+	for _, s := range m.secondaries {
+		if err := s.SetReadDeadline(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *ServerPortMux) SetWriteDeadline(t time.Time) error {
+	if err := m.primary.SetWriteDeadline(t); err != nil {
+		return err
+	}
+	for _, s := range m.secondaries {
+		if err := s.SetWriteDeadline(t); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// — quic.OOBCapablePacketConn (preserves ECN on primary-socket traffic) —
+
+// SyscallConn returns the primary socket's RawConn so quic.Listen can apply
+// socket options such as IP_RECVTOS. Options applied here affect only the
+// primary socket; secondary sockets are created with default options which is
+// acceptable given their role as fallback paths.
+func (m *ServerPortMux) SyscallConn() (syscall.RawConn, error) {
+	return m.primary.SyscallConn()
+}
+
+func (m *ServerPortMux) SetReadBuffer(bytes int) error {
+	return m.primary.SetReadBuffer(bytes)
+}
+
+// ReadMsgUDP returns the next datagram from the merged queue, including any
+// ECN / ancillary data captured from the primary socket. Datagrams from
+// secondary sockets return empty OOB.
+func (m *ServerPortMux) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
+	pkt, ok := <-m.incoming
+	if !ok {
+		return 0, 0, 0, nil, net.ErrClosed
+	}
+	n = copy(b, pkt.data)
+	oobn = copy(oob, pkt.oob)
+	flags = pkt.flags
+	addr = pkt.src
+	m.routes.Store(pkt.src.String(), pkt.conn)
+	return n, oobn, flags, addr, nil
+}
+
+func (m *ServerPortMux) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
+	return m.pickConn(addr).WriteMsgUDP(b, oob, addr)
+}
+
+// net.Conn shim for transientRouteOOBPacketConn compatibility.
+
+func (m *ServerPortMux) Read(b []byte) (int, error) { return m.primary.Read(b) }
+func (m *ServerPortMux) Write(b []byte) (int, error) { return m.primary.Write(b) }
+func (m *ServerPortMux) RemoteAddr() net.Addr        { return nil }

--- a/internal/portmux/portmux.go
+++ b/internal/portmux/portmux.go
@@ -24,12 +24,8 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 )
-
-// muxOOBSize is enough room for ECN / DSCP ancillary data on all platforms.
-const muxOOBSize = 128
 
 // HopPorts derives a reproducible, collision-free set of count UDP ports for
 // the given provider and primary port. The primary port is always first;
@@ -77,9 +73,18 @@ func HopPorts(providerID string, primaryPort, count int) []int {
 }
 
 // ClientPortMux wraps a single UDP socket with bidirectional port rewriting so
-// that port hops are invisible to quic-go. It implements net.PacketConn,
-// quic.OOBCapablePacketConn, and net.Conn so it composes cleanly with the
-// existing tolerateTransientRouteErrors wrapper.
+// that port hops are invisible to quic-go. It implements net.PacketConn and
+// net.Conn so it composes cleanly with the existing tolerateTransientRouteErrors
+// wrapper.
+//
+// It deliberately does NOT implement quic.OOBCapablePacketConn. quic-go binds
+// OOB-capable conns with ipv4.NewPacketConn and reads them with recvmmsg
+// directly on the raw file descriptor, bypassing ReadMsgUDP: hop-port source
+// addresses would never be normalised back to the primary port, the
+// send/receive counters would never move, and the HopController would fire on
+// phantom zero-receive. The plain ReadFrom/WriteTo path keeps the rewriting
+// and counters exact, at the cost of ECN/GSO/batched I/O on hop-enabled
+// sockets — a fair trade on the hostile paths hopping exists for.
 //
 // Thread safety: all exported methods are safe for concurrent use. Hop() is
 // the only writer of currentIdx and is called at most once per cooldown
@@ -130,6 +135,11 @@ func (m *ClientPortMux) PrimaryAddr() *net.UDPAddr { return m.primaryAddr }
 // CurrentPort returns the currently active hop port.
 func (m *ClientPortMux) CurrentPort() int {
 	return m.ports[m.currentIdx.Load()]
+}
+
+// CurrentIndex returns the port-list index the mux is currently sending to.
+func (m *ClientPortMux) CurrentIndex() int32 {
+	return m.currentIdx.Load()
 }
 
 // Hop atomically switches to ports[idx], returning the old and new ports.
@@ -212,41 +222,14 @@ func (m *ClientPortMux) SetWriteDeadline(t time.Time) error {
 	return m.conn.SetWriteDeadline(t)
 }
 
-// — net.Conn (required by transientRouteOOBPacketConn's type assertion) —
+// — net.Conn (required by transientRoutePacketConn's type assertion) —
 
 func (m *ClientPortMux) Read(b []byte) (int, error)  { return m.conn.Read(b) }
 func (m *ClientPortMux) Write(b []byte) (int, error) { return m.conn.Write(b) }
 func (m *ClientPortMux) RemoteAddr() net.Addr        { return m.primaryAddr }
 
-// — quic.OOBCapablePacketConn (preserves ECN / GSO fast path) —
-
-func (m *ClientPortMux) SyscallConn() (syscall.RawConn, error) {
-	return m.conn.SyscallConn()
-}
-
 func (m *ClientPortMux) SetReadBuffer(bytes int) error {
 	return m.conn.SetReadBuffer(bytes)
-}
-
-func (m *ClientPortMux) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
-	n, oobn, flags, addr, err = m.conn.ReadMsgUDP(b, oob)
-	if err == nil {
-		m.recvCount.Add(1)
-		addr = m.normSrc(addr)
-	}
-	return n, oobn, flags, addr, err
-}
-
-func (m *ClientPortMux) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
-	m.sendCount.Add(1)
-	target := addr
-	if addr != nil {
-		hopPort := m.ports[m.currentIdx.Load()]
-		if addr.Port == m.primaryAddr.Port && hopPort != m.primaryAddr.Port {
-			target = &net.UDPAddr{IP: addr.IP, Port: hopPort, Zone: addr.Zone}
-		}
-	}
-	return m.conn.WriteMsgUDP(b, oob, target)
 }
 
 // — ServerPortMux —
@@ -254,17 +237,21 @@ func (m *ClientPortMux) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn i
 // serverPacket carries one UDP datagram received by any of the server's
 // listening sockets.
 type serverPacket struct {
-	data  []byte
-	oob   []byte // ECN / ancillary data; empty for non-primary sockets
-	flags int
-	src   *net.UDPAddr
-	conn  *net.UDPConn // socket the datagram arrived on
+	data []byte
+	src  *net.UDPAddr
+	conn *net.UDPConn // socket the datagram arrived on
 }
 
 // ServerPortMux listens on N UDP ports simultaneously and presents them as a
 // single net.PacketConn to quic.Listen. It remembers which socket each client
 // address most recently used and routes responses back through that socket so
 // the client's address-rewriting stays consistent.
+//
+// Like ClientPortMux it deliberately does NOT implement
+// quic.OOBCapablePacketConn: quic-go would read the primary socket directly
+// with recvmmsg, racing this mux's reader goroutines for primary packets and
+// never touching the merged queue the hop-port sockets feed. Every packet the
+// listener processes must come through ReadFrom.
 //
 // Thread safety: all exported methods are safe for concurrent use.
 type ServerPortMux struct {
@@ -313,47 +300,19 @@ func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error)
 	}
 
 	m.wg.Add(1)
-	go m.readPrimary()
+	go m.readSocket(m.primary)
 	for _, sec := range secondaries {
 		m.wg.Add(1)
-		go m.readSecondary(sec)
+		go m.readSocket(sec)
 	}
 
 	return m, nil
 }
 
-// readPrimary reads from the primary socket using ReadMsgUDP to capture ECN /
-// DSCP ancillary data. Packets are forwarded to the incoming channel together
-// with their OOB data so the upper layer receives full ECN information for
-// primary-socket traffic.
-func (m *ServerPortMux) readPrimary() {
-	defer m.wg.Done()
-	buf := make([]byte, 1500)
-	oob := make([]byte, muxOOBSize)
-	for {
-		n, oobn, flags, src, err := m.primary.ReadMsgUDP(buf, oob)
-		if err != nil {
-			return // socket closed
-		}
-		data := make([]byte, n)
-		copy(data, buf[:n])
-		oobCopy := make([]byte, oobn)
-		copy(oobCopy, oob[:oobn])
-		pkt := serverPacket{data: data, oob: oobCopy, flags: flags, src: src, conn: m.primary}
-		select {
-		case m.incoming <- pkt:
-		case <-m.done:
-			return
-		}
-	}
-}
-
-// readSecondary reads from a secondary socket using ReadFrom. OOB data is not
-// captured on secondary sockets, so ECN is not propagated for packets that
-// arrive on a hop port. This is an acceptable trade-off: secondary sockets
-// are used only after the client has hopped away from the primary port, and
-// the server's ECN feedback is less critical than correctness of routing.
-func (m *ServerPortMux) readSecondary(conn *net.UDPConn) {
+// readSocket copies datagrams from one listening socket into the merged
+// incoming queue, tagging each with the socket it arrived on so replies can
+// take the same path back.
+func (m *ServerPortMux) readSocket(conn *net.UDPConn) {
 	defer m.wg.Done()
 	buf := make([]byte, 1500)
 	for {
@@ -385,15 +344,20 @@ func (m *ServerPortMux) pickConn(addr *net.UDPAddr) *net.UDPConn {
 // — net.PacketConn —
 
 // ReadFrom returns the next datagram from the merged receive queue and updates
-// the routing table so responses go back through the correct socket.
+// the routing table so responses go back through the correct socket. Closing
+// the mux unblocks it, since quic-go's read loop parks here.
 func (m *ServerPortMux) ReadFrom(b []byte) (int, net.Addr, error) {
-	pkt, ok := <-m.incoming
-	if !ok {
+	select {
+	case pkt, ok := <-m.incoming:
+		if !ok {
+			return 0, nil, net.ErrClosed
+		}
+		n := copy(b, pkt.data)
+		m.routes.Store(pkt.src.String(), pkt.conn)
+		return n, pkt.src, nil
+	case <-m.done:
 		return 0, nil, net.ErrClosed
 	}
-	n := copy(b, pkt.data)
-	m.routes.Store(pkt.src.String(), pkt.conn)
-	return n, pkt.src, nil
 }
 
 func (m *ServerPortMux) WriteTo(b []byte, addr net.Addr) (int, error) {
@@ -459,42 +423,6 @@ func (m *ServerPortMux) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
-// — quic.OOBCapablePacketConn (preserves ECN on primary-socket traffic) —
-
-// SyscallConn returns the primary socket's RawConn so quic.Listen can apply
-// socket options such as IP_RECVTOS. Options applied here affect only the
-// primary socket; secondary sockets are created with default options which is
-// acceptable given their role as fallback paths.
-func (m *ServerPortMux) SyscallConn() (syscall.RawConn, error) {
-	return m.primary.SyscallConn()
-}
-
 func (m *ServerPortMux) SetReadBuffer(bytes int) error {
 	return m.primary.SetReadBuffer(bytes)
 }
-
-// ReadMsgUDP returns the next datagram from the merged queue, including any
-// ECN / ancillary data captured from the primary socket. Datagrams from
-// secondary sockets return empty OOB.
-func (m *ServerPortMux) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPAddr, err error) {
-	pkt, ok := <-m.incoming
-	if !ok {
-		return 0, 0, 0, nil, net.ErrClosed
-	}
-	n = copy(b, pkt.data)
-	oobn = copy(oob, pkt.oob)
-	flags = pkt.flags
-	addr = pkt.src
-	m.routes.Store(pkt.src.String(), pkt.conn)
-	return n, oobn, flags, addr, nil
-}
-
-func (m *ServerPortMux) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
-	return m.pickConn(addr).WriteMsgUDP(b, oob, addr)
-}
-
-// net.Conn shim for transientRouteOOBPacketConn compatibility.
-
-func (m *ServerPortMux) Read(b []byte) (int, error) { return m.primary.Read(b) }
-func (m *ServerPortMux) Write(b []byte) (int, error) { return m.primary.Write(b) }
-func (m *ServerPortMux) RemoteAddr() net.Addr        { return nil }

--- a/internal/portmux/portmux_test.go
+++ b/internal/portmux/portmux_test.go
@@ -214,6 +214,71 @@ type nopMetrics struct{ count int }
 
 func (n *nopMetrics) PortHop() { n.count++ }
 
+// — HopWalk tests —
+
+func TestHopWalkVisitsEveryIndexOncePerRound(t *testing.T) {
+	const count = 20
+	w := portmux.NewHopWalk(count)
+	for round := 0; round < 3; round++ {
+		seen := make(map[int32]bool, count)
+		for i := 0; i < count; i++ {
+			idx := w.Next()
+			if idx < 0 || idx >= count {
+				t.Fatalf("round %d: index %d out of range [0, %d)", round, idx, count)
+			}
+			if seen[idx] {
+				t.Fatalf("round %d: index %d returned twice within one permutation", round, idx)
+			}
+			seen[idx] = true
+		}
+	}
+}
+
+// Note: HopConfig clamps PollInterval to a minimum of 1s and the controller
+// requires a full detect window before triggering, so these tests run on a
+// 1s poll cadence and need multi-second durations.
+
+func TestHopControllerWaitsForFullWindow(t *testing.T) {
+	clientConn, _ := newLoopbackPair(t)
+	defer clientConn.Close()
+
+	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 19998}
+	ports := portmux.HopPorts("test", serverAddr.Port, 5)
+	mux := portmux.NewClientPortMux(clientConn, serverAddr, ports)
+	defer mux.Close()
+
+	m := &nopMetrics{}
+	ctrl := portmux.NewHopController(mux, portmux.HopConfig{
+		DetectWindow: 1500 * time.Millisecond, // 2 samples at the clamped 1s poll
+		PollInterval: 100 * time.Millisecond,  // clamped to 1s
+		MinSent:      3,
+		Cooldown:     time.Second,
+		Metrics:      m,
+	})
+	go ctrl.Run(mux.Context())
+
+	send := func(d time.Duration) {
+		deadline := time.Now().Add(d)
+		for time.Now().Before(deadline) {
+			clientConn.SetWriteDeadline(time.Now().Add(time.Millisecond))
+			_, _ = mux.WriteTo([]byte("x"), serverAddr)
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+
+	// A partially filled window must not trigger, no matter how lossy it looks.
+	send(1500 * time.Millisecond)
+	if m.count != 0 {
+		t.Fatalf("hop triggered after one sample with a two-sample detect window")
+	}
+
+	// Once the window is full of zero-receive evidence, the hop fires.
+	send(2500 * time.Millisecond)
+	if m.count == 0 {
+		t.Fatal("no hop after a full window of zero-receive loss")
+	}
+}
+
 func TestHopControllerTriggersOnLoss(t *testing.T) {
 	clientConn, _ := newLoopbackPair(t)
 	defer clientConn.Close()
@@ -247,8 +312,9 @@ func TestHopControllerTriggersOnLoss(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	// Wait for the detect window plus a couple of poll intervals.
-	time.Sleep(800 * time.Millisecond)
+	// Wait for the two-sample detect window to fill at the clamped 1s poll
+	// cadence, plus margin.
+	time.Sleep(2600 * time.Millisecond)
 
 	if m.count == 0 {
 		t.Error("HopController did not trigger a hop despite sustained zero-receive loss")
@@ -296,7 +362,10 @@ func TestHopControllerNoHopWhenReceiving(t *testing.T) {
 	}()
 
 	buf := make([]byte, 8)
-	for i := 0; i < 20; i++ {
+	// Keep the path busy well past the two-sample detect window (1s clamped
+	// polls), so the receive guard is what actually suppresses the hop.
+	deadline := time.Now().Add(2600 * time.Millisecond)
+	for time.Now().Before(deadline) {
 		_, _ = mux.WriteTo([]byte("x"), serverAddr)
 		clientConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 		_, _, _ = mux.ReadFrom(buf)

--- a/internal/portmux/portmux_test.go
+++ b/internal/portmux/portmux_test.go
@@ -1,0 +1,311 @@
+package portmux_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/portmux"
+)
+
+// — HopPorts tests —
+
+func TestHopPortsPrimaryFirst(t *testing.T) {
+	ports := portmux.HopPorts("test-provider", 12540, 10)
+	if len(ports) != 10 {
+		t.Fatalf("want 10 ports, got %d", len(ports))
+	}
+	if ports[0] != 12540 {
+		t.Errorf("first port must be the primary port; got %d", ports[0])
+	}
+}
+
+func TestHopPortsDeterministic(t *testing.T) {
+	a := portmux.HopPorts("abc", 1234, 50)
+	b := portmux.HopPorts("abc", 1234, 50)
+	for i := range a {
+		if a[i] != b[i] {
+			t.Fatalf("HopPorts is not deterministic: index %d got %d and %d", i, a[i], b[i])
+		}
+	}
+}
+
+func TestHopPortsDifferentProviders(t *testing.T) {
+	a := portmux.HopPorts("provider-A", 12540, 20)
+	b := portmux.HopPorts("provider-B", 12540, 20)
+	// Different providers should yield different secondary ports
+	// (primary is the same by definition; check at least one secondary differs).
+	differ := false
+	for i := 1; i < 20; i++ {
+		if a[i] != b[i] {
+			differ = true
+			break
+		}
+	}
+	if !differ {
+		t.Error("different providerIDs should yield different port sequences")
+	}
+}
+
+func TestHopPortsNoDuplicates(t *testing.T) {
+	ports := portmux.HopPorts("dupecheck", 55555, 100)
+	seen := make(map[int]bool, len(ports))
+	for _, p := range ports {
+		if seen[p] {
+			t.Errorf("duplicate port %d in HopPorts output", p)
+		}
+		seen[p] = true
+	}
+}
+
+func TestHopPortsRange(t *testing.T) {
+	ports := portmux.HopPorts("rangecheck", 9000, 100)
+	for _, p := range ports[1:] { // skip primary which may be outside range
+		if p < 1024 || p >= 65535 {
+			t.Errorf("port %d out of range [1024, 65535)", p)
+		}
+	}
+}
+
+func TestHopPortsSingleOrZero(t *testing.T) {
+	for _, count := range []int{0, 1} {
+		ports := portmux.HopPorts("x", 4444, count)
+		if len(ports) != 1 || ports[0] != 4444 {
+			t.Errorf("count=%d: want [4444], got %v", count, ports)
+		}
+	}
+}
+
+// — ClientPortMux address-rewriting tests —
+
+// newLoopbackPair returns two connected UDP sockets suitable for testing the
+// port mux without a real server. a and b are peers.
+func newLoopbackPair(t *testing.T) (a, b *net.UDPConn) {
+	t.Helper()
+	la, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lb, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		la.Close()
+		t.Fatal(err)
+	}
+	return la, lb
+}
+
+func TestClientPortMuxRewritesOnWrite(t *testing.T) {
+	client, server := newLoopbackPair(t)
+	defer client.Close()
+	defer server.Close()
+
+	serverAddr := server.LocalAddr().(*net.UDPAddr)
+	// Build a 3-port list; ports[1] is a fake "second" port.
+	altPort := serverAddr.Port + 100
+	ports := []int{serverAddr.Port, altPort}
+
+	mux := portmux.NewClientPortMux(client, serverAddr, ports)
+	defer mux.Close()
+
+	// Hop to index 1 (altPort).
+	mux.Hop(1)
+
+	// Write to the primary address — mux should rewrite to altPort.
+	sent := []byte("hello")
+	if _, err := mux.WriteTo(sent, serverAddr); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	// Server is not actually listening on altPort; just verify the outgoing
+	// destination was rewritten by checking CurrentPort.
+	if mux.CurrentPort() != altPort {
+		t.Errorf("CurrentPort = %d, want %d", mux.CurrentPort(), altPort)
+	}
+}
+
+func TestClientPortMuxNormalisesIncoming(t *testing.T) {
+	// Simulate: server sends from altPort; mux should normalise to primaryPort.
+	clientConn, serverConn := newLoopbackPair(t)
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Open a second server socket on a different port to simulate the hop port.
+	altServerConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer altServerConn.Close()
+
+	primaryAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	altPort := altServerConn.LocalAddr().(*net.UDPAddr).Port
+
+	ports := []int{primaryAddr.Port, altPort}
+	mux := portmux.NewClientPortMux(clientConn, primaryAddr, ports)
+	defer mux.Close()
+
+	clientAddr := clientConn.LocalAddr().(*net.UDPAddr)
+
+	// Alt server sends a reply packet to the client.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		_, _ = altServerConn.WriteTo([]byte("reply"), clientAddr)
+	}()
+
+	buf := make([]byte, 64)
+	_ = clientConn.SetReadDeadline(time.Now().Add(time.Second))
+	n, addr, err := mux.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	if string(buf[:n]) != "reply" {
+		t.Errorf("payload = %q, want %q", buf[:n], "reply")
+	}
+	// The returned address should be the primary address, not the alt port.
+	uaddr, ok := addr.(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("addr is not *net.UDPAddr")
+	}
+	if uaddr.Port != primaryAddr.Port {
+		t.Errorf("source port = %d, want primary %d (src from alt port must be normalised)",
+			uaddr.Port, primaryAddr.Port)
+	}
+}
+
+func TestClientPortMuxCounters(t *testing.T) {
+	clientConn, serverConn := newLoopbackPair(t)
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	serverAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	mux := portmux.NewClientPortMux(clientConn, serverAddr, []int{serverAddr.Port})
+	defer mux.Close()
+
+	if mux.SendCount() != 0 || mux.RecvCount() != 0 {
+		t.Fatal("counters must start at zero")
+	}
+
+	// Send two packets.
+	clientAddr := clientConn.LocalAddr().(*net.UDPAddr)
+	_, _ = mux.WriteTo([]byte("a"), serverAddr)
+	_, _ = mux.WriteTo([]byte("b"), serverAddr)
+	if mux.SendCount() != 2 {
+		t.Errorf("SendCount = %d, want 2", mux.SendCount())
+	}
+
+	// Server echoes them back.
+	buf := make([]byte, 8)
+	for i := 0; i < 2; i++ {
+		_, _, _ = serverConn.ReadFrom(buf)
+		_, _ = serverConn.WriteTo(buf[:1], clientAddr)
+	}
+	// Drain the client side.
+	_ = clientConn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	for i := 0; i < 2; i++ {
+		_, _, _ = mux.ReadFrom(buf)
+	}
+	if mux.RecvCount() != 2 {
+		t.Errorf("RecvCount = %d, want 2", mux.RecvCount())
+	}
+}
+
+// — HopController tests —
+
+type nopMetrics struct{ count int }
+
+func (n *nopMetrics) PortHop() { n.count++ }
+
+func TestHopControllerTriggersOnLoss(t *testing.T) {
+	clientConn, _ := newLoopbackPair(t)
+	defer clientConn.Close()
+
+	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 19999}
+	ports := portmux.HopPorts("test", serverAddr.Port, 5)
+	mux := portmux.NewClientPortMux(clientConn, serverAddr, ports)
+	defer mux.Close()
+
+	m := &nopMetrics{}
+	ctrl := portmux.NewHopController(mux, portmux.HopConfig{
+		DetectWindow: 500 * time.Millisecond,
+		PollInterval: 100 * time.Millisecond,
+		MinSent:      3,
+		Cooldown:     200 * time.Millisecond,
+		Metrics:      m,
+	})
+
+	ctx := mux.Context()
+	go ctrl.Run(ctx)
+
+	// Simulate sustained sending with zero receives.
+	for i := 0; i < 20; i++ {
+		mux.SendCount() // just read; we need to increment sendCount manually
+		// Directly increment the send counter to simulate sends without
+		// actually sending UDP packets (the server addr is not really listening).
+		// Use the exported counter indirectly through WriteTo which may fail.
+		// Instead we call WriteTo and accept the send error.
+		clientConn.SetWriteDeadline(time.Now().Add(time.Millisecond))
+		_, _ = mux.WriteTo([]byte("x"), serverAddr)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Wait for the detect window plus a couple of poll intervals.
+	time.Sleep(800 * time.Millisecond)
+
+	if m.count == 0 {
+		t.Error("HopController did not trigger a hop despite sustained zero-receive loss")
+	}
+	if mux.CurrentPort() == serverAddr.Port {
+		t.Error("port is still primary after hop controller triggered")
+	}
+}
+
+func TestHopControllerNoHopWhenReceiving(t *testing.T) {
+	clientConn, serverConn := newLoopbackPair(t)
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	serverAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	ports := portmux.HopPorts("test", serverAddr.Port, 5)
+	mux := portmux.NewClientPortMux(clientConn, serverAddr, ports)
+	defer mux.Close()
+
+	m := &nopMetrics{}
+	ctrl := portmux.NewHopController(mux, portmux.HopConfig{
+		DetectWindow: 300 * time.Millisecond,
+		PollInterval: 50 * time.Millisecond,
+		MinSent:      3,
+		Cooldown:     200 * time.Millisecond,
+		Metrics:      m,
+	})
+	go ctrl.Run(mux.Context())
+
+	clientAddr := clientConn.LocalAddr().(*net.UDPAddr)
+
+	// Send and receive traffic to simulate a healthy path.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 8)
+		for {
+			serverConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+			_, _, err := serverConn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			serverConn.WriteTo(buf[:1], clientAddr)
+		}
+	}()
+
+	buf := make([]byte, 8)
+	for i := 0; i < 20; i++ {
+		_, _ = mux.WriteTo([]byte("x"), serverAddr)
+		clientConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		_, _, _ = mux.ReadFrom(buf)
+		time.Sleep(20 * time.Millisecond)
+	}
+	time.Sleep(400 * time.Millisecond)
+
+	if m.count > 0 {
+		t.Errorf("HopController triggered %d hops on a healthy path; want 0", m.count)
+	}
+	<-done
+}

--- a/internal/portmux/quic_hop_test.go
+++ b/internal/portmux/quic_hop_test.go
@@ -1,0 +1,196 @@
+package portmux_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apernet/quic-go"
+	"github.com/bojieli/queqiao/internal/portmux"
+)
+
+const hopQuicALPN = "queqiao-hop-test"
+
+func hopTestTLSConfig(t *testing.T) *tls.Config {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "hop-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		NextProtos:   []string{hopQuicALPN},
+	}
+}
+
+// serveQUICEcho runs a quic-go listener on conn and echoes one stream back.
+func serveQUICEcho(t *testing.T, conn net.PacketConn, tlsCfg *tls.Config) {
+	t.Helper()
+	listener, err := quic.Listen(conn, tlsCfg, &quic.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			quicConn, err := listener.Accept(context.Background())
+			if err != nil {
+				return
+			}
+			go func() {
+				for {
+					stream, err := quicConn.AcceptStream(context.Background())
+					if err != nil {
+						return
+					}
+					go func() {
+						defer stream.Close()
+						_, _ = io.Copy(stream, stream)
+					}()
+				}
+			}()
+		}
+	}()
+}
+
+func dialQUICEcho(t *testing.T, packetConn net.PacketConn, serverAddr *net.UDPAddr, payload []byte) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := quic.Dial(ctx, packetConn, serverAddr,
+		&tls.Config{InsecureSkipVerify: true, NextProtos: []string{hopQuicALPN}}, &quic.Config{})
+	if err != nil {
+		t.Fatalf("QUIC dial: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+	stream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	if _, err := stream.Write(payload); err != nil {
+		t.Fatalf("stream write: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("stream close: %v", err)
+	}
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("stream read: %v", err)
+	}
+	return got
+}
+
+// A client whose every packet goes to a secondary hop port must still
+// complete the QUIC handshake: the server mux has to feed hop-port datagrams
+// to the listener and route replies back through the same socket.
+func TestQUICHandshakeViaSecondaryHopPort(t *testing.T) {
+	primary, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryPort := primary.LocalAddr().(*net.UDPAddr).Port
+	ports := portmux.HopPorts("hop-itest", primaryPort, 3)
+	if len(ports) < 3 {
+		t.Fatalf("want at least 3 hop ports, got %v", ports)
+	}
+
+	mux, err := portmux.NewServerPortMux(primary, ports)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveQUICEcho(t, mux, hopTestTLSConfig(t))
+
+	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: primaryPort}
+	clientConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmux := portmux.NewClientPortMux(clientConn, serverAddr, ports)
+	defer cmux.Close()
+	// Hop onto a secondary port before sending a single packet.
+	from, to := cmux.Hop(1)
+	if from != primaryPort || to == primaryPort {
+		t.Fatalf("unexpected hop %d -> %d", from, to)
+	}
+
+	payload := []byte("echo-over-a-hop-port")
+	if got := dialQUICEcho(t, cmux, serverAddr, payload); string(got) != string(payload) {
+		t.Fatalf("echo mismatch: got %q want %q", got, payload)
+	}
+}
+
+// An established connection must survive a mid-session hop: packets start
+// arriving on a different server socket and replies must follow them.
+func TestQUICConnectionSurvivesMidSessionHop(t *testing.T) {
+	primary, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryPort := primary.LocalAddr().(*net.UDPAddr).Port
+	ports := portmux.HopPorts("hop-itest-mid", primaryPort, 3)
+
+	mux, err := portmux.NewServerPortMux(primary, ports)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serveQUICEcho(t, mux, hopTestTLSConfig(t))
+
+	serverAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: primaryPort}
+	clientConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmux := portmux.NewClientPortMux(clientConn, serverAddr, ports)
+	defer cmux.Close()
+
+	// Dial on the primary port, open a stream, then hop mid-stream.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := quic.Dial(ctx, cmux, serverAddr,
+		&tls.Config{InsecureSkipVerify: true, NextProtos: []string{hopQuicALPN}}, &quic.Config{})
+	if err != nil {
+		t.Fatalf("QUIC dial: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+	stream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+
+	cmux.Hop(2)
+	payload := []byte("post-hop-echo")
+	if _, err := stream.Write(payload); err != nil {
+		t.Fatalf("stream write after hop: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("stream close: %v", err)
+	}
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("stream read after hop: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("echo mismatch after hop: got %q want %q", got, payload)
+	}
+}


### PR DESCRIPTION
## Summary

This PR contains the reactive UDP port-hopping feature plus the fixes that make it work, validated live against a deployment whose primary port was being throttled/blocked.

- `4ac3e33` feat(portmux): reactive UDP port hopping to evade per-port GFW blocking (server listens on N derived ports, client hops on sustained zero-receive).
- `7fe7d94` fix(portmux): make port hopping actually hop — three bugs found while enabling it in production:

### The bugs

1. **quic-go bypassed both muxes.** Because the muxes implemented `quic.OOBCapablePacketConn`, quic-go bound the raw fd with `ipv4.NewPacketConn` and read it with recvmmsg. Server-side, hop-port sockets were never read — packet capture on the gateway showed client Initials arriving on a hop port with zero reply. The mux reader goroutines also raced quic-go for primary-port packets. Client-side, reply addresses were never normalised and the loss counters never moved, so the detector hopped on phantom evidence. Both muxes now expose only the plain `net.PacketConn` path they control (trade-off: no ECN/GSO/batched I/O on hop-enabled sockets).
2. **The pool was never walked.** Every dial restarted on the primary port, and the 15 s hop cooldown exceeded the 10 s dial timeout, so only 2 of the 100 configured ports were ever tried. A client-wide `HopWalk` now shuffles the pool, persists across dials, starts each dial on a walked port, and hops multiple times within a dial (cooldown 3 s, detect window 4 s, requires a full window before firing).
3. **Premature hops.** The detector fired seconds after connect on a partially-filled window; it now waits for a full detect window.

### Tests

- New `internal/portmux/quic_hop_test.go`: real quic-go handshake carried entirely over a secondary hop port, and an established connection surviving a mid-session hop. **Both fail before the fix, pass after.**
- `go test ./internal/portmux ./internal/pep` pass; a latent deadlock in `ServerPortMux.ReadFrom` on close is also fixed.
- Live: after deploying both ends, proxied requests succeed 8/10 over a path with ~60% packet loss, with the gateway captured sending QUIC data from a hop port.