### PR TITLE
fix(pep): do not fall back on lane-capacity refusals in rescue races

### DIFF
--- a/changelog.d/rescue-capacity-refusal.fixed.md
+++ b/changelog.d/rescue-capacity-refusal.fixed.md
@@ -1,0 +1,10 @@
+Rescue races no longer misfire on the peer's lane ceiling. A capacity
+refusal of the pooled control JOIN is a benign per-attempt outcome — usually
+a sibling attempt already holds the lane — but it fell through to the
+fallback paths: an ordinary QUIC join under `--transport quic`, or the AUTO
+TCP commit, which could hand the flow to TCP while a QUIC sibling won the
+race. Capacity refusals now end the attempt instead. The TCP fallback
+metric also moved from commit time to install time, so a TCP commit that
+loses its race no longer counts as a fallback, and the stall watchdog stays
+silent while a rescue round is in flight rather than queueing another round
+behind it.

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -238,6 +238,10 @@ type Client struct {
 	// production path still goes through dialAuthenticatedLane; tests can make
 	// TCP ready before QUIC without relying on scheduler timing or live loss.
 	dialAuthenticatedLaneForTest func(context.Context, TransportKind) (*authenticatedLane, error)
+	// disableStallWatchdogForTest keeps the flow stall watchdog off, so tests
+	// that pin exact dial counts see only the recovery they injected, not
+	// rescue rounds the watchdog starts on a slow runner.
+	disableStallWatchdogForTest bool
 
 	// quicPoolActive counts flows currently sharing the pooled control
 	// connection. A bulk flow only needs to move off it when another flow
@@ -812,6 +816,7 @@ func (c *Client) handleLocal(ctx context.Context, inner net.Conn) {
 	}
 	c.cfg.Logger.Debug("local flow opened", "transport", flow.kind, "duration", time.Since(flowOpenStarted))
 	flowSession := newMultipathFlowWithMemory(ctx, inner, flow.sessionID, flow.flowID, c.cfg.ChunkSize, protocol.FlagAckUp, protocol.FlagAckDown, c.budget, c.metrics, c.cfg.Logger, c.memoryLimits, c.sendMemory, c.receiveMemory, c.classifierConfig())
+	flowSession.stallWatchdogDisabled = c.disableStallWatchdogForTest
 	c.declareClass(ctx, inner, flowSession)
 	flowSession.ackRanges.Store(true)
 	flowSession.idleTimeout = c.cfg.FlowIdleTimeout
@@ -1965,7 +1970,7 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 			if now.Before(nextStallRescue) {
 				continue
 			}
-			if err := c.openParallelRescue(manageCtx, flow, sessionID, flowID); err != nil {
+			if err := c.runRescueRound(manageCtx, flow, sessionID, flowID); err != nil {
 				if manageCtx.Err() != nil || flow.doneChanClosed() {
 					return
 				}
@@ -2070,7 +2075,7 @@ func (c *Client) manageQUICLanes(ctx context.Context, flow *multipathFlow, sessi
 				recoveryAttempts++
 				lastRecoveryAttempt = now
 				flow.noteReplacementAttempt()
-				if err := c.openParallelRescue(manageCtx, flow, sessionID, flowID); err != nil {
+				if err := c.runRescueRound(manageCtx, flow, sessionID, flowID); err != nil {
 					flow.noteReplacementFailure()
 					if errors.Is(err, errLaneJoinRejected) {
 						// The peer answered, and its answer was that it does
@@ -2443,6 +2448,22 @@ type rescueAttempt func(ctx context.Context) (*mpLane, error)
 // independent retransmission schedules rather than port diversity. The TCP
 // fallback's conditions are untouched: a TCP commit can still only come from
 // attempt zero, on the same terms openRecoveryLane always had.
+// runRescueRound executes one parallel rescue round under the flow's
+// in-flight guard: the stall watchdog stays silent for the round, and any
+// request it managed to queue just before the guard engaged is dropped
+// afterwards, because the round has just changed the state that request
+// described.
+func (c *Client) runRescueRound(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) error {
+	flow.rescueInFlight.Store(true)
+	err := c.openParallelRescue(ctx, flow, sessionID, flowID)
+	flow.rescueInFlight.Store(false)
+	select {
+	case <-flow.stallSignals():
+	default:
+	}
+	return err
+}
+
 func (c *Client) openParallelRescue(ctx context.Context, flow *multipathFlow, sessionID [16]byte, flowID uint64) error {
 	// As in openRecoveryLane: a completed flow must not keep dialing. Only
 	// attempt zero checks this itself; the sprayed racers rely on the guard
@@ -2620,13 +2641,25 @@ func (c *Client) openRecoveryLane(ctx context.Context, flow *multipathFlow, sess
 		if recoveryCtx.Err() != nil || flow.doneChanClosed() {
 			return nil, context.Canceled
 		}
+		if errors.Is(err, errLaneJoinCapacity) {
+			// The peer is alive and at its lane ceiling, which in a rescue
+			// race usually means a sibling attempt already holds the lane.
+			// Falling back here -- an ordinary QUIC join, or the AUTO TCP
+			// commit -- would burn another handshake on an answer that
+			// cannot change, and could even hand the flow to TCP while a
+			// QUIC sibling wins.
+			return nil, err
+		}
 		if c.cfg.Transport == TransportQUIC {
 			// Protocol-v1 development peers predating control-role JOINs reject the flag.
 			// One ordinary QUIC join preserves rolling-upgrade recovery; a new
 			// peer which genuinely lost the session rejects this one as well.
 			lane, err = c.openJoinLane(recoveryCtx, TransportQUIC, sessionID, flowID, laneID)
 		} else {
-			c.metrics.Fallback()
+			// The fallback is counted where the TCP lane is installed, not
+			// here: in a parallel rescue round this commit races sprayed
+			// QUIC dials, and when one of those wins the flow never touches
+			// TCP at all.
 			c.cfg.Logger.Debug("shared QUIC generation recovery unavailable; committing flow to TCP",
 				"flow", flowID, "error", err)
 			lane, err = c.openJoinLane(recoveryCtx, TransportTCP, sessionID, flowID, laneID)
@@ -2654,8 +2687,13 @@ func (c *Client) installRecoveryLane(flow *multipathFlow, lane *mpLane) error {
 		_ = lane.fc.Close()
 		return err
 	}
-	if lane.kind == TransportTCP && c.cfg.TCPFallbackLanes > 1 {
-		flow.tcpStriping.Store(lane.tcpStriping)
+	if lane.kind == TransportTCP {
+		// The handoff is real only now: the lane won its rescue round and
+		// will actually carry the flow.
+		c.metrics.Fallback()
+		if c.cfg.TCPFallbackLanes > 1 {
+			flow.tcpStriping.Store(lane.tcpStriping)
+		}
 	}
 	c.metrics.LaneReplacement()
 	return nil

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -324,6 +324,16 @@ type multipathFlow struct {
 	// loses nothing, and a flow with no listener (the server end) never
 	// blocks its watchdog.
 	stallSignal chan struct{}
+	// rescueInFlight is set by the lane manager for the duration of one
+	// rescue round. While it is set the watchdog does not signal: a request
+	// queued behind an active round would only fire a redundant round the
+	// moment the first one returns, before its fresh lane had any chance to
+	// prove itself.
+	rescueInFlight atomic.Bool
+	// stallWatchdogDisabled turns the watchdog goroutine off entirely. Zero
+	// in production; tests that pin exact dial counts set it so recovery
+	// behaviour under measurement is deterministic.
+	stallWatchdogDisabled bool
 	// stallScan and stallGrace are zero in production. Tests shorten them so
 	// the watchdog can be exercised without sleeping for seconds, the same
 	// pattern as abortGrace above.
@@ -1376,7 +1386,9 @@ func (f *multipathFlow) run(ctx context.Context) (FlowStats, error) {
 	completionStop := make(chan struct{})
 	go f.completionWatchdog(completionStop)
 	stallStop := make(chan struct{})
-	go f.stallWatchdog(stallStop)
+	if !f.stallWatchdogDisabled {
+		go f.stallWatchdog(stallStop)
+	}
 	limitsStop := make(chan struct{})
 	limitErr := make(chan error, 1)
 	go f.watchLimits(limitsStop, limitErr)
@@ -1818,8 +1830,10 @@ func (f *multipathFlow) stallWatchdog(stop <-chan struct{}) {
 		// The manager's own backoff paces the dials; this pacing only keeps a
 		// persistent stall from queueing signals faster than they can be
 		// acted on. An episode that outlives its rescue still re-asks, because
-		// the stall it describes is still true.
-		if now.Sub(lastSignal) >= threshold {
+		// the stall it describes is still true. While a round is in flight it
+		// does not ask at all: the queued request would be answered by state
+		// the round is about to change.
+		if now.Sub(lastSignal) >= threshold && !f.rescueInFlight.Load() {
 			select {
 			case f.stallSignal <- struct{}{}:
 				lastSignal = now

--- a/internal/pep/pool_recovery_test.go
+++ b/internal/pep/pool_recovery_test.go
@@ -71,6 +71,11 @@ func TestPooledFlowsRecoverThroughOneReplacementGeneration(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			// This test pins exact dial counts for the recovery it injects.
+			// On a slow runner the stall watchdog would start rounds of its
+			// own -- a slow echo is a real stall to it -- and each of those
+			// rounds opens two sprayed dials the ceiling does not budget for.
+			client.disableStallWatchdogForTest = true
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()


### PR DESCRIPTION
## Problem

CI on `windows-11-arm` failed `TestPooledFlowsRecoverThroughOneReplacementGeneration/auto` after #92:

```
pool_recovery_test.go:154: successful shared QUIC recovery recorded 1 TCP fallbacks
```

Reproduced locally under CPU contention (`GOMAXPROCS=1`, ~25% flake), which surfaced **four** distinct issues, all rooted in how the new parallel rescue interacts with slow machines:

1. **Capacity refusals fell through to fallback paths (the real bug).** Under contention the sprayed racers win their rounds, so the pooled control JOIN arrives after the flow's lane ceiling is full. The resulting `errLaneJoinCapacity` was treated like any other failure: under `--transport quic` it fell back to an ordinary QUIC join (an extra `dialBulkConn` socket, breaking the test's socket ceiling), and under AUTO it triggered the **TCP commit** — which on localhost wins the race and hands the flow to TCP *while a QUIC sibling already rescued it*. A capacity refusal is a benign per-attempt outcome (usually a sibling already holds the lane); it now ends the attempt instead of falling back.

2. **`queqiao_fallbacks_total` counted at commit, not handoff.** In a rescue race the AUTO TCP commit can be cancelled after a QUIC sibling wins — the flow never touches TCP but the counter incremented. It's now counted when a TCP rescue lane is actually installed.

3. **The stall watchdog queued signals behind in-flight rounds.** A persistent stall re-signals every threshold interval (250ms floor); a signal queued during a multi-second round fired a redundant round the moment the first returned, before the fresh lane could prove itself. The watchdog now stays silent while a round is in flight (`rescueInFlight`), and the manager drains any signal queued just before the guard engaged.

4. **The test itself needed watchdog isolation.** It pins exact dial counts for the recovery it injects; on a slow runner the watchdog legitimately starts rounds of its own (a slow echo is a real stall to it), each opening sprayed dials the ceiling can't budget for. New `disableStallWatchdogForTest` hook, used by this test. Watchdog behavior remains covered by `stallwatch_test.go`.

## Verification

- `GOMAXPROCS=1 -count=30` clean for both subtests (previously ~25% flake)
- `-race` on the stall/grace/race/pool/isolation tests green
- Full `internal/pep` suite green
- Diagnosis was done by tracing every socket creation to its caller frame: the excess came from `dialBulkConn` (the capacity-fallback path), confirming root cause #1 before fixing
