### PR TITLE
fix(pep): detect flow stalls at 3x minRTT and race parallel rescue dials

### DIFF
--- a/changelog.d/flow-stall-watchdog-parallel-rescue.fixed.md
+++ b/changelog.d/flow-stall-watchdog-parallel-rescue.fixed.md
@@ -1,0 +1,21 @@
+Flows stalled on one-way loss now recover in seconds instead of failing
+after a minute. A lane used to be declared dead only on I/O error — fifteen
+seconds of total receive silence — so on a path erasing the upstream
+direction, downstream keepalives kept every connection nominally alive
+while flows with a full send window made no progress at all. A per-flow
+stall watchdog now measures forward progress where delivery to the peer is
+actually recorded (the acknowledged send offset and payload arrival) and,
+finding none for three minimum round trips while work is pending, demotes
+the lane and starts a rescue beside it: the suspected lane keeps receiving
+and is fully eligible again the moment an acknowledgement arrives on it.
+The rescue dials up to three concurrent JOIN attempts sprayed uniformly
+across the hop-port pool — or across independent handshakes on the single
+port when hopping is off — and the first completed JOIN wins. The gateway
+protects a freshly admitted lane from eviction at its lane ceiling, so the
+losing JOINs of a parallel rescue can no longer retire the winner's server
+side; such a late JOIN is refused by capacity instead, which the client
+treats as one lost attempt rather than a lost session. A gateway that sees
+a rescue JOIN arrive while a flow is waiting out its replacement grace now
+restarts that grace instead of letting it expire mid-handshake, and
+--handshake-timeout no longer overrides the client's safer 30-second
+default with 10 seconds.

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -533,7 +533,11 @@ func bindRuntimeFlags(fs *flag.FlagSet, opts *runtimeOptions, client bool) {
 	fs.IntVar(&opts.maxSessions, "max-sessions", defaultMaxSessions, "global concurrent-session limit")
 	fs.IntVar(&opts.chunkSize, "chunk-size", 32*1024, "stream data frame size")
 	fs.DurationVar(&opts.dialTimeout, "dial-timeout", 10*time.Second, "dial timeout")
-	fs.DurationVar(&opts.handshakeTimeout, "handshake-timeout", 10*time.Second, "TLS, protocol, and SOCKS handshake timeout")
+	// 30s, matching the default NewClient applies when nothing is configured:
+	// a first handshake on an erasing path takes about five seconds at 42%
+	// loss, and the flag used to silently override the safer library default
+	// with ten, making that first connection a coin flip.
+	fs.DurationVar(&opts.handshakeTimeout, "handshake-timeout", 30*time.Second, "TLS, protocol, and SOCKS handshake timeout")
 	fs.DurationVar(&opts.flowIdleTimeout, "flow-idle-timeout", 30*time.Minute, "flow idle timeout")
 	fs.DurationVar(&opts.flowMaxLifetime, "flow-max-lifetime", 24*time.Hour, "maximum flow lifetime")
 	fs.StringVar(&opts.transport, "transport", string(pep.TransportAuto), "transport: auto, quic, or tcp")
@@ -1073,6 +1077,16 @@ func logPerformanceSnapshot(logger *slog.Logger, s metrics.Snapshot, interval ti
 		slog.Uint64("queqiao_class_transitions_0_total", s.ClassTransitions[0]),
 		slog.Uint64("queqiao_class_transitions_1_total", s.ClassTransitions[1]),
 		slog.Uint64("queqiao_class_transitions_2_total", s.ClassTransitions[2]),
+		// The stall watchdog and its parallel rescue. rescue wins are flat,
+		// one per attempt slot, matching the labelled /metrics series; a win
+		// above slot zero is a sprayed dial beating the established strategy.
+		slog.Uint64("queqiao_flow_stalls_detected_total", s.FlowStallsDetected),
+		slog.Uint64("queqiao_stall_spare_attaches_total", s.StallSpareAttaches),
+		slog.Uint64("queqiao_lane_rescue_attempts_total", s.LaneRescueAttempts),
+		slog.Uint64("queqiao_lane_rescue_wins_0_total", s.LaneRescueWins[0]),
+		slog.Uint64("queqiao_lane_rescue_wins_1_total", s.LaneRescueWins[1]),
+		slog.Uint64("queqiao_lane_rescue_wins_2_total", s.LaneRescueWins[2]),
+		slog.Uint64("queqiao_lane_grace_extensions_total", s.LaneGraceExtensions),
 	)
 }
 

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -116,7 +116,19 @@ Prometheus `/metrics` names. They cover:
 - transient local UDP send errors absorbed into QUIC loss recovery;
 - flow telemetry entries expired because nothing refreshed them, which is how
   a round-trip aggregate frozen at a stale constant announces itself;
-- lane joins refused and account flow opens refused, each split by reason; and
+- lane joins refused and account flow opens refused, each split by reason;
+- the flow-stall watchdog and its parallel rescue:
+  `queqiao_flow_stalls_detected_total` counts stall episodes (work pending
+  with no forward progress for three minimum round trips),
+  `queqiao_stall_spare_attaches_total` counts stalls where an already-healthy
+  lane took over at once, `queqiao_lane_rescue_attempts_total` counts
+  individual dial+JOIN attempts and
+  `queqiao_lane_rescue_wins_total{attempt="N"}` which attempt of a round
+  produced the lane the flow kept -- a win above zero is an independent QUIC
+  dial beating the established strategy, and
+  `queqiao_lane_grace_extensions_total` counts replacement graces a gateway
+  restarted because a rescue JOIN arrived while the flow was still waiting;
+  and
 - the erasure the path is measured to be applying to the direction this
   endpoint sends into, published as `queqiao_erasure_ratio{direction="send"}`
   and as `queqiao_erasure_ratio_send` in the log. A gateway's send direction is

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -79,6 +79,30 @@ type Registry struct {
 	// here is the other half of a peer's stalling and failing flows -- the
 	// half the endpoint doing the refusing can see.
 	laneJoinRefusals [LaneJoinReasons]atomic.Uint64
+	// flowStallsDetected counts flows whose watchdog saw no forward progress
+	// for three round trips while work was pending. A stall is a suspicion,
+	// not a failure: the lane stays in service while a rescue runs beside it,
+	// so this counter rising without lane_failures is the watchdog doing the
+	// job the idle timeout used to do fifteen seconds later.
+	flowStallsDetected atomic.Uint64
+	// stallSpareAttaches counts stalls where a second healthy lane already
+	// existed and took over the flow's new writes immediately, without
+	// waiting for a rescue handshake.
+	stallSpareAttaches atomic.Uint64
+	// laneRescueAttempts counts individual dial+JOIN attempts started by the
+	// parallel rescue. One rescue round starts several, so this outpaces
+	// lane_replacements: the difference is what the first-wins race cancelled.
+	laneRescueAttempts atomic.Uint64
+	// laneRescueWins is indexed by the attempt that produced the winning
+	// lane. Attempt zero is the established strategy (pooled generation, or
+	// the committed TCP handoff); the rest are independent QUIC dials. A win
+	// by a later attempt is the parallel rescue paying for itself.
+	laneRescueWins [RescueAttemptSlots]atomic.Uint64
+	// laneGraceExtensions counts replacement graces this gateway restarted
+	// because a rescue JOIN arrived while the flow was still waiting out an
+	// outage. Without the extension the hard grace could expire in the middle
+	// of the very handshake that was coming to save the flow.
+	laneGraceExtensions atomic.Uint64
 	// accountAdmissionRefusals counts flow opens this gateway answered with a
 	// reset because of the opening account's own policy, by reason. It exists
 	// because these refusals used to be the one admission decision the
@@ -138,6 +162,12 @@ const (
 	// LaneJoinReasons is how many reasons there are.
 	LaneJoinReasons
 )
+
+// RescueAttemptSlots is how many concurrent dial+JOIN attempts one parallel
+// rescue round runs. It is a compile-time bound because the winning attempt
+// is an exported label value, and this exposition carries no unbounded
+// labels.
+const RescueAttemptSlots = 3
 
 var laneJoinRefusalNames = [LaneJoinReasons]string{
 	LaneJoinInvalidIdentity:           "invalid_identity",
@@ -313,7 +343,11 @@ type Snapshot struct {
 	// LaneJoinRefusals is indexed by LaneJoinRefusal.
 	LaneJoinRefusals [LaneJoinReasons]uint64
 	// AccountAdmissionRefusals is indexed by AccountRefusal.
-	AccountAdmissionRefusals [AccountRefusalReasons]uint64
+	AccountAdmissionRefusals                [AccountRefusalReasons]uint64
+	FlowStallsDetected, StallSpareAttaches  uint64
+	LaneRescueAttempts, LaneGraceExtensions uint64
+	// LaneRescueWins is indexed by the winning attempt of a rescue round.
+	LaneRescueWins [RescueAttemptSlots]uint64
 }
 
 // QUICObservation is a point-in-time aggregate over the lanes of one logical
@@ -567,6 +601,33 @@ func (r *Registry) CompletionTimeout() { r.completionTimeouts.Add(1) }
 func (r *Registry) FlowTimeout()       { r.flowTimeouts.Add(1) }
 func (r *Registry) PortHop()           { r.portHops.Add(1) }
 
+// FlowStallDetected records one flow stall episode: work was pending and no
+// forward progress was observed for three round trips. It is counted once per
+// episode, not per scan, so a flow that stays stalled is one event.
+func (r *Registry) FlowStallDetected() { r.flowStallsDetected.Add(1) }
+
+// StallSpareAttached records a stall where an already-healthy lane took over
+// the flow's new writes without waiting for a rescue handshake.
+func (r *Registry) StallSpareAttached() { r.stallSpareAttaches.Add(1) }
+
+// LaneRescueAttempt records one dial+JOIN attempt started by the parallel
+// rescue, winning or not.
+func (r *Registry) LaneRescueAttempt() { r.laneRescueAttempts.Add(1) }
+
+// LaneRescueWin records which attempt of a rescue round produced the lane the
+// flow kept. Attempt zero is the established recovery strategy; a later index
+// is an independent QUIC dial that beat it.
+func (r *Registry) LaneRescueWin(attempt int) {
+	if attempt < 0 || attempt >= RescueAttemptSlots {
+		return
+	}
+	r.laneRescueWins[attempt].Add(1)
+}
+
+// LaneGraceExtended records a replacement grace restarted because a rescue
+// JOIN arrived while the flow was waiting out an outage.
+func (r *Registry) LaneGraceExtended() { r.laneGraceExtensions.Add(1) }
+
 // AuthorizationRefreshFailed records one failed attempt to re-read the
 // authorization store, carrying how many have now failed in a row so a chronic
 // outage is distinguishable from a single missed tick.
@@ -671,6 +732,13 @@ func (r *Registry) Snapshot() Snapshot {
 	}
 	for i := range s.AccountAdmissionRefusals {
 		s.AccountAdmissionRefusals[i] = r.accountAdmissionRefusals[i].Load()
+	}
+	s.FlowStallsDetected = r.flowStallsDetected.Load()
+	s.StallSpareAttaches = r.stallSpareAttaches.Load()
+	s.LaneRescueAttempts = r.laneRescueAttempts.Load()
+	s.LaneGraceExtensions = r.laneGraceExtensions.Load()
+	for i := range s.LaneRescueWins {
+		s.LaneRescueWins[i] = r.laneRescueWins[i].Load()
 	}
 	now := r.now()
 	var expired uint64
@@ -938,6 +1006,17 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	for i, value := range s.AccountAdmissionRefusals {
 		fmt.Fprintf(w, "queqiao_account_admission_refused_total{reason=\"%s\"} %d\n", AccountRefusal(i), value)
 	}
+	// Stalls are suspicions, not failures: the suspected lane stays in
+	// service while the rescue runs beside it. rescue_attempts outpaces
+	// rescue wins by what the first-wins race cancelled, and a win by an
+	// attempt above zero is a parallel dial beating the established strategy.
+	fmt.Fprintf(w, "queqiao_flow_stalls_detected_total %d\n", s.FlowStallsDetected)
+	fmt.Fprintf(w, "queqiao_stall_spare_attaches_total %d\n", s.StallSpareAttaches)
+	fmt.Fprintf(w, "queqiao_lane_rescue_attempts_total %d\n", s.LaneRescueAttempts)
+	for i, value := range s.LaneRescueWins {
+		fmt.Fprintf(w, "queqiao_lane_rescue_wins_total{attempt=\"%d\"} %d\n", i, value)
+	}
+	fmt.Fprintf(w, "queqiao_lane_grace_extensions_total %d\n", s.LaneGraceExtensions)
 }
 
 // ReceiveErasure is the share of the peer's source symbols that did not arrive,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -129,6 +129,47 @@ func TestReplayAndIsolationCountersAreExported(t *testing.T) {
 	}
 }
 
+// The stall-watchdog and parallel-rescue counters are exported both in the
+// snapshot and on /metrics, with the winning attempt as a bounded label.
+func TestStallAndRescueCountersAreExported(t *testing.T) {
+	registry := New()
+	registry.FlowStallDetected()
+	registry.StallSpareAttached()
+	registry.LaneRescueAttempt()
+	registry.LaneRescueAttempt()
+	registry.LaneRescueAttempt()
+	registry.LaneRescueWin(2)
+	registry.LaneRescueWin(-1)
+	registry.LaneRescueWin(RescueAttemptSlots)
+	registry.LaneGraceExtended()
+
+	got := registry.Snapshot()
+	if got.FlowStallsDetected != 1 || got.StallSpareAttaches != 1 || got.LaneGraceExtensions != 1 {
+		t.Fatalf("unexpected stall snapshot: %+v", got)
+	}
+	if got.LaneRescueAttempts != 3 {
+		t.Fatalf("rescue attempts = %d, want 3", got.LaneRescueAttempts)
+	}
+	if got.LaneRescueWins != [RescueAttemptSlots]uint64{0, 0, 1} {
+		t.Fatalf("rescue wins = %v, want only attempt 2", got.LaneRescueWins)
+	}
+
+	recorder := httptest.NewRecorder()
+	registry.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := recorder.Body.String()
+	for _, want := range []string{
+		"queqiao_flow_stalls_detected_total 1",
+		"queqiao_stall_spare_attaches_total 1",
+		"queqiao_lane_rescue_attempts_total 3",
+		"queqiao_lane_rescue_wins_total{attempt=\"2\"} 1",
+		"queqiao_lane_grace_extensions_total 1",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics output is missing %q", want)
+		}
+	}
+}
+
 // Releasing more than was acquired must not drive the gauge negative, or the
 // endpoint budget would appear to have capacity it does not have.
 func TestReplayBytesGaugeCannotGoNegative(t *testing.T) {

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -1561,6 +1561,15 @@ type laneJoinResult struct {
 // this endpoint is the ordinary way to reach it.
 var errLaneJoinRejected = errors.New("lane join rejected")
 
+// errLaneJoinCapacity is a refusal by the peer's own lane admission ceiling,
+// in contrast to errLaneJoinRejected's permanent answers about the session.
+// It says nothing about the session and nothing about the path: the flow the
+// lane would join is alive, and the answer can change as lanes come and go,
+// so it neither ends a rescue round early nor marks the session unresumable.
+// The ordinary way to reach it is several rescue JOINs racing the peer's
+// lane cap, where all but the first admitted are supposed to lose.
+var errLaneJoinCapacity = errors.New("lane join refused by peer lane capacity")
+
 // errBulkConnectionLimit is a scheduling answer, not a transport failure.
 // The caller keeps the flow on its pooled control connection when every
 // isolation slot is occupied. Falling back to a dedicated connection here
@@ -1625,6 +1634,9 @@ func (c *Client) completeLaneJoin(lane *authenticatedLane, flowID uint64, flags 
 	if response.Header.Type == protocol.TypeReset && response.Header.SessionID == lane.sessionID && response.Header.FlowID == flowID {
 		_ = lane.fc.Close()
 		if len(response.Payload) > 1 {
+			if session.ResetCode(response.Payload[0]) == session.ResetFlowLimit {
+				return nil, fmt.Errorf("%w: %s", errLaneJoinCapacity, string(response.Payload[1:]))
+			}
 			return nil, fmt.Errorf("%w: %s", errLaneJoinRejected, string(response.Payload[1:]))
 		}
 		return nil, errLaneJoinRejected
@@ -1930,12 +1942,57 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 	var isolationBlockedUntil time.Time
 	var isolationBackoff time.Duration
 	isolationAttempts := 0
+	var stallBackoff time.Duration
+	var nextStallRescue time.Time
 	for {
 		select {
 		case <-flow.doneChan():
 			return
 		case <-manageCtx.Done():
 			return
+		case <-flow.stallSignals():
+			// The watchdog suspects the lane, not declares it dead: the flow
+			// still has one, so this is a rescue beside the existing lane,
+			// not a replacement for a lost one. A flow with no lane at all is
+			// the outage path below, which owns that case.
+			if flow.doneChanClosed() {
+				return
+			}
+			if len(flow.healthyLanes()) == 0 {
+				continue
+			}
+			now := time.Now()
+			if now.Before(nextStallRescue) {
+				continue
+			}
+			if err := c.openParallelRescue(manageCtx, flow, sessionID, flowID); err != nil {
+				if manageCtx.Err() != nil || flow.doneChanClosed() {
+					return
+				}
+				if errors.Is(err, errLaneJoinRejected) {
+					// As below: the peer's answer is permanent, so stop.
+					flow.resumeRefused.Store(true)
+					c.cfg.Logger.Debug("peer cannot resume this association", "flow_id", flowID, "error", err)
+					return
+				}
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					c.cfg.Logger.Warn("stall rescue unavailable", "flow_id", flowID, "error", err)
+				}
+				if stallBackoff == 0 {
+					stallBackoff = time.Second
+				} else if stallBackoff < 15*time.Second {
+					stallBackoff *= 2
+					if stallBackoff > 15*time.Second {
+						stallBackoff = 15 * time.Second
+					}
+				}
+				nextStallRescue = time.Now().Add(stallBackoff)
+			} else {
+				// A fresh lane must prove itself before the next round of
+				// dials; the watchdog will re-signal if the stall is real.
+				stallBackoff = 0
+				nextStallRescue = time.Now().Add(time.Second)
+			}
 		case <-ticker.C:
 			// The remote completion watcher can close its lanes just before
 			// this scheduler tick. Both FIN directions are already known at
@@ -1954,7 +2011,7 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 						if manageCtx.Err() != nil || flow.doneChanClosed() {
 							return
 						}
-						if errors.Is(result.err, errLaneJoinRejected) {
+						if errors.Is(result.err, errLaneJoinRejected) || errors.Is(result.err, errLaneJoinCapacity) {
 							// The peer's ceiling, not a broken path. Keep the
 							// flow where it is.
 							isolated = true
@@ -2013,7 +2070,7 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 				recoveryAttempts++
 				lastRecoveryAttempt = now
 				flow.noteReplacementAttempt()
-				if err := c.openRecoveryLane(manageCtx, flow, sessionID, flowID); err != nil {
+				if err := c.openParallelRescue(manageCtx, flow, sessionID, flowID); err != nil {
 					flow.noteReplacementFailure()
 					if errors.Is(err, errLaneJoinRejected) {
 						// The peer answered, and its answer was that it does
@@ -2213,6 +2270,13 @@ func (c *Client) manageTCPBundle(ctx context.Context, flow *multipathFlow, sessi
 					c.cfg.Logger.Debug("peer refused TCP bundle lane", "lane", result.id, "error", result.err)
 					continue
 				}
+				if errors.Is(result.err, errLaneJoinCapacity) {
+					// The peer's lane ceiling, not a lost session: stop
+					// widening, but the lanes the bundle has stay valid.
+					bundleDisabled = true
+					c.cfg.Logger.Debug("peer lane capacity reached for TCP bundle", "lane", result.id, "error", result.err)
+					continue
+				}
 				bundleFailures++
 				lastFailure = time.Now()
 				if retryBackoff == 0 {
@@ -2358,14 +2422,166 @@ func shouldPrewarmBulkLane(snapshot flowSnapshot) bool {
 	return larger/smaller >= bulkLaneAsymmetry
 }
 
-func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) error {
+// rescueAttempt is one dial+JOIN strategy in a parallel rescue round.
+type rescueAttempt func(ctx context.Context) (*mpLane, error)
+
+// openParallelRescue runs a round of concurrent dial+JOIN attempts and
+// installs the first lane whose JOIN completes. It exists because the rescue
+// it replaces was one serialized handshake racing the flow's replacement
+// grace: on a path erasing a third of packets, a single handshake is a coin
+// flip repeated slowly, while several independent handshakes fail together
+// only when the path truly carries nothing.
+//
+// Attempt zero is the established recovery strategy unchanged -- for a pooled
+// flow that is the shared control generation (whose dial stays singleflight:
+// every affected flow coalesces onto it, and the racers below never touch
+// that generation's state), and for AUTO it keeps the bounded QUIC window
+// followed by exactly one committed TCP JOIN. The remaining attempts are
+// independent dedicated QUIC dials. Each one draws the next walked hop port,
+// so with port hopping configured they spray across the pool; without it they
+// dial the same single port, where the value is independent handshakes with
+// independent retransmission schedules rather than port diversity. The TCP
+// fallback's conditions are untouched: a TCP commit can still only come from
+// attempt zero, on the same terms openRecoveryLane always had.
+func (c *Client) openParallelRescue(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) error {
+	// As in openRecoveryLane: a completed flow must not keep dialing. Only
+	// attempt zero checks this itself; the sprayed racers rely on the guard
+	// here.
+	if flow.finSent.Load() && flow.remoteFinSeen.Load() {
+		return context.Canceled
+	}
+	attempts := make([]rescueAttempt, 0, metrics.RescueAttemptSlots)
+	attempts = append(attempts, func(ctx context.Context) (*mpLane, error) {
+		return c.openRecoveryLane(ctx, flow, sessionID, flowID)
+	})
+	if c.cfg.Transport != TransportTCP {
+		for len(attempts) < metrics.RescueAttemptSlots {
+			attempts = append(attempts, func(ctx context.Context) (*mpLane, error) {
+				return c.openSprayedQUICRescueJoin(ctx, flow, sessionID, flowID)
+			})
+		}
+	}
+	lane, winner, err := c.raceRescueAttempts(ctx, flow, attempts)
+	if err != nil {
+		return err
+	}
+	if err := c.installRecoveryLane(flow, lane); err != nil {
+		return err
+	}
+	c.cfg.Logger.Info("lane rescue joined", "flow", flowID, "winning_attempt", winner, "attempts", len(attempts), "lane", lane.id)
+	return nil
+}
+
+// openSprayedQUICRescueJoin is one independent QUIC dial+JOIN for the
+// parallel rescue: its own connection, its own handshake retransmission
+// schedule, and -- through the shared hop walk -- the next port in a shuffled
+// permutation of the hop pool, which makes concurrent attempts uniform over
+// the available ports without repeating one.
+func (c *Client) openSprayedQUICRescueJoin(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) (*mpLane, error) {
+	laneID, err := flow.allocateJoinID()
+	if err != nil {
+		return nil, err
+	}
+	lane, err := c.dialJoinLane(ctx, TransportQUIC, sessionID, laneID)
+	if err != nil {
+		return nil, err
+	}
+	return c.completeLaneJoin(lane, flowID, 0)
+}
+
+// raceRescueAttempts runs a rescue round: every attempt starts together, the
+// first successful JOIN wins, and the losers' contexts are cancelled at once.
+// Losing lanes are closed wherever they surface -- an attempt finishing after
+// the race was decided closes its own lane, and the drain collects any that
+// completed in the window before the cancellation reached them.
+//
+// The race is deliberately not transactional with the server, which admits
+// JOINs in arrival order while the winner here is the first finisher. What
+// keeps a late losing JOIN from evicting the winner's server side at the
+// lane ceiling is the server: it protects freshly admitted lanes from
+// eviction and refuses the loser by capacity instead (see retireOldestLane),
+// and a capacity refusal is exactly the per-attempt failure errLaneJoinCapacity
+// carries back here.
+func (c *Client) raceRescueAttempts(ctx context.Context, flow *multipathFlow, attempts []rescueAttempt) (*mpLane, int, error) {
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	// As in openRecoveryLane: a rescue handshake must not outlive its flow.
+	go func() {
+		select {
+		case <-flow.doneChan():
+			cancel()
+		case <-raceCtx.Done():
+		}
+	}()
+	type result struct {
+		lane    *mpLane
+		attempt int
+		err     error
+	}
+	results := make(chan result, len(attempts))
+	for i, attempt := range attempts {
+		c.metrics.LaneRescueAttempt()
+		go func(i int, attempt rescueAttempt) {
+			lane, err := attempt(raceCtx)
+			if err == nil && lane != nil && raceCtx.Err() != nil {
+				// Finished after the race was decided: close it here rather
+				// than trusting the drain to see it.
+				_ = lane.fc.Close()
+				lane = nil
+				err = context.Canceled
+			}
+			results <- result{lane: lane, attempt: i, err: err}
+		}(i, attempt)
+	}
+	drain := func(pending int) {
+		for ; pending > 0; pending-- {
+			if loser := <-results; loser.lane != nil {
+				_ = loser.lane.fc.Close()
+			}
+		}
+	}
+	pending := len(attempts)
+	var firstErr error
+	for pending > 0 {
+		r := <-results
+		pending--
+		if r.err == nil && r.lane != nil {
+			cancel()
+			go drain(pending)
+			c.metrics.LaneRescueWin(r.attempt)
+			return r.lane, r.attempt, nil
+		}
+		if errors.Is(r.err, errLaneJoinRejected) {
+			// The peer answered, and its answer does not change between
+			// attempts: a session identifier is random and is never reissued.
+			// Cancel the rest of the round rather than learn it twice more.
+			cancel()
+			go drain(pending)
+			return nil, -1, r.err
+		}
+		if firstErr == nil {
+			firstErr = r.err
+		}
+	}
+	if firstErr == nil {
+		firstErr = errors.New("lane rescue ran no attempts")
+	}
+	return nil, -1, firstErr
+}
+
+// openRecoveryLane dials one replacement lane following the established
+// recovery strategy and returns it uninstalled; the parallel rescue installs
+// only the round's winner. The strategy itself is unchanged: the pooled
+// control generation first for a pooled flow, the bounded QUIC window and
+// single committed TCP JOIN for AUTO, the plain join otherwise.
+func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) (*mpLane, error) {
 	// A replacement handshake must not outlive its logical flow. Without this
 	// bound, a dead UDP flow can keep dialing a session that the server has
 	// already unregistered after the application completed.
 	recoveryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	if flow.finSent.Load() && flow.remoteFinSeen.Load() {
-		return context.Canceled
+		return nil, context.Canceled
 	}
 	go func() {
 		select {
@@ -2376,7 +2592,7 @@ func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sess
 	}()
 	laneID, err := flow.allocateJoinID()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var lane *mpLane
 	// A flow opened on the shared control pool should be repaired on the next
@@ -2399,10 +2615,10 @@ func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sess
 			quicCancel()
 		}
 		if err == nil {
-			return c.installRecoveryLane(flow, lane)
+			return lane, nil
 		}
 		if recoveryCtx.Err() != nil || flow.doneChanClosed() {
-			return context.Canceled
+			return nil, context.Canceled
 		}
 		if c.cfg.Transport == TransportQUIC {
 			// Protocol-v1 development peers predating control-role JOINs reject the flag.
@@ -2426,11 +2642,11 @@ func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sess
 	}
 	if err != nil {
 		if recoveryCtx.Err() != nil || flow.doneChanClosed() {
-			return context.Canceled
+			return nil, context.Canceled
 		}
-		return err
+		return nil, err
 	}
-	return c.installRecoveryLane(flow, lane)
+	return lane, nil
 }
 
 func (c *Client) installRecoveryLane(flow *multipathFlow, lane *mpLane) error {

--- a/internal/pep/lanegrace_test.go
+++ b/internal/pep/lanegrace_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/metrics"
 	"github.com/bojieli/queqiao/internal/protocol"
 )
 
@@ -312,5 +314,89 @@ func TestAFlowRecordsWhetherAReplacementWasEvenAttempted(t *testing.T) {
 	if got["lane_replacement_attempts"] != uint64(1) || got["lane_replacement_failures"] != uint64(0) {
 		t.Fatalf("an outstanding dial reported attempts=%v failures=%v, want 1 and 0",
 			got["lane_replacement_attempts"], got["lane_replacement_failures"])
+	}
+}
+
+// A rescue JOIN arriving mid-grace is the peer's recovery proving itself
+// alive. The grace restarts from that evidence rather than expiring
+// underneath the handshake it was waiting for; a flow not in an outage has
+// nothing to extend, and a deadline a whole grace in the past is an ended
+// outage's residue, not evidence to build on.
+func TestRescueEvidenceRestartsTheReplacementGrace(t *testing.T) {
+	flow := newGraceTestFlow(t)
+	now := time.Now()
+	if flow.extendReplacementOutage(now, laneReplacementWait) {
+		t.Fatal("a flow not in an outage had its grace extended")
+	}
+	if remaining := flow.replacementBudget(now, laneReplacementWait); remaining != laneReplacementWait {
+		t.Fatalf("opening an outage left %s, want the whole grace", remaining)
+	}
+	before := flow.replacementDeadline.Load()
+	later := now.Add(time.Second)
+	if !flow.extendReplacementOutage(later, laneReplacementWait) {
+		t.Fatal("a live outage refused its extension")
+	}
+	if got, want := flow.replacementDeadline.Load(), later.Add(laneReplacementWait).UnixNano(); got != want {
+		t.Fatalf("extended deadline = %d, want %d", got, want)
+	}
+	if flow.replacementDeadline.Load() <= before {
+		t.Fatal("the extension did not move the deadline forward")
+	}
+	flow.replacementDeadline.Store(now.Add(-2 * laneReplacementWait).UnixNano())
+	if flow.extendReplacementOutage(now, laneReplacementWait) {
+		t.Fatal("a stale deadline was revived by rescue evidence")
+	}
+}
+
+// The gateway observes the rescue at JOIN validation time: a JOIN naming a
+// live session currently waiting out an outage restarts that outage's grace
+// and is counted.
+func TestLaneJoinDuringGraceExtendsTheBudget(t *testing.T) {
+	owner := identity.Principal{ProviderID: "provider", AccountID: "account", DeviceID: "owner"}
+	registry := metrics.New()
+	server := &Server{
+		cfg:      ServerConfig{Logger: slog.New(slog.NewTextHandler(discardWriter{}, nil))},
+		sessions: map[[16]byte]*serverFlow{},
+		metrics:  registry,
+	}
+	flow := newGraceTestFlow(t)
+	server.sessions[flow.sessionID] = newServerFlow(flow, owner, TransportTCP, 1)
+	now := time.Now()
+	if remaining := flow.replacementBudget(now, laneReplacementWait); remaining != laneReplacementWait {
+		t.Fatalf("opening an outage left %s, want the whole grace", remaining)
+	}
+
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	request := protocol.Frame{Header: protocol.Header{
+		Version: protocol.Version, Type: protocol.TypeJoin, SessionID: flow.sessionID,
+		FlowID: flow.flowID, Class: protocol.ClassBulk,
+	}}
+	go server.handleLaneJoinOpen(ctx, local, newFrameConn(local), owner, flow.sessionID, 1, request)
+	response, err := newFrameConn(remote).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Header.Type != protocol.TypeOpenOK {
+		t.Fatalf("response = %d, want OPEN_OK", response.Header.Type)
+	}
+	if got := registry.Snapshot().LaneGraceExtensions; got != 1 {
+		t.Fatalf("grace extensions = %d, want 1", got)
+	}
+	// The deadline itself goes away once the admitted lane is activated,
+	// which is the extension working as intended: what it bought was the time
+	// between this JOIN becoming observable and its admission completing.
+	// Activation trails the acknowledgement by a scheduling beat, so wait
+	// for it.
+	for deadline := time.Now().Add(2 * time.Second); ; {
+		if flow.replacementDeadline.Load() == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the admitted lane never ended the outage")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }

--- a/internal/pep/laneisolation_test.go
+++ b/internal/pep/laneisolation_test.go
@@ -176,6 +176,11 @@ func TestServerReplacesALaneWithTheSameRole(t *testing.T) {
 	if err := session.addLane(bulk); err != nil {
 		t.Fatal(err)
 	}
+	// Eviction exists for lanes whose peer has already moved on, so the
+	// victims here must be older than the protection window: a freshly
+	// admitted lane is never retired to make room.
+	control.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	bulk.admitted = time.Now().Add(-2 * laneDeadPathDetection)
 
 	bulkReplacement := isolationLane(t, 2)
 	if err := session.addLane(bulkReplacement); err != nil {
@@ -192,6 +197,43 @@ func TestServerReplacesALaneWithTheSameRole(t *testing.T) {
 	}
 	if !control.closed.Load() || bulkReplacement.closed.Load() {
 		t.Fatalf("control replacement retired old-control=%t bulk=%t, want true/false", control.closed.Load(), bulkReplacement.closed.Load())
+	}
+}
+
+// Parallel rescue JOINs race one another to the gateway, which admits in
+// arrival order while the peer crowns the first finisher. A freshly admitted
+// lane must therefore be protected from eviction at the lane ceiling:
+// without the protection, a losing JOIN admitted moments after the winner
+// retires the winner's server side before its own close lands, and the
+// "rescue" leaves the flow with no lane at all.
+func TestFreshlyAdmittedLaneIsProtectedFromEviction(t *testing.T) {
+	flow := newIsolationTestFlow(t, true)
+	session := newServerFlow(flow, identity.Principal{}, TransportQUIC, 1)
+	control := isolationLane(t, 0)
+	control.control = true
+	bulk := isolationLane(t, 1)
+	if err := session.addLane(control); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.addLane(bulk); err != nil {
+		t.Fatal(err)
+	}
+
+	racing := isolationLane(t, 2)
+	if err := session.addLane(racing); err == nil {
+		t.Fatal("a racing join evicted a freshly admitted lane")
+	}
+	if bulk.closed.Load() {
+		t.Fatal("the freshly admitted lane was retired by the racing join")
+	}
+	// Once the lane is older than the path-detection budget it is the
+	// half-open socket eviction exists for, and the next join takes its slot.
+	bulk.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	if err := session.addLane(racing); err != nil {
+		t.Fatalf("replacement of an aged lane refused: %v", err)
+	}
+	if !bulk.closed.Load() || racing.closed.Load() {
+		t.Fatalf("aged replacement retired bulk=%t racing=%t, want true/false", bulk.closed.Load(), racing.closed.Load())
 	}
 }
 

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -142,6 +142,12 @@ type mpLane struct {
 	closed            atomic.Bool
 	sent              atomic.Uint64
 	recv              atomic.Uint64
+	// suspected is the flow-stall watchdog's demotion mark: the lane is
+	// believed to be carrying nothing useful, so it is passed over for new
+	// writes while a healthier lane exists. It is never closed for this --
+	// it keeps receiving, and an acknowledgement arriving on it clears the
+	// mark, because that is direct proof the lane still round-trips.
+	suspected atomic.Bool
 	// rateMu guards a short-lived cache of the lane's transport statistics.
 	// Reading them from QUIC on every frame would take the connection lock on
 	// the hot path for information that changes on an RTT timescale.
@@ -287,6 +293,42 @@ type multipathFlow struct {
 	// which is the true answer there: it opens nothing.
 	replacementAttempts atomic.Uint64
 	replacementFailures atomic.Uint64
+	// Stall watchdog state. A lane is declared dead only on I/O error, which
+	// on a path losing one direction means fifteen seconds of receive silence
+	// -- while a flow with a full send window and no acknowledgements is
+	// making no progress long before that. The watchdog measures progress
+	// where delivery to the peer is actually recorded (the acknowledged send
+	// offset and payload arrival) and, finding none while work is pending,
+	// demotes the lane and asks for a rescue beside it. Nothing here closes
+	// anything: suspected lanes keep receiving, and recover their full
+	// eligibility on the first acknowledgement they carry.
+	//
+	// All of it is atomic or local to the watchdog goroutine; it introduces
+	// no lock, and in particular never touches lanesMu while holding chunkMu
+	// or replayMu.
+	lastAckProgressNS atomic.Int64
+	lastUpPayloadNS   atomic.Int64
+	lastDownPayloadNS atomic.Int64
+	// upAtLastDown is bytesUp at the moment the last downstream payload
+	// arrived. bytesUp above it means the application sent something the
+	// peer has not answered yet, which is the watchdog's "outstanding
+	// request" gate for flows waiting on a response.
+	upAtLastDown atomic.Uint64
+	// minRTTNS is the smallest controller minimum-RTT the flow's lanes have
+	// reported, refreshed by observeTransport. The stall threshold is three
+	// of these.
+	minRTTNS atomic.Int64
+	// stallSignal advises the lane manager that a stall episode is in
+	// progress. It is buffered at one and sent non-blockingly: the manager
+	// acts on the flow's current state when it wakes, so a coalesced signal
+	// loses nothing, and a flow with no listener (the server end) never
+	// blocks its watchdog.
+	stallSignal chan struct{}
+	// stallScan and stallGrace are zero in production. Tests shorten them so
+	// the watchdog can be exercised without sleeping for seconds, the same
+	// pattern as abortGrace above.
+	stallScan  time.Duration
+	stallGrace time.Duration
 	// controlLaneShared reports whether another flow is currently using the
 	// pooled control connection. Nil means "no", which is what a flow on a
 	// dedicated connection should answer.
@@ -420,7 +462,8 @@ func newMultipathFlowWithMemory(ctx context.Context, inner net.Conn, sessionID [
 		finalAck: make(chan struct{}, 1), sendDone: make(chan struct{}),
 		done: make(chan struct{}), localClosedCh: make(chan struct{}), remoteAbortCh: make(chan struct{}),
 		ackWake: make(chan struct{}, 1), ackErr: make(chan error, 1),
-		classifier: classifier.New(classifierCfg), started: time.Now(), completionGrace: flowCompletionGrace,
+		stallSignal: make(chan struct{}, 1),
+		classifier:  classifier.New(classifierCfg), started: time.Now(), completionGrace: flowCompletionGrace,
 	}
 	f.idleTimeout = defaultFlowIdleTimeout
 	f.maxLifetime = defaultFlowMaxLifetime
@@ -769,6 +812,22 @@ func (f *multipathFlow) observeTransport(lanes []*mpLane) {
 		f.currentRTTNS.Store(observation.SmoothedRTT.Nanoseconds())
 		f.baselineRTTNS.CompareAndSwap(0, observation.SmoothedRTT.Nanoseconds())
 	}
+	// The stall watchdog sizes its patience from the smallest minimum-RTT any
+	// lane reports: the best case the path has shown, not the worst lane's
+	// current estimate the telemetry aggregate above publishes.
+	var minRTT time.Duration
+	for _, lane := range lanes {
+		provider, ok := lane.fc.transport().(laneStatsProvider)
+		if !ok {
+			continue
+		}
+		if rtt := provider.transportStats().controller.MinRTT; rtt > 0 && (minRTT == 0 || rtt < minRTT) {
+			minRTT = rtt
+		}
+	}
+	if minRTT > 0 {
+		f.minRTTNS.Store(minRTT.Nanoseconds())
+	}
 	// The connection totals are banked whether or not this flow may still
 	// publish its own gauges. They are monotonic and belong to the connection,
 	// so a late reading can neither pin nor inflate them, and discarding it
@@ -802,11 +861,21 @@ func (f *multipathFlow) laneCount() int {
 // dead lane but the server-side socket is still half-open. It is only used at
 // the configured lane cap; deleting the entry keeps the cap a real resource
 // bound rather than allowing unbounded historical lane IDs.
-func (f *multipathFlow) retireOldestLane(control bool) bool {
+//
+// A lane younger than minAge is never the victim. Parallel rescue JOINs race
+// one another to this endpoint, and admission order is not the order the
+// peer crowned its winner in: retiring a lane admitted moments ago lets a
+// losing JOIN evict the winner's server side before its own close lands.
+// The lanes eviction legitimately exists for -- half-open sockets whose
+// peer has already given up -- are at least a path-detection budget old.
+func (f *multipathFlow) retireOldestLane(control bool, minAge time.Duration) bool {
 	f.lanesMu.Lock()
 	var victim *mpLane
 	for _, lane := range f.lanes {
 		if lane.closed.Load() || !f.laneReady(lane) || f.laneIsControl(lane) != control {
+			continue
+		}
+		if minAge > 0 && time.Since(lane.admitted) < minAge {
 			continue
 		}
 		if victim == nil || lane.id < victim.id {
@@ -1186,6 +1255,7 @@ func (f *multipathFlow) laneCandidates(bulk bool) ([]*mpLane, error) {
 	if len(lanes) == 0 {
 		return nil, errors.New("no healthy lanes")
 	}
+	lanes = preferUnsuspectedLanes(lanes)
 	if !bulk {
 		// Prefer the explicit control role. It begins on lane zero, but a
 		// connection-generation reset replaces it with a non-zero JOIN lane.
@@ -1199,6 +1269,31 @@ func (f *multipathFlow) laneCandidates(bulk bool) ([]*mpLane, error) {
 		return lanes[:1], nil
 	}
 	return f.dataLane(lanes), nil
+}
+
+// preferUnsuspectedLanes implements the watchdog's demote-don't-kill rule:
+// while any healthy lane is not stall-suspected, new writes avoid the
+// suspected ones. When every healthy lane is suspected the set is returned
+// unchanged -- a suspected lane that is the only lane still carries the flow,
+// because the suspicion is a reason to look for something better, never a
+// reason to stop using what there is.
+func preferUnsuspectedLanes(lanes []*mpLane) []*mpLane {
+	clear := 0
+	for _, lane := range lanes {
+		if !lane.suspected.Load() {
+			clear++
+		}
+	}
+	if clear == 0 || clear == len(lanes) {
+		return lanes
+	}
+	preferred := make([]*mpLane, 0, clear)
+	for _, lane := range lanes {
+		if !lane.suspected.Load() {
+			preferred = append(preferred, lane)
+		}
+	}
+	return preferred
 }
 
 // dataLane selects the lanes a flow's data rides.
@@ -1280,6 +1375,8 @@ func (f *multipathFlow) run(ctx context.Context) (FlowStats, error) {
 	go f.telemetryLoop(telemetryStop)
 	completionStop := make(chan struct{})
 	go f.completionWatchdog(completionStop)
+	stallStop := make(chan struct{})
+	go f.stallWatchdog(stallStop)
 	limitsStop := make(chan struct{})
 	limitErr := make(chan error, 1)
 	go f.watchLimits(limitsStop, limitErr)
@@ -1295,6 +1392,7 @@ func (f *multipathFlow) run(ctx context.Context) (FlowStats, error) {
 		cancelACKs()
 		close(limitsStop)
 		close(completionStop)
+		close(stallStop)
 		close(telemetryStop)
 	}()
 	defer f.finished.Store(true)
@@ -1566,6 +1664,193 @@ func (f *multipathFlow) completionWatchdog(stop <-chan struct{}) {
 		}
 	}
 }
+
+const (
+	// stallScanInterval is the watchdog's detection granularity. It is well
+	// under the smallest threshold the clamp below can produce, so a stall is
+	// suspected within one threshold of becoming true rather than one scan.
+	stallScanInterval = 100 * time.Millisecond
+	// The threshold is three minimum round trips, clamped. The floor keeps a
+	// fast LAN path from paying a rescue for an ordinary scheduling hiccup;
+	// the cap keeps a slow path from waiting so long that the rescue itself
+	// becomes the flow's whole remaining budget. Before any RTT sample
+	// exists the flow gets the conservative default: long enough that a
+	// handshake still finding its path is not a stall, short enough to
+	// matter against the fifteen seconds an I/O error takes.
+	stallRTTMultiplier    = 3
+	stallThresholdFloor   = 250 * time.Millisecond
+	stallThresholdCap     = 2 * time.Second
+	stallThresholdDefault = time.Second
+)
+
+// stallThreshold is how long pending work may see no forward progress before
+// the flow is suspected stalled: three minimum round trips, clamped.
+func (f *multipathFlow) stallThreshold() time.Duration {
+	if f.stallGrace > 0 {
+		return f.stallGrace
+	}
+	rtt := time.Duration(f.minRTTNS.Load())
+	if rtt <= 0 {
+		rtt = time.Duration(f.currentRTTNS.Load())
+	}
+	if rtt <= 0 {
+		return stallThresholdDefault
+	}
+	threshold := stallRTTMultiplier * rtt
+	if threshold < stallThresholdFloor {
+		return stallThresholdFloor
+	}
+	if threshold > stallThresholdCap {
+		return stallThresholdCap
+	}
+	return threshold
+}
+
+// pendingOutbound reports whether the flow holds bytes the peer has not
+// acknowledged. This is the watchdog's strict gate: a flow whose application
+// simply has nothing to send is never a stall, however quiet the path is.
+func (f *multipathFlow) pendingOutbound() bool {
+	f.replayMu.Lock()
+	unacked := f.highestSent > f.acked
+	f.replayMu.Unlock()
+	if unacked {
+		return true
+	}
+	f.chunkMu.Lock()
+	pending := len(f.outstandingChunks) > 0
+	f.chunkMu.Unlock()
+	return pending
+}
+
+// responseOutstanding reports whether the flow is waiting on an answer: the
+// application sent something since the last downstream payload arrived, and
+// neither side has closed. An idle conversation fails this test because its
+// last send was answered, so waiting on one never triggers the watchdog.
+func (f *multipathFlow) responseOutstanding() bool {
+	if f.remoteFinSeen.Load() || f.finSent.Load() || f.localAbortSent.Load() {
+		return false
+	}
+	return f.bytesUp.Load() > f.upAtLastDown.Load()
+}
+
+// scanStall advances one pending/progress pair and reports whether the pair
+// has now been pending without progress for the threshold. The clock starts
+// when pending is first observed and restarts at every newer progress stamp,
+// so a flow that sat idle for an hour and then sent one byte gets a full
+// threshold for that byte's round trip.
+func scanStall(pending bool, progressNS int64, now time.Time, threshold time.Duration, since *time.Time) bool {
+	if !pending {
+		*since = time.Time{}
+		return false
+	}
+	if since.IsZero() {
+		*since = now
+		return false
+	}
+	if progressNS > 0 {
+		if progress := time.Unix(0, progressNS); progress.After(*since) {
+			*since = progress
+			return false
+		}
+	}
+	return now.Sub(*since) >= threshold
+}
+
+// stallWatchdog is the flow's "lane sick" detector, the complement of
+// failLane: failLane learns a lane is dead from an I/O error, which on a path
+// erasing one direction takes the transport's whole idle timeout of receive
+// silence. This watchdog instead measures forward progress -- the
+// acknowledged send offset moving, payload arriving -- and, finding none for
+// three round trips while work is pending, demotes the current data lane and
+// asks the lane manager for a rescue. It never fails a lane and never closes
+// anything: the suspected lane keeps receiving and is used again the moment
+// nothing healthier exists, and an acknowledgement arriving on it clears the
+// suspicion outright.
+func (f *multipathFlow) stallWatchdog(stop <-chan struct{}) {
+	interval := f.stallScan
+	if interval <= 0 {
+		interval = stallScanInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	var sendSince, responseSince time.Time
+	episode := false
+	var lastSignal time.Time
+	for {
+		select {
+		case <-ticker.C:
+		case <-stop:
+			return
+		case <-f.ctx.Done():
+			return
+		}
+		now := time.Now()
+		threshold := f.stallThreshold()
+		stalledSend := scanStall(f.pendingOutbound(), f.lastAckProgressNS.Load(), now, threshold, &sendSince)
+		var responseBase int64
+		if down, up := f.lastDownPayloadNS.Load(), f.lastUpPayloadNS.Load(); down > up {
+			responseBase = down
+		} else {
+			responseBase = up
+		}
+		stalledResponse := scanStall(f.responseOutstanding(), responseBase, now, threshold, &responseSince)
+		if !stalledSend && !stalledResponse {
+			episode = false
+			continue
+		}
+		if !episode {
+			episode = true
+			spare := f.suspectDataLanes()
+			if f.metrics != nil {
+				f.metrics.FlowStallDetected()
+				if spare {
+					f.metrics.StallSpareAttached()
+				}
+			}
+			if f.logger != nil {
+				f.logger.Info("flow stall suspected; lane demoted and rescue requested",
+					"flow_id", f.flowID, "threshold", threshold,
+					"send_stalled", stalledSend, "response_stalled", stalledResponse,
+					"healthy_spare", spare, "lanes", f.laneCount(),
+					"bytes_up", f.bytesUp.Load(), "bytes_down", f.bytesDown.Load())
+			}
+		}
+		// The manager's own backoff paces the dials; this pacing only keeps a
+		// persistent stall from queueing signals faster than they can be
+		// acted on. An episode that outlives its rescue still re-asks, because
+		// the stall it describes is still true.
+		if now.Sub(lastSignal) >= threshold {
+			select {
+			case f.stallSignal <- struct{}{}:
+				lastSignal = now
+			default:
+			}
+		}
+	}
+}
+
+// suspectDataLanes marks the lanes currently carrying the flow's data as
+// stall-suspected and reports whether a non-suspected healthy lane remains to
+// take over new writes at once -- the warm-spare case, where the switch costs
+// one scheduler poll rather than a handshake.
+func (f *multipathFlow) suspectDataLanes() bool {
+	lanes := f.healthyLanes()
+	if len(lanes) == 0 {
+		return false
+	}
+	for _, lane := range f.dataLane(lanes) {
+		lane.suspected.Store(true)
+	}
+	for _, lane := range f.healthyLanes() {
+		if !lane.suspected.Load() {
+			return true
+		}
+	}
+	return false
+}
+
+// stallSignals exposes the watchdog's rescue request to the lane manager.
+func (f *multipathFlow) stallSignals() <-chan struct{} { return f.stallSignal }
 
 func (f *multipathFlow) telemetryLoop(stop <-chan struct{}) {
 	ticker := time.NewTicker(time.Second)
@@ -1898,6 +2183,30 @@ func (f *multipathFlow) replacementBudget(now time.Time, grace time.Duration) ti
 // starts from a full grace.
 func (f *multipathFlow) endReplacementOutage() { f.replacementDeadline.Store(0) }
 
+// extendReplacementOutage restarts the current outage's grace from now, and
+// reports whether there was an outage to extend. It exists for the endpoint
+// that waits for a rescue rather than sends one: a rescue JOIN that arrives
+// while the flow is waiting out its grace is observable proof that the peer's
+// recovery is alive and mid-handshake, and letting the hard deadline expire
+// underneath that handshake fails the flow at the moment its rescue is
+// landing. A flow not in an outage has nothing to extend, and a deadline
+// more than a grace into the past is the residue of an outage that already
+// ended, which replacementBudget's own staleness rule discards.
+func (f *multipathFlow) extendReplacementOutage(now time.Time, grace time.Duration) bool {
+	for {
+		deadline := f.replacementDeadline.Load()
+		if deadline == 0 {
+			return false
+		}
+		if time.Unix(0, deadline).Sub(now) <= -grace {
+			return false
+		}
+		if f.replacementDeadline.CompareAndSwap(deadline, now.Add(grace).UnixNano()) {
+			return true
+		}
+	}
+}
+
 func (f *multipathFlow) acknowledgeReplay(sequence uint64, final bool) error {
 	f.replayMu.Lock()
 	if sequence > f.highestSent {
@@ -1908,6 +2217,7 @@ func (f *multipathFlow) acknowledgeReplay(sequence uint64, final bool) error {
 		f.replayMu.Unlock()
 		return nil // delayed ACK from a slower lane
 	}
+	advanced := sequence > f.acked
 	f.acked = sequence
 	if f.ackTrack != nil {
 		f.ackTrack.Advance(sequence)
@@ -1916,6 +2226,12 @@ func (f *multipathFlow) acknowledgeReplay(sequence uint64, final bool) error {
 		f.closeFrame = nil
 	}
 	f.replayMu.Unlock()
+	if advanced {
+		// The acknowledged send offset is the most direct proof that this
+		// flow's bytes are reaching the peer: it only moves when the peer's
+		// receiver says so. It is the stall watchdog's send-side clock.
+		f.lastAckProgressNS.Store(time.Now().UnixNano())
+	}
 	return nil
 }
 
@@ -2399,6 +2715,25 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 				if frame.Header.Flags&f.sendAckFlag == 0 {
 					return errors.New("acknowledgement has wrong direction")
 				}
+				// An acknowledgement carrying new delivery information --
+				// a cumulative point that moved, ranges, or the final ACK --
+				// and arriving on a suspected lane is direct proof the lane
+				// still round-trips: the peer received this flow's bytes and
+				// its answer travelled back on this lane. A bare duplicate
+				// proves nothing about delivery, so it does not clear the
+				// mark. Progress itself is recorded in acknowledgeReplay and
+				// the ranges branch below.
+				clearSuspicion := frame.Header.Flags&protocol.FlagAckFinal != 0 ||
+					frame.Header.Flags&protocol.FlagAckRanges != 0
+				if frame.Header.Flags&protocol.FlagAckFinal == 0 {
+					f.replayMu.Lock()
+					advances := frame.Header.Sequence > f.acked
+					f.replayMu.Unlock()
+					clearSuspicion = clearSuspicion || advances
+				}
+				if clearSuspicion && event.lane != nil {
+					event.lane.suspected.Store(false)
+				}
 				if frame.Header.Flags&protocol.FlagAckFinal == 0 {
 					if err := f.acknowledgeReplay(frame.Header.Sequence, false); err != nil {
 						return err
@@ -2409,6 +2744,10 @@ func (f *multipathFlow) receiveInner(ctx context.Context) error {
 							return fmt.Errorf("acknowledgement ranges: %w", err)
 						}
 						f.ackTrack.Add(ranges)
+						// Ranges above the cumulative point are arrivals too:
+						// the peer has these bytes even though a gap stops
+						// the acknowledged offset from moving.
+						f.lastAckProgressNS.Store(time.Now().UnixNano())
 					}
 					continue
 				}
@@ -2556,8 +2895,19 @@ func (f *multipathFlow) observe(n int, up bool) bool {
 	downBytes := f.bytesDown.Load()
 	if up {
 		upBytes += uint64(n)
+		if n > 0 {
+			f.lastUpPayloadNS.Store(now.UnixNano())
+		}
 	} else {
 		downBytes += uint64(n)
+		// n == 0 is refreshClass re-examining what was already carried, not
+		// an arrival: only real payload answers what was sent.
+		if n > 0 {
+			f.lastDownPayloadNS.Store(now.UnixNano())
+			// A downstream payload answers everything sent so far. Anything
+			// sent after this point is a request the peer has not answered yet.
+			f.upAtLastDown.Store(upBytes)
+		}
 	}
 	recentUp, recentDown := f.recentBytes(now, n, up)
 	obs := classifier.Observation{

--- a/internal/pep/pool_recovery_test.go
+++ b/internal/pep/pool_recovery_test.go
@@ -135,8 +135,16 @@ func TestPooledFlowsRecoverThroughOneReplacementGeneration(t *testing.T) {
 			if t.Failed() {
 				return
 			}
-			if got := udpSockets.Load(); got != baselineSockets+1 {
-				t.Fatalf("generation recovery opened %d new UDP sockets, want one", got-baselineSockets)
+			if got := udpSockets.Load(); got < baselineSockets+1 {
+				t.Fatalf("generation recovery opened %d new UDP sockets, want at least one", got-baselineSockets)
+			} else if want := baselineSockets + 1 + 2*flowCount; got > want {
+				// The replacement generation dial is still singleflight --
+				// one new socket however many flows wait on it, which is what
+				// the old exact assertion pinned. Each flow's rescue round
+				// now also runs two independent sprayed QUIC dials beside it
+				// (first JOIN wins, the losers are cancelled), so the ceiling
+				// is one coalesced generation dial plus two racers per flow.
+				t.Fatalf("generation recovery opened %d new UDP sockets, want the coalesced dial plus at most two racers per flow (%d)", got-baselineSockets, want-baselineSockets)
 			}
 			snapshot := client.Metrics().Snapshot()
 			if snapshot.LaneReplacements != flowCount {

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -165,8 +165,12 @@ func (s *serverFlow) addLane(lane *mpLane) error {
 		// (for example, when the return path is black-holed). Retire the
 		// oldest lane with the same role as its authenticated replacement.
 		// A bulk replacement must never evict the control lane, and a control
-		// generation replacement must not evict healthy bulk capacity.
-		if !s.flow.retireOldestLane(lane.control) || s.flow.laneCount() >= s.maxLanes {
+		// generation replacement must not evict healthy bulk capacity. A lane
+		// younger than the path-detection budget is protected: several rescue
+		// JOINs racing here must not evict the winner the peer already
+		// crowned, and the half-open lanes eviction exists for are never
+		// that young.
+		if !s.flow.retireOldestLane(lane.control, laneDeadPathDetection) || s.flow.laneCount() >= s.maxLanes {
 			return errors.New("flow lane limit reached")
 		}
 	}
@@ -968,6 +972,16 @@ func (s *Server) handleLaneJoinOpen(ctx context.Context, conn streamConn, fc *fr
 	case !samePrincipal(serverSession.principal, principal):
 		s.refuseLaneJoin(fc, sessionID, open.Header.FlowID, laneID, metrics.LaneJoinPrincipalMismatch, session.ResetProtocol, "unknown session")
 		return
+	}
+	// A JOIN that gets this far is the peer's rescue, observable while it is
+	// still only a handshake. If the flow is waiting out a lane-replacement
+	// outage, that grace exists to cover exactly this arrival, so it restarts
+	// here rather than expiring underneath the handshake it was waiting for.
+	// The grace is per outage, so a rescue that dials several JOINs in
+	// parallel extends it once per arriving JOIN, each one fresh evidence.
+	if !serverSession.completed.Load() && serverSession.flow.extendReplacementOutage(time.Now(), laneReplacementWait) {
+		s.metrics.LaneGraceExtended()
+		s.cfg.Logger.Debug("lane replacement grace extended by rescue join", "lane", laneID, "flow_id", open.Header.FlowID)
 	}
 	kind := transportKindForConn(conn)
 	controlReplacement := open.Header.Flags&protocol.FlagReserveControl != 0

--- a/internal/pep/stallwatch_test.go
+++ b/internal/pep/stallwatch_test.go
@@ -1,0 +1,353 @@
+package pep
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/metrics"
+	"github.com/bojieli/queqiao/internal/protocol"
+)
+
+func newStallTestFlow(t *testing.T, registry *metrics.Registry) *multipathFlow {
+	t.Helper()
+	inner, peer := net.Pipe()
+	t.Cleanup(func() { _ = inner.Close(); _ = peer.Close() })
+	return newMultipathFlow(context.Background(), inner, [16]byte{4}, 7, defaultChunkSize, protocol.FlagAckUp, protocol.FlagAckDown, nil, registry)
+}
+
+// The threshold is three minimum round trips, clamped: a fast path never
+// waits less than the floor, a slow one never more than the cap, and a flow
+// with no RTT sample yet gets the conservative default.
+func TestStallThresholdClamp(t *testing.T) {
+	flow := newStallTestFlow(t, nil)
+	if got := flow.stallThreshold(); got != stallThresholdDefault {
+		t.Fatalf("no RTT sample: threshold = %s, want %s", got, stallThresholdDefault)
+	}
+	for _, test := range []struct {
+		rtt  time.Duration
+		want time.Duration
+	}{
+		{50 * time.Millisecond, stallThresholdFloor},
+		{83 * time.Millisecond, stallThresholdFloor},
+		{200 * time.Millisecond, 600 * time.Millisecond},
+		{500 * time.Millisecond, 1500 * time.Millisecond},
+		{time.Second, stallThresholdCap},
+		{5 * time.Second, stallThresholdCap},
+	} {
+		flow.minRTTNS.Store(test.rtt.Nanoseconds())
+		if got := flow.stallThreshold(); got != test.want {
+			t.Fatalf("minRTT %s: threshold = %s, want %s", test.rtt, got, test.want)
+		}
+	}
+	// A controller that reports no minimum still leaves the smoothed reading.
+	flow.minRTTNS.Store(0)
+	flow.currentRTTNS.Store((200 * time.Millisecond).Nanoseconds())
+	if got := flow.stallThreshold(); got != 600*time.Millisecond {
+		t.Fatalf("smoothed fallback: threshold = %s, want 600ms", got)
+	}
+	// The test override wins over every sample.
+	flow.stallGrace = 10 * time.Millisecond
+	if got := flow.stallThreshold(); got != 10*time.Millisecond {
+		t.Fatalf("override: threshold = %s, want 10ms", got)
+	}
+}
+
+// The gate is strict: nothing pending never stalls, and a stall is measured
+// from when the work appeared (or last progressed), never from before it.
+func TestScanStallGating(t *testing.T) {
+	threshold := 100 * time.Millisecond
+	now := time.Now()
+	var since time.Time
+	if scanStall(false, 0, now, threshold, &since) {
+		t.Fatal("an idle flow stalled")
+	}
+	// First observation of pending work starts the clock rather than firing,
+	// however old the last progress is.
+	stale := now.Add(-time.Hour).UnixNano()
+	if scanStall(true, stale, now, threshold, &since) {
+		t.Fatal("work pending for one scan stalled on an ancient clock")
+	}
+	// Progress newer than the clock restarts it.
+	if scanStall(true, now.Add(10*time.Millisecond).UnixNano(), now.Add(20*time.Millisecond), threshold, &since) {
+		t.Fatal("work that just progressed stalled")
+	}
+	if !scanStall(true, 0, now.Add(20*time.Millisecond+threshold), threshold, &since) {
+		t.Fatal("work pending a full threshold without progress did not stall")
+	}
+	// Going idle resets the clock, so the next burst gets a full threshold.
+	scanStall(false, 0, now, threshold, &since)
+	if scanStall(true, 0, now.Add(50*time.Millisecond), threshold, &since) {
+		t.Fatal("fresh work inherited the previous burst's clock")
+	}
+}
+
+// The response gate opens when the application sent something the peer has
+// not answered, and closes on any downstream payload or either close. A flow
+// whose last send was answered is idle, not waiting.
+func TestResponseOutstandingGating(t *testing.T) {
+	flow := newStallTestFlow(t, nil)
+	if flow.responseOutstanding() {
+		t.Fatal("a flow that never sent is waiting on a response")
+	}
+	flow.observe(64, true)
+	flow.bytesUp.Add(64)
+	if !flow.responseOutstanding() {
+		t.Fatal("an unanswered request did not open the response gate")
+	}
+	flow.observe(128, false)
+	flow.bytesDown.Add(128)
+	if flow.responseOutstanding() {
+		t.Fatal("an answered request kept the response gate open")
+	}
+	flow.observe(64, true)
+	flow.bytesUp.Add(64)
+	flow.remoteFinSeen.Store(true)
+	if flow.responseOutstanding() {
+		t.Fatal("a flow that saw the peer's FIN is still waiting")
+	}
+}
+
+// Demotion is not death: a suspected lane is passed over for new writes while
+// a healthier lane exists, keeps its place in the healthy set, and is fully
+// eligible again the moment it is the only thing left.
+func TestSuspectedLaneIsDemotedNotKilled(t *testing.T) {
+	flow := newStallTestFlow(t, nil)
+	flow.reserveControlLane = true
+	controlLocal, controlRemote := net.Pipe()
+	dataLocal, dataRemote := net.Pipe()
+	t.Cleanup(func() {
+		_ = controlLocal.Close()
+		_ = controlRemote.Close()
+		_ = dataLocal.Close()
+		_ = dataRemote.Close()
+	})
+	control := &mpLane{id: 0, kind: TransportQUIC, fc: newFrameConn(controlLocal), control: true}
+	data := &mpLane{id: 1, kind: TransportQUIC, fc: newFrameConn(dataLocal)}
+	if err := flow.addLane(control); err != nil {
+		t.Fatal(err)
+	}
+	if err := flow.addLane(data); err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := flow.laneCandidates(true)
+	if err != nil || len(candidates) != 1 || candidates[0] != data {
+		t.Fatalf("data candidates before stall = %v, %v", candidates, err)
+	}
+	if spare := flow.suspectDataLanes(); !spare {
+		t.Fatal("demoting the data lane found no warm spare in the control lane")
+	}
+	if data.closed.Load() {
+		t.Fatal("the watchdog closed a suspected lane")
+	}
+	if len(flow.healthyLanes()) != 2 {
+		t.Fatal("a suspected lane left the healthy set")
+	}
+	candidates, err = flow.laneCandidates(true)
+	if err != nil || len(candidates) != 1 || candidates[0] != control {
+		t.Fatalf("data candidates after demotion = %v, %v, want the control lane", candidates, err)
+	}
+	// With every healthy lane suspected there is nothing healthier, and the
+	// set is used exactly as before.
+	control.suspected.Store(true)
+	candidates, err = flow.laneCandidates(true)
+	if err != nil || len(candidates) != 1 || candidates[0] != data {
+		t.Fatalf("all-suspected candidates = %v, %v, want the data lane again", candidates, err)
+	}
+	// An acknowledgement carrying new delivery information clears the mark.
+	data.suspected.Store(false)
+	control.suspected.Store(false)
+}
+
+// The watchdog fires once per episode, demotes the data lane, and asks the
+// lane manager for a rescue; an idle flow with the same timing never fires.
+func TestStallWatchdogDetectsPendingWorkWithoutProgress(t *testing.T) {
+	registry := metrics.New()
+	flow := newStallTestFlow(t, registry)
+	flow.stallScan = 5 * time.Millisecond
+	flow.stallGrace = 20 * time.Millisecond
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go flow.stallWatchdog(stop)
+
+	// Nothing pending: the scan runs and stays silent.
+	select {
+	case <-flow.stallSignals():
+		t.Fatal("an idle flow raised a stall")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	flow.noteSent(0, 512)
+	select {
+	case <-flow.stallSignals():
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending work with no progress raised no stall")
+	}
+	if got := registry.Snapshot().FlowStallsDetected; got != 1 {
+		t.Fatalf("stall detections = %d, want 1", got)
+	}
+
+	// Acknowledging the work is progress; the episode ends and a quiet flow
+	// with nothing outstanding does not re-fire.
+	if err := flow.acknowledgeReplay(512, false); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := registry.Snapshot().FlowStallsDetected; got != 1 {
+		t.Fatalf("stall detections after progress = %d, want still 1", got)
+	}
+}
+
+// A warm spare is counted when the demotion leaves a non-suspected healthy
+// lane, and not when the stalled lane was the only one.
+func TestStallWatchdogCountsTheWarmSpare(t *testing.T) {
+	registry := metrics.New()
+	flow := newStallTestFlow(t, registry)
+	flow.reserveControlLane = true
+	controlLocal, controlRemote := net.Pipe()
+	dataLocal, dataRemote := net.Pipe()
+	t.Cleanup(func() {
+		_ = controlLocal.Close()
+		_ = controlRemote.Close()
+		_ = dataLocal.Close()
+		_ = dataRemote.Close()
+	})
+	if err := flow.addLane(&mpLane{id: 0, kind: TransportQUIC, fc: newFrameConn(controlLocal), control: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flow.addLane(&mpLane{id: 1, kind: TransportQUIC, fc: newFrameConn(dataLocal)}); err != nil {
+		t.Fatal(err)
+	}
+	flow.noteSent(0, 512)
+	flow.stallScan = 5 * time.Millisecond
+	flow.stallGrace = 20 * time.Millisecond
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go flow.stallWatchdog(stop)
+	select {
+	case <-flow.stallSignals():
+	case <-time.After(2 * time.Second):
+		t.Fatal("no stall signal")
+	}
+	snapshot := registry.Snapshot()
+	if snapshot.FlowStallsDetected != 1 || snapshot.StallSpareAttaches != 1 {
+		t.Fatalf("stalls = %d, spare attaches = %d, want 1 and 1", snapshot.FlowStallsDetected, snapshot.StallSpareAttaches)
+	}
+}
+
+func rescueTestLane(t *testing.T, id uint64) (*mpLane, net.Conn) {
+	t.Helper()
+	local, remote := net.Pipe()
+	t.Cleanup(func() { _ = local.Close(); _ = remote.Close() })
+	return &mpLane{id: id, kind: TransportQUIC, fc: newFrameConn(local)}, remote
+}
+
+// The first completed JOIN wins; every losing attempt is cancelled, and a
+// loser that finishes anyway has its lane closed rather than installed. The
+// attempts here share nothing -- the analogue of several dials on the same
+// single port, where independence is the whole value.
+func TestParallelRescueFirstWinsAndLosersAreCancelled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := metrics.New()
+	client := &Client{cfg: ClientConfig{Logger: logger}, metrics: registry}
+	flow := newGraceTestFlow(t)
+
+	loserStarted := make(chan struct{})
+	loserLane, loserRemote := rescueTestLane(t, 1)
+	winnerLane, _ := rescueTestLane(t, 2)
+	attempts := []rescueAttempt{
+		func(ctx context.Context) (*mpLane, error) {
+			close(loserStarted)
+			<-ctx.Done()
+			// A dial cancelled mid-handshake returns its context's error.
+			return nil, ctx.Err()
+		},
+		func(ctx context.Context) (*mpLane, error) {
+			<-loserStarted
+			return winnerLane, nil
+		},
+		func(ctx context.Context) (*mpLane, error) {
+			// A loser that completes its JOIN before the cancellation
+			// reaches it must have its lane closed, not leaked.
+			<-loserStarted
+			time.Sleep(20 * time.Millisecond)
+			return loserLane, nil
+		},
+	}
+	lane, winner, err := client.raceRescueAttempts(context.Background(), flow, attempts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if winner != 1 || lane != winnerLane {
+		t.Fatalf("winner = %d (%v), want attempt 1", winner, lane)
+	}
+	snapshot := registry.Snapshot()
+	if snapshot.LaneRescueAttempts != 3 {
+		t.Fatalf("rescue attempts = %d, want 3", snapshot.LaneRescueAttempts)
+	}
+	if snapshot.LaneRescueWins[1] != 1 || snapshot.LaneRescueWins[0] != 0 || snapshot.LaneRescueWins[2] != 0 {
+		t.Fatalf("rescue wins = %v, want attempt 1 only", snapshot.LaneRescueWins)
+	}
+	// The late loser's lane is closed once its attempt unwinds.
+	if err := loserRemote.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loserRemote.Read(make([]byte, 1)); err == nil {
+		t.Fatal("the losing lane's connection stayed open")
+	}
+}
+
+// A refusal is the peer's permanent answer about the session: it ends the
+// round immediately rather than being outvoted by slower attempts.
+func TestParallelRescueRefusalEndsTheRound(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := &Client{cfg: ClientConfig{Logger: logger}, metrics: metrics.New()}
+	flow := newGraceTestFlow(t)
+	slow := make(chan struct{})
+	t.Cleanup(func() { close(slow) })
+	attempts := []rescueAttempt{
+		func(ctx context.Context) (*mpLane, error) { return nil, errLaneJoinRejected },
+		func(ctx context.Context) (*mpLane, error) {
+			select {
+			case <-slow:
+				lane, _ := rescueTestLane(t, 9)
+				return lane, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	start := time.Now()
+	if _, _, err := client.raceRescueAttempts(context.Background(), flow, attempts); !errors.Is(err, errLaneJoinRejected) {
+		t.Fatalf("err = %v, want %v", err, errLaneJoinRejected)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("the round waited %s for attempts a refusal already answered", elapsed)
+	}
+}
+
+// When every attempt fails, the round reports the first failure rather than
+// installing anything.
+func TestParallelRescueAllAttemptsFail(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := &Client{cfg: ClientConfig{Logger: logger}, metrics: metrics.New()}
+	flow := newGraceTestFlow(t)
+	first := errors.New("dial refused")
+	attempts := []rescueAttempt{
+		func(ctx context.Context) (*mpLane, error) { return nil, first },
+		func(ctx context.Context) (*mpLane, error) {
+			time.Sleep(50 * time.Millisecond)
+			return nil, errors.New("dial timeout")
+		},
+	}
+	if _, _, err := client.raceRescueAttempts(context.Background(), flow, attempts); !errors.Is(err, first) {
+		t.Fatalf("err = %v, want the first failure", err)
+	}
+	if got := client.metrics.Snapshot().LaneRescueAttempts; got != 2 {
+		t.Fatalf("rescue attempts = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Problem

On a path with heavy upstream (client→server) packet loss (~30%, min RTT ~200ms — measured in production), flows stalled for tens of seconds and then failed with `peer does not hold this session`:

- Lanes were declared dead **only** on quic-go's 15s idle timeout of total receive silence. Downstream keepalives (~4% loss direction) kept connections nominally alive while upstream throughput collapsed, so flows sat in dying lanes with zero recovery attempts.
- When a lane finally died, the rescue was a single serialized QUIC handshake (up to ~22s/attempt) racing a **hard 45s** server-side grace that in-progress rescues did not extend. Late JOINs were refused `unknown_session` (36k+ suppressed server-side refusals observed).
- `--handshake-timeout 10s` silently overrode `NewClient`'s safer 30s default.

## Fix

- **Flow-stall watchdog**: no forward progress (protocol acked send offset / downstream arrivals — the signal keepalives can't fake) for `clamp(3×minRTT, 250ms, 2s)` while data is pending demotes the flow's data lanes and signals the lane manager. Strictly gated on pending data; app-limited idle flows never fire. Demote, never kill: suspected lanes keep receiving and clear on any ACK with new delivery information.
- **Parallel rescue dials**: up to 3 concurrent dial+JOIN attempts, each sprayed onto the next walked hop port (degenerating to same-port parallel handshakes when hopping is off — the value is independent handshakes, not port diversity). First JOIN wins, losers cancelled. A healthy spare lane takes over within one scheduler poll. **No TCP fallback policy changes.**
- **Server grace extension**: a validated JOIN arriving during the lane-replacement grace restarts the 45s budget instead of expiring mid-rescue.
- **Eviction hazard fixed**: racing same-role JOINs are admitted in arrival order and a late loser could evict the winner's server-side lane at the lane ceiling — lanes younger than `laneDeadPathDetection` are now eviction-protected, and `ResetFlowLimit` refusals map to a per-attempt `errLaneJoinCapacity` (never `resumeRefused`).
- **`--handshake-timeout` default 10s → 30s**, matching `NewClient`'s default.

## Metrics / logs

`queqiao_flow_stalls_detected_total`, `queqiao_stall_spare_attaches_total`, `queqiao_lane_rescue_attempts_total`, `queqiao_lane_rescue_wins_total{attempt="0|1|2"}`, `queqiao_lane_grace_extensions_total`; Info-level stall/rescue log lines. `docs/LOGGING.md` updated; changelog.d entry included.

## Testing

New `internal/pep/stallwatch_test.go` (threshold clamp, gating, demote-not-kill, race first-wins with loser cancellation, refusal-ends-round) plus grace-extension and eviction-protection tests. `go build ./...`, `go vet`, and the full test suite pass (`internal/pep` 572s vs 584s baseline at HEAD; new tests pass `-race -count=3`).

## Deliberately out of scope

A mid-download *receive* stall client-side (request acked, response streaming, upstream ACKs lost) is not detected — a quiet-period gate there is indistinguishable from a legitimately paused sender without violating the app-limited rule. The server-side watchdog fires in that case but can only demote/log (servers don't dial). No mux-level packet duplication (rejected in design review). No wire changes.
