### PR TITLE
fix(portmux): CI and review follow-ups for port hopping

### DIFF
--- a/cmd/queqiaod/providers.go
+++ b/cmd/queqiaod/providers.go
@@ -203,7 +203,7 @@ func newRuntimeClient(profile identity.ClientProfile, listen string, opts runtim
 		FallbackDelay:      opts.fallbackDelay, FallbackGrace: opts.fallbackGrace,
 		UDPFailureThreshold: opts.udpFailureThreshold, UDPCooldown: opts.udpCooldown,
 		HopPortCount: profile.HopPortCount,
-		Metrics: registry, Logger: logger,
+		Metrics:      registry, Logger: logger,
 	})
 }
 

--- a/internal/portmux/hop.go
+++ b/internal/portmux/hop.go
@@ -2,8 +2,9 @@ package portmux
 
 import (
 	"context"
+	"crypto/rand"
 	"log/slog"
-	"math/rand/v2"
+	"math/big"
 	"sync"
 	"time"
 )
@@ -19,6 +20,20 @@ type HopWalk struct {
 	pos   int
 }
 
+// shuffleInts is Fisher-Yates over crypto/rand. The port order is meant to be
+// unpredictable to the same network observer who already knows the HopPorts
+// derivation hash, so a weak PRNG would not do.
+func shuffleInts(order []int) {
+	for i := len(order) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			return // leave the rest unshuffled rather than fail the dial path
+		}
+		k := int(j.Int64())
+		order[i], order[k] = order[k], order[i]
+	}
+}
+
 // NewHopWalk returns a walk over the port-list indices [0, count) in a
 // freshly shuffled order.
 func NewHopWalk(count int) *HopWalk {
@@ -26,7 +41,7 @@ func NewHopWalk(count int) *HopWalk {
 	for i := range order {
 		order[i] = i
 	}
-	rand.Shuffle(count, func(i, j int) { order[i], order[j] = order[j], order[i] })
+	shuffleInts(order)
 	return &HopWalk{order: order}
 }
 
@@ -36,11 +51,13 @@ func (w *HopWalk) Next() int32 {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.pos >= len(w.order) {
-		rand.Shuffle(len(w.order), func(i, j int) { w.order[i], w.order[j] = w.order[j], w.order[i] })
+		shuffleInts(w.order)
 		w.pos = 0
 	}
 	idx := w.order[w.pos]
 	w.pos++
+	// idx < count, and count is the configured hop pool size (order 100), so
+	// the int32 conversion cannot overflow.
 	return int32(idx)
 }
 

--- a/internal/portmux/portmux_test.go
+++ b/internal/portmux/portmux_test.go
@@ -100,8 +100,12 @@ func TestClientPortMuxRewritesOnWrite(t *testing.T) {
 	defer server.Close()
 
 	serverAddr := server.LocalAddr().(*net.UDPAddr)
-	// Build a 3-port list; ports[1] is a fake "second" port.
+	// Build a 2-port list; ports[1] is a fake "second" port. Stay inside the
+	// valid port range no matter which ephemeral port the OS assigned.
 	altPort := serverAddr.Port + 100
+	if altPort > 65535 {
+		altPort = serverAddr.Port - 100
+	}
 	ports := []int{serverAddr.Port, altPort}
 
 	mux := portmux.NewClientPortMux(client, serverAddr, ports)

--- a/internal/portmux/quic_hop_test.go
+++ b/internal/portmux/quic_hop_test.go
@@ -51,7 +51,7 @@ func serveQUICEcho(t *testing.T, conn net.PacketConn, tlsCfg *tls.Config) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { listener.Close() })
+	t.Cleanup(func() { _ = conn.Close(); _ = listener.Close() })
 	go func() {
 		for {
 			quicConn, err := listener.Accept(context.Background())

--- a/scripts/check_gosec.py
+++ b/scripts/check_gosec.py
@@ -41,6 +41,9 @@ BASELINE = {
     ("G115", "internal/pep/mpflow.go"): 12,
     ("G115", "internal/pep/server.go"): 1,
     ("G115", "internal/pep/stripedsend.go"): 5,
+    # The hop walk index is bounded by the configured pool size (order 100),
+    # far inside int32.
+    ("G115", "internal/portmux/hop.go"): 1,
     ("G115", "internal/protocol/frame.go"): 1,
     ("G115", "internal/session/packet.go"): 1,
     ("G115", "internal/socks5/socks5.go"): 1,


### PR DESCRIPTION
Follow-up to #90 fixing the CI failures found on the merge commit: gofmt on cmd/queqiaod/providers.go, crypto/rand for the hop-pool shuffle (G404), one reviewed G115 baseline entry, and two test flakes (synthetic alt port out of range, mux sockets leaking across repeated test runs). Local: gofmt clean, gosec baseline accepted, portmux -count=3 green.