### PR TITLE
Locate a deployment's loss to a path segment, measured from both ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ workload; see the full [comparison and methodology](docs/COMPARISON.md).
   listener, for Clash/mihomo routing and failover.
 - Bounded JSON logs, metrics, a local visualizer, deterministic benchmarks,
   release packaging, SBOMs, and rollback procedures.
+- `queqiaod segments`, which profiles a live tunnel and says *which* segment
+  the loss is on — the client's own access link, the long haul this transport
+  carries, or the gateway's transit onward — measuring the far end over SSH
+  rather than inferring it. See [which segment is at
+  fault](docs/PROFILING-A-TUNNEL.md).
 
 All of it ships as a prebuilt binary. Download it below, or from the
 [latest release](https://github.com/bojieli/queqiao/releases/latest); there is no build step for normal use.

--- a/changelog.d/locate-loss-by-segment.added.md
+++ b/changelog.d/locate-loss-by-segment.added.md
@@ -1,0 +1,18 @@
+`queqiaod segments` profiles a live tunnel and says which segment the loss is
+on, rather than only how much there is. A slow deployment has three candidates
+that need three different responses -- the client's own access link, the long
+haul this transport carries, and the gateway's transit onward -- and until now
+every instrument here described the path end to end, so an operator losing a
+seventh of what crossed the path learned only that they were losing a seventh.
+The command measures both ends in the same minutes and localises the fault by
+what the legs share: it reads the running client's own per-direction erasure
+from `--metrics-listen`, which is the only measurement that separates upstream
+from downstream, and with `--ssh` it runs the same code on the gateway to
+measure that end's transit directly instead of inferring it by subtraction.
+Anchors are chosen per vantage point and never averaged, because a probe from
+a filtered network to a filtered destination measures the filter: a Chinese
+and a global anchor are probed from both ends, whichever answers cleanly
+establishes
+that end's own link, and an address that answers echo while refusing a
+handshake is reported as filtering rather than charged to anyone's link. A leg
+that returns nothing is reported as unanswered, not as total loss.

--- a/cmd/queqiaod/doctor_probe.go
+++ b/cmd/queqiaod/doctor_probe.go
@@ -369,12 +369,19 @@ func checkPlacement(p destinationProbe) check {
 // a large gateway leg is a placement decision the operator can revisit, and a
 // large far leg is the gateway's own transit, which moving the client will not
 // change.
+// The far leg here is a subtraction, and queqiaod segments --ssh measures the
+// same leg from the gateway itself. Two commands answering one question with
+// two methods will disagree, so the derived one has to name the measured one
+// rather than let a reader take a subtraction for an observation.
 func decomposition(p destinationProbe) string {
 	if !p.Decomposed {
-		return "the gateway leg was not measured, so the tunnelled time is not decomposed"
+		return "the gateway leg was not measured, so the tunnelled time is not decomposed; " +
+			"queqiaod segments measures the legs separately"
 	}
 	return fmt.Sprintf("of which %.1fms is the leg to the gateway and about %.1fms is the gateway's own hop "+
-		"to the destination", p.GatewayLeg, p.FarLeg)
+		"to the destination -- a subtraction rather than a measurement, which queqiaod segments --ssh "+
+		"takes from the gateway itself, along with the loss on each leg that this check cannot see",
+		p.GatewayLeg, p.FarLeg)
 }
 
 // wantsTLS decides whether a handshake belongs in the measurement. Port 443 is

--- a/cmd/queqiaod/doctor_probe_test.go
+++ b/cmd/queqiaod/doctor_probe_test.go
@@ -401,3 +401,20 @@ func startSOCKSProxy(t *testing.T) string {
 	}()
 	return ln.Addr().String()
 }
+
+// doctor derives the gateway's hop to a destination by subtracting one
+// measurement from another, and queqiaod segments measures that same leg from
+// the gateway. Two commands answering one question by two methods will
+// disagree, so the derived figure has to say which it is and where the measured
+// one lives -- otherwise an operator reads a subtraction as an observation.
+func TestTheDerivedFarLegNamesTheCommandThatMeasuresIt(t *testing.T) {
+	decomposed := decomposition(destinationProbe{Decomposed: true, GatewayLeg: 197, FarLeg: 14})
+	for _, want := range []string{"subtraction rather than a measurement", "segments --ssh"} {
+		if !strings.Contains(decomposed, want) {
+			t.Fatalf("the decomposition omits %q: %s", want, decomposed)
+		}
+	}
+	if !strings.Contains(decomposition(destinationProbe{}), "segments") {
+		t.Fatalf("an undecomposed report does not point anywhere: %s", decomposition(destinationProbe{}))
+	}
+}

--- a/cmd/queqiaod/main.go
+++ b/cmd/queqiaod/main.go
@@ -43,7 +43,7 @@ func main() {
 
 func run(args []string) error {
 	if len(args) == 0 {
-		return errors.New("a command is required: provider, enroll, client, service, server, doctor, logs, or version")
+		return errors.New("a command is required: provider, enroll, client, service, server, doctor, segments, logs, or version")
 	}
 	switch args[0] {
 	case "version", "--version", "-version":
@@ -62,12 +62,14 @@ func run(args []string) error {
 		return runServer(args[1:])
 	case "doctor":
 		return runDoctorCommand(args[1:])
+	case "segments":
+		return runSegmentsCommand(args[1:])
 	case "logs":
 		return runLogs(args[1:])
 	case "service":
 		return runService(args[1:])
 	default:
-		return fmt.Errorf("unknown command %q; want provider, enroll, client, service, server, logs, or version", args[0])
+		return fmt.Errorf("unknown command %q; want provider, enroll, client, service, server, doctor, segments, logs, or version", args[0])
 	}
 }
 

--- a/cmd/queqiaod/segments.go
+++ b/cmd/queqiaod/segments.go
@@ -1,0 +1,564 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/identity"
+	"github.com/bojieli/queqiao/internal/pathseg"
+)
+
+// The segments command answers the question a slow deployment actually raises,
+// which none of the existing instruments answers: not how bad the path is, but
+// whose fault it is.
+//
+// queqiaod doctor checks preconditions and gateway placement. cmd/pathprobe
+// finds a capacity knee and an erasure floor. cmd/pathmeasure says what a stack
+// achieves. All three describe a path end to end, so a deployment that is
+// losing a seventh of what crosses it learns that it is losing a seventh and
+// nothing about where. The three candidates need different responses and only
+// one of them is this project's problem: a lossy first mile is the client's
+// ISP, a lossy gateway transit is past the point where this transport stops,
+// and a lossy long haul between them is the one thing coding and pacing repair.
+//
+// The separation comes from measuring the same minutes from two vantage points
+// against anchors chosen so that each leg's loss can only have come from one
+// place. See internal/pathseg for the shared-element argument that makes the
+// legs add up, and why the anchors have to be local and unfiltered at the
+// vantage point that probes them.
+//
+// The gateway vantage point is optional and the report is honest about what it
+// cannot conclude without one: with only the client's side measured, a clean
+// report does not clear the gateway's transit, it merely never looked at it.
+
+// defaultReferences are deliberately one Chinese and one global anchor, used
+// unchanged at both ends.
+//
+// A probe from a filtered network to a filtered destination measures the
+// filter. Read as loss it would convict a healthy access link of the worst
+// fault this report can report, which on the path this project was built for is
+// not a hypothetical: a client in China probing a blocked host sees near-total
+// loss on a first mile in perfect health.
+//
+// Rather than guess where a vantage point is -- which needs a geolocation table
+// that would then be wrong somewhere -- both anchors are probed from both ends
+// and each end's link is judged by whichever answered cleanly. One clean anchor
+// proves the link carries traffic. That makes the defaults correct in both
+// directions without knowing which side of the filter anything is on, and it
+// makes the disagreement between the two anchors a finding in its own right
+// rather than noise to be averaged away.
+var defaultReferences = []string{"baidu.com:443", "www.google.com:443"}
+
+type segmentOptions struct {
+	endpoint     string
+	socks        string
+	metrics      string
+	localAddress string
+
+	clientRefs   stringList
+	gatewayRefs  stringList
+	destinations stringList
+
+	sshTarget     string
+	sshOptions    stringList
+	remoteBinary  string
+	remoteMetrics string
+
+	count          int
+	establishCount int
+	interval       time.Duration
+	timeout        time.Duration
+	pin            bool
+	quiet          bool
+}
+
+// segmentReport is the whole run, and the JSON form is the whole run too. A
+// report that printed more than it serialised would make the machine-readable
+// output the lesser of the two, which is the wrong way round for something
+// whose results are meant to be attached to a bug.
+type segmentReport struct {
+	Version     string              `json:"version"`
+	StartedAt   time.Time           `json:"started_at"`
+	ElapsedS    float64             `json:"elapsed_seconds"`
+	Gateway     string              `json:"gateway_endpoint,omitempty"`
+	SSHTarget   string              `json:"ssh_target,omitempty"`
+	RemoteHost  string              `json:"remote_hostname,omitempty"`
+	Probes      int                 `json:"probes"`
+	IntervalMS  int                 `json:"interval_ms"`
+	Evidence    pathseg.Evidence    `json:"evidence"`
+	Attribution pathseg.Attribution `json:"attribution"`
+	Notes       []string            `json:"notes,omitempty"`
+}
+
+func runSegmentsCommand(args []string) error {
+	fs := newFlagSet("segments")
+	agent := fs.Bool("agent", false,
+		"run the far-side half of a profile: read a request on stdin, measure, write the result on stdout. "+
+			"This is what --ssh invokes on the gateway; it is not normally run by hand")
+	profilePath := fs.String("profile", "", "client profile to read the gateway endpoint from")
+	asJSON := fs.Bool("json", false, "emit the report as JSON")
+
+	var opts segmentOptions
+	fs.StringVar(&opts.endpoint, "endpoint", "", "gateway host:port, when no client profile is available")
+	fs.StringVar(&opts.socks, "socks", "127.0.0.1:12080", "local SOCKS5 listener, for the tunnelled arm")
+	fs.StringVar(&opts.metrics, "metrics", "",
+		"the running client's metrics URL, such as http://127.0.0.1:19090/metrics. This is the only "+
+			"per-direction measurement of the client-to-gateway segment there is; without it that "+
+			"segment is reduced to a round-trip probe")
+	fs.StringVar(&opts.localAddress, "local-address", "",
+		"bind probes to this local IP, so a host TUN route does not carry a direct measurement through "+
+			"the very tunnel being measured")
+	fs.Var(&opts.clientRefs, "client-reference",
+		"a destination that is local and unfiltered from the client, to establish its own link; repeat for several")
+	fs.Var(&opts.gatewayRefs, "gateway-reference",
+		"the same for the gateway, whose local and unfiltered destinations are usually different ones")
+	fs.Var(&opts.destinations, "destination",
+		"a destination you actually care about, compared direct against tunnelled; repeat for several")
+	fs.StringVar(&opts.sshTarget, "ssh", "",
+		"ssh into the gateway to measure its own transit, instead of inferring it by subtraction. "+
+			"Takes anything ssh takes, such as user@host or a Host alias from ssh_config")
+	fs.Var(&opts.sshOptions, "ssh-option", "extra argument to pass to ssh; repeat for several")
+	fs.StringVar(&opts.remoteBinary, "remote-binary", "queqiaod",
+		"path to queqiaod on the gateway, which runs the far half of the measurement")
+	fs.StringVar(&opts.remoteMetrics, "remote-metrics", "",
+		"the gateway's metrics URL as reachable from the gateway itself, such as http://127.0.0.1:19090/metrics")
+	fs.IntVar(&opts.count, "count", 50, "echo probes per leg")
+	fs.IntVar(&opts.establishCount, "establish-count", 3, "connections per leg, the reachability instrument")
+	fs.DurationVar(&opts.interval, "interval", 100*time.Millisecond, "time between probes")
+	fs.DurationVar(&opts.timeout, "timeout", 2*time.Second, "how long to wait for a straggler after the last probe")
+	fs.BoolVar(&opts.quiet, "quiet", false,
+		"do not report progress while measuring. Progress goes to stderr, so it never contaminates "+
+			"--json on stdout; this is for a log that should hold only the result")
+	fs.BoolVar(&opts.pin, "pin-addresses", false,
+		"make the gateway measure the addresses this client resolved, rather than resolving for itself. "+
+			"Pins the comparison to one machine, at the cost of hiding a name that resolves differently "+
+			"at each end -- which is itself worth knowing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *agent {
+		return runSegmentsAgent(os.Stdin, os.Stdout)
+	}
+	if opts.count < 1 {
+		return errors.New("--count must be at least 1")
+	}
+	if opts.interval <= 0 {
+		return errors.New("--interval must be positive")
+	}
+	if len(opts.clientRefs) == 0 {
+		opts.clientRefs = defaultReferences
+	}
+	if len(opts.gatewayRefs) == 0 {
+		opts.gatewayRefs = defaultReferences
+	}
+	if opts.endpoint == "" && *profilePath != "" {
+		p, err := identity.LoadClientProfile(*profilePath)
+		if err != nil {
+			return fmt.Errorf("read client profile: %w", err)
+		}
+		opts.endpoint = p.Endpoint
+	}
+	if opts.endpoint == "" {
+		return errors.New("the gateway is not known: pass --endpoint or --profile")
+	}
+
+	report, err := profileSegments(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+	if *asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+	renderSegments(os.Stdout, report)
+	return nil
+}
+
+// runSegmentsAgent is the far half. It writes JSON on stdout and nothing else,
+// because stdout is a pipe back through ssh; anything friendly printed here
+// would arrive as a parse error on the other end.
+func runSegmentsAgent(in io.Reader, out io.Writer) error {
+	req, err := pathseg.DecodeAgentRequest(in)
+	if err != nil {
+		return fmt.Errorf("read the measurement request: %w", err)
+	}
+	budget := time.Duration(req.Count)*time.Duration(req.IntervalMS)*time.Millisecond*
+		time.Duration(len(req.References)) + 2*time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+	resp := pathseg.RunAgent(ctx, req, version)
+	return json.NewEncoder(out).Encode(resp)
+}
+
+// progress narrates a run while it happens.
+//
+// A profile takes tens of seconds per leg and minutes once --ssh and several
+// destinations are involved, all of it spent waiting on probes that produce no
+// output. Silence for that long is indistinguishable from a hang, and an
+// operator who cannot tell the difference kills the run and never sees the
+// verdict.
+//
+// It writes to stderr so that --json on stdout stays machine-readable with the
+// narration still visible, which is the arrangement that needs no flag to be
+// safe in a pipeline.
+type progress struct {
+	w     io.Writer
+	on    bool
+	step  int
+	total int
+}
+
+func (p *progress) notef(format string, args ...any) {
+	if !p.on {
+		return
+	}
+	fmt.Fprintf(p.w, "  "+format+"\n", args...)
+}
+
+// begin announces a leg and returns the function that closes it out, so the
+// two halves of one line cannot drift apart.
+func (p *progress) begin(vantage, target string) func(string) {
+	if !p.on {
+		return func(string) {}
+	}
+	p.step++
+	started := time.Now()
+	fmt.Fprintf(p.w, "  [%d/%d] %s -> %-28s ", p.step, p.total, vantage, target)
+	return func(result string) {
+		fmt.Fprintf(p.w, "%-24s (%.1fs)\n", result, time.Since(started).Seconds())
+	}
+}
+
+// summarizeReference is the one-line form of a finished leg, which is the
+// figure the verdict will rest on rather than a restatement of the request.
+func summarizeReference(r pathseg.Reference) string {
+	if r.Error != "" {
+		return "failed"
+	}
+	health, ok := r.Health()
+	switch {
+	case !ok:
+		return "no reply"
+	case r.Filtered():
+		return "echo ok, handshake refused"
+	case health.Loss > 0:
+		return fmt.Sprintf("%.1f%% loss, %.0fms", health.Loss*100, health.P50MS)
+	default:
+		return fmt.Sprintf("clean, %.0fms", health.P50MS)
+	}
+}
+
+func profileSegments(ctx context.Context, opts segmentOptions) (segmentReport, error) {
+	started := time.Now()
+	report := segmentReport{
+		Version: version, StartedAt: started.UTC(), Gateway: opts.endpoint,
+		SSHTarget: opts.sshTarget, Probes: opts.count,
+		IntervalMS: int(opts.interval / time.Millisecond),
+	}
+
+	// One budget for the whole run, sized from what was asked for rather than
+	// from a constant, so a long run is not cut off in the middle and a short
+	// one does not sit waiting on a hung ssh.
+	legs := len(opts.clientRefs) + len(opts.destinations) + 1
+	budget := time.Duration(legs)*(time.Duration(opts.count)*opts.interval+opts.timeout) + 3*time.Minute
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	perLeg := time.Duration(opts.count)*opts.interval + opts.timeout
+	prog := &progress{w: os.Stderr, on: !opts.quiet, total: 1 + len(opts.clientRefs) + len(opts.destinations)}
+	prog.notef("profiling %s: %d legs from the client at about %.0fs each",
+		opts.endpoint, prog.total, perLeg.Seconds())
+
+	cfg := pathseg.ProbeConfig{
+		Count: opts.count, Interval: opts.interval, Timeout: opts.timeout,
+		EstablishCount: opts.establishCount, LocalAddress: opts.localAddress,
+	}
+
+	// The far side starts first and runs while the near side measures, so both
+	// vantage points cover the same minutes. This is not an optimisation. The
+	// path this project was built for moves between roughly zero and seventeen
+	// percent loss within minutes, so two legs measured one after the other can
+	// differ by more than any fault would move them, and the whole
+	// shared-element argument rests on the legs being comparable.
+	type remoteResult struct {
+		resp  pathseg.AgentResponse
+		notes []string
+	}
+	remote := make(chan remoteResult, 1)
+	if opts.sshTarget != "" {
+		req := pathseg.AgentRequest{
+			References: opts.gatewayRefs, Count: opts.count,
+			IntervalMS:     int(opts.interval / time.Millisecond),
+			TimeoutMS:      int(opts.timeout / time.Millisecond),
+			EstablishCount: opts.establishCount, MetricsURL: opts.remoteMetrics,
+		}
+		prog.notef("gateway vantage: ssh %s, %d legs running alongside these",
+			opts.sshTarget, len(opts.gatewayRefs))
+		go func() {
+			resp, notes := measureFromGateway(ctx, opts, req)
+			remote <- remoteResult{resp, notes}
+		}()
+	}
+
+	var e pathseg.Evidence
+	e.Gateway = measureWithProgress(ctx, "client", []string{opts.endpoint}, cfg, prog)[0]
+	e.ClientReferences = measureWithProgress(ctx, "client", opts.clientRefs, cfg, prog)
+
+	if opts.metrics != "" {
+		view, err := pathseg.FetchMetrics(ctx, opts.metrics)
+		if err != nil {
+			prog.notef("metrics: %s could not be read", opts.metrics)
+			report.Notes = append(report.Notes, fmt.Sprintf(
+				"the client's metrics at %s could not be read (%v), so the client-to-gateway segment "+
+					"falls back to a round-trip probe that cannot separate the two directions",
+				opts.metrics, err))
+		} else {
+			e.Tunnel = view
+			prog.notef("metrics: %.1f%% receive erasure, %.1f%% send, over %d coded symbols",
+				view.ReceiveErasure*100, view.SendErasure*100, view.CodedSymbols)
+		}
+	} else {
+		report.Notes = append(report.Notes,
+			"no --metrics URL was given. The running client publishes the per-direction erasure of the "+
+				"client-to-gateway segment on --metrics-listen, and it is a better measurement of that "+
+				"segment than anything this command can probe from outside")
+	}
+
+	e.Direct, e.Tunneled = compareDestinations(ctx, opts, prog)
+
+	if opts.sshTarget != "" {
+		if len(opts.destinations) == 0 {
+			prog.notef("waiting for the gateway's legs to finish")
+		}
+		select {
+		case res := <-remote:
+			prog.notef("gateway vantage: %d legs returned", len(res.resp.References))
+			report.Notes = append(report.Notes, res.notes...)
+			report.RemoteHost = res.resp.Hostname
+			e.GatewayReferences = res.resp.References
+			for i := range e.GatewayReferences {
+				e.GatewayReferences[i].Echo.From = "gateway"
+				e.GatewayReferences[i].Establish.From = "gateway"
+			}
+			e.Remote = res.resp.Metrics
+			e.GatewayVantage = len(res.resp.References) > 0
+			if res.resp.MetricsError != "" {
+				report.Notes = append(report.Notes,
+					"the gateway's metrics could not be read: "+res.resp.MetricsError)
+			}
+		case <-ctx.Done():
+			report.Notes = append(report.Notes, "the gateway-side measurement did not finish in time")
+		}
+	}
+
+	report.Evidence = e
+	report.Attribution = pathseg.Attribute(e)
+	report.ElapsedS = time.Since(started).Round(time.Millisecond).Seconds()
+	return report, nil
+}
+
+// measureWithProgress drives the anchor loop here rather than inside the
+// package, so that each leg is announced before it is waited on.
+func measureWithProgress(ctx context.Context, vantage string, targets []string,
+	cfg pathseg.ProbeConfig, prog *progress) []pathseg.Reference {
+	out := make([]pathseg.Reference, 0, len(targets))
+	for _, target := range targets {
+		done := prog.begin(vantage, target)
+		r := pathseg.MeasureReference(ctx, target, cfg)
+		r.Echo.From, r.Establish.From = vantage, vantage
+		done(summarizeReference(r))
+		out = append(out, r)
+	}
+	return out
+}
+
+// compareDestinations compares each destination direct against tunnelled, one
+// establishment at a time with the arms alternated.
+//
+// The alternation is not optional. This project has already paid for the
+// lesson: on the characterised path, position in the test sequence was worth
+// 158ms where the policy under test was worth 2.4ms, and running one arm to
+// completion before the other produced a 53% win that reversed when the order
+// flipped. Running each arm as a block here would measure the path's drift and
+// call it the tunnel's contribution.
+func compareDestinations(ctx context.Context, opts segmentOptions, prog *progress) (direct, tunneled []pathseg.Leg) {
+	for _, target := range opts.destinations {
+		done := prog.begin("client", target)
+		var d, t pathseg.Sequence
+		for round := 0; round < opts.establishCount; round++ {
+			one := func(socks string) pathseg.Sequence {
+				return pathseg.Establish(ctx, pathseg.EstablishOptions{
+					Target: withDefaultPort(target), LocalAddress: opts.localAddress,
+					SOCKS: socks, Count: 1, Timeout: opts.timeout + 3*time.Second,
+				})
+			}
+			first, second := "", opts.socks
+			directFirst := round%2 == 0
+			if !directFirst {
+				first, second = opts.socks, ""
+			}
+			a, b := one(first), one(second)
+			if !directFirst {
+				a, b = b, a
+			}
+			d.Arrived, d.RTTs = append(d.Arrived, a.Arrived...), append(d.RTTs, a.RTTs...)
+			t.Arrived, t.RTTs = append(t.Arrived, b.Arrived...), append(t.RTTs, b.RTTs...)
+		}
+		dl := pathseg.Summarize("direct:"+target, "client", target, "tcp-connect", d)
+		tl := pathseg.Summarize("tunnelled:"+target, "client", target, "tcp-connect", t)
+		done(fmt.Sprintf("%s direct, %s tunnelled", establishSummary(dl), establishSummary(tl)))
+		direct = append(direct, dl)
+		tunneled = append(tunneled, tl)
+	}
+	return direct, tunneled
+}
+
+func establishSummary(l pathseg.Leg) string {
+	if !l.Usable() {
+		return "unreachable"
+	}
+	return fmt.Sprintf("%.0fms", l.P50MS)
+}
+
+// splitHostForResolve returns the host part of a reference, which may or may
+// not carry a port.
+func splitHostForResolve(target string) (string, bool) {
+	if h, _, err := net.SplitHostPort(target); err == nil {
+		return h, true
+	}
+	return target, false
+}
+
+func withDefaultPort(target string) string {
+	if _, _, err := net.SplitHostPort(target); err == nil {
+		return target
+	}
+	return net.JoinHostPort(target, "443")
+}
+
+// measureFromGateway runs the far half over ssh.
+//
+// It shells out to the system ssh rather than speaking the protocol itself, so
+// that the operator's own config, agent, keys and known_hosts decide what
+// happens. A diagnostic tool is the last place that should grow its own idea of
+// how to authenticate to a host, and no key material passes through this
+// process as a result.
+func measureFromGateway(ctx context.Context, opts segmentOptions, req pathseg.AgentRequest) (pathseg.AgentResponse, []string) {
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return pathseg.AgentResponse{}, []string{"could not encode the gateway request: " + err.Error()}
+	}
+	remote := shellQuote(opts.remoteBinary) + " segments --agent"
+	out, stderr, err := runSSH(ctx, opts, bytes.NewReader(payload), remote)
+	if err == nil {
+		var resp pathseg.AgentResponse
+		if jsonErr := json.Unmarshal(out, &resp); jsonErr == nil && len(resp.References) > 0 {
+			var notes []string
+			if resp.Version != version {
+				notes = append(notes, fmt.Sprintf(
+					"the gateway runs queqiaod %s and this client runs %s; both ends measured with their "+
+						"own build", resp.Version, version))
+			}
+			return resp, notes
+		}
+	}
+
+	// The remote binary is missing, too old, or not on the path. Fall back to
+	// ping, and say so: the fallback gives up the one property that made the
+	// two vantage points comparable, which is that they ran the same code.
+	notes := []string{fmt.Sprintf(
+		"%s on the gateway could not run the agent (%s), so its legs were measured with ping instead. "+
+			"That loses the per-packet order, so no loss pattern is reported for them, and the two "+
+			"vantage points are no longer running one instrument. Install a matching queqiaod there, "+
+			"or point --remote-binary at it",
+		opts.remoteBinary, firstLine(stderr, err))}
+	refs, pingNotes := measureFromGatewayWithPing(ctx, opts, req)
+	return pathseg.AgentResponse{References: refs}, append(notes, pingNotes...)
+}
+
+func measureFromGatewayWithPing(ctx context.Context, opts segmentOptions, req pathseg.AgentRequest) ([]pathseg.Reference, []string) {
+	var refs []pathseg.Reference
+	var notes []string
+	// iputils refuses an interval below 200ms to an unprivileged caller, and a
+	// run that is refused measures nothing at all, so the fallback slows down
+	// rather than failing.
+	interval := time.Duration(req.IntervalMS) * time.Millisecond
+	if interval < 200*time.Millisecond {
+		interval = 200 * time.Millisecond
+	}
+	for _, target := range req.References {
+		host := target
+		if h, _, err := net.SplitHostPort(target); err == nil {
+			host = h
+		}
+		cmd := fmt.Sprintf("ping -n -q -c %d -i %.1f %s", req.Count, interval.Seconds(), shellQuote(host))
+		out, stderr, err := runSSH(ctx, opts, nil, cmd)
+		ref := pathseg.Reference{Target: target}
+		if err != nil && len(out) == 0 {
+			ref.Error = firstLine(stderr, err)
+			notes = append(notes, fmt.Sprintf("ping to %s from the gateway failed: %s", target, ref.Error))
+			refs = append(refs, ref)
+			continue
+		}
+		leg, parseErr := parsePingSummary(string(out), target)
+		if parseErr != nil {
+			ref.Error = parseErr.Error()
+		}
+		leg.From, leg.To = "gateway", target
+		ref.Echo = leg
+		refs = append(refs, ref)
+	}
+	return refs, notes
+}
+
+func runSSH(ctx context.Context, opts segmentOptions, stdin io.Reader, remote string) ([]byte, string, error) {
+	// BatchMode is not a hardening choice but a correctness one: stdin carries
+	// the measurement request, so ssh has nowhere to read a password from and a
+	// prompt would hang until the run's deadline rather than fail.
+	//
+	// The operator's own options go first because ssh takes the first value it
+	// obtains for any parameter, so anything set here before them could not be
+	// overridden from the command line.
+	args := append([]string{}, opts.sshOptions...)
+	args = append(args, "-o", "BatchMode=yes", "-o", "ConnectTimeout=10")
+	args = append(args, opts.sshTarget, "--", remote)
+	// #nosec G204 -- ssh is a fixed program name, and its arguments are this
+	// operator's own flags rather than anything read from the network. The
+	// remote command is shell-quoted because ssh runs it through a shell.
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	cmd.Stdin = stdin
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.String(), err
+}
+
+// shellQuote wraps a value so that the remote shell sees it as one word. ssh
+// hands the command to a shell on the far side, so a path with a space in it
+// would otherwise arrive as two arguments.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func firstLine(stderr string, err error) string {
+	for _, line := range strings.Split(stderr, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "no output"
+}

--- a/cmd/queqiaod/segments_render.go
+++ b/cmd/queqiaod/segments_render.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bojieli/queqiao/internal/pathseg"
+)
+
+// pingSummary and pingTiming match the two lines every ping(8) worth parsing
+// prints, across iputils and the BSD family: the counts, and the timing.
+//
+// Only the summary is available this way. ping -q reports what happened but not
+// in what order, so a run parsed from it has a loss rate and no loss pattern,
+// and the difference between an erasure channel and a policer -- which is the
+// difference between compensating and backing off -- cannot be read from it at
+// all. That is the cost of the fallback, and the report says so where it is used.
+var (
+	pingSummary = regexp.MustCompile(`(\d+) packets transmitted, (\d+)( packets)? received`)
+	pingTiming  = regexp.MustCompile(`(?:rtt|round-trip) min/avg/max(?:/[a-z]+)? = ([0-9.]+)/([0-9.]+)/([0-9.]+)`)
+)
+
+func parsePingSummary(out, target string) (pathseg.Leg, error) {
+	leg := pathseg.Leg{Name: "echo:" + target, To: target, Method: "ping-summary"}
+	m := pingSummary.FindStringSubmatch(out)
+	if m == nil {
+		return leg, fmt.Errorf("could not read a ping summary from the gateway's output")
+	}
+	sent, err := strconv.Atoi(m[1])
+	if err != nil {
+		return leg, err
+	}
+	received, err := strconv.Atoi(m[2])
+	if err != nil {
+		return leg, err
+	}
+	leg.Sent, leg.Arrived = sent, received
+	if sent > 0 {
+		leg.Loss = float64(sent-received) / float64(sent)
+	}
+	if received == 0 {
+		leg.Blocked = true
+		return leg, nil
+	}
+	if t := pingTiming.FindStringSubmatch(out); t != nil {
+		min, _ := strconv.ParseFloat(t[1], 64)
+		avg, _ := strconv.ParseFloat(t[2], 64)
+		max, _ := strconv.ParseFloat(t[3], 64)
+		leg.MinMS, leg.MeanMS, leg.P99MS = min, avg, max
+	}
+	return leg, nil
+}
+
+func renderSegments(w io.Writer, r segmentReport) {
+	fmt.Fprintf(w, "queqiao path segment profile — queqiaod %s\n", r.Version)
+	fmt.Fprintf(w, "  started        %s (took %.1fs)\n", r.StartedAt.Format("2006-01-02T15:04:05Z"), r.ElapsedS)
+	fmt.Fprintf(w, "  gateway        %s\n", r.Gateway)
+	if r.SSHTarget != "" {
+		host := r.RemoteHost
+		if host == "" {
+			host = "unnamed"
+		}
+		fmt.Fprintf(w, "  far vantage    ssh %s (%s)\n", r.SSHTarget, host)
+	} else {
+		fmt.Fprintf(w, "  far vantage    none. Pass --ssh to measure the gateway's own transit instead of\n")
+		fmt.Fprintf(w, "                 leaving it unexamined\n")
+	}
+	fmt.Fprintf(w, "  window         %d echo probes at %dms per leg\n", r.Probes, r.IntervalMS)
+
+	fmt.Fprintf(w, "\nVERDICT  %s\n\n", r.Attribution.Headline)
+	for _, f := range r.Attribution.Findings {
+		fmt.Fprintf(w, "  %-6s %s\n", strings.ToUpper(f.Severity), f.Segment)
+		fmt.Fprintf(w, "         %s\n", f.Summary)
+		for _, line := range wrap(f.Detail, 84) {
+			fmt.Fprintf(w, "         %s\n", line)
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintln(w, "legs")
+	rows, problems := legRows(r.Evidence)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  vantage\ttarget\tinstrument\tsent\tloss\tmin\ttypical\tp99\tburst")
+	for _, row := range rows {
+		fmt.Fprintln(tw, row)
+	}
+	_ = tw.Flush()
+	// A leg that failed has no figures, and threading its error through the
+	// table would widen a numeric column to the width of a sentence and make
+	// every measured row unreadable. The reason it failed still has to appear,
+	// so it appears here instead of being dropped.
+	if len(problems) > 0 {
+		fmt.Fprintln(w, "\n  not measured")
+		for _, p := range problems {
+			fmt.Fprintf(w, "    %s\n", p)
+		}
+	}
+
+	if r.Evidence.Tunnel.Present {
+		renderTunnel(w, "tunnel, as the running client measures it", r.Evidence.Tunnel)
+	}
+	if r.Evidence.Remote.Present {
+		renderTunnel(w, "tunnel, as the gateway measures it", r.Evidence.Remote)
+	}
+
+	if len(r.Notes) > 0 {
+		fmt.Fprintln(w, "\nnotes")
+		for _, n := range r.Notes {
+			lines := wrap(n, 84)
+			for i, line := range lines {
+				prefix := "  - "
+				if i > 0 {
+					prefix = "    "
+				}
+				fmt.Fprintf(w, "%s%s\n", prefix, line)
+			}
+		}
+	}
+}
+
+func legRows(e pathseg.Evidence) (rows, problems []string) {
+	add := func(vantage string, refs ...pathseg.Reference) {
+		for _, ref := range refs {
+			if ref.Error != "" {
+				problems = append(problems, fmt.Sprintf("%s -> %s: %s", vantage, ref.Target, ref.Error))
+				continue
+			}
+			for _, leg := range []pathseg.Leg{ref.Echo, ref.Establish} {
+				switch {
+				case leg.Sent == 0 && leg.Error != "":
+					problems = append(problems, fmt.Sprintf("%s -> %s (%s): %s",
+						vantage, ref.Target, legMethod(leg), leg.Error))
+				case leg.Sent == 0:
+					continue
+				default:
+					rows = append(rows, legRow(vantage, ref.Target, leg))
+				}
+			}
+		}
+	}
+	add("client", e.Gateway)
+	add("client", e.ClientReferences...)
+	add("gateway", e.GatewayReferences...)
+	for i := range e.Direct {
+		rows = append(rows, legRow("client direct", e.Direct[i].To, e.Direct[i]))
+		if i < len(e.Tunneled) {
+			rows = append(rows, legRow("via tunnel", e.Tunneled[i].To, e.Tunneled[i]))
+		}
+	}
+	return rows, problems
+}
+
+// legMethod names the instrument even for a leg that never produced a sample,
+// so a failure can be told apart from the other instrument's failure.
+func legMethod(leg pathseg.Leg) string {
+	if leg.Method == "" {
+		return "probe"
+	}
+	return leg.Method
+}
+
+func legRow(vantage, target string, leg pathseg.Leg) string {
+	loss := fmt.Sprintf("%.1f%%", leg.Loss*100)
+	if leg.Blocked {
+		// A leg that got nothing back has not measured total loss, it has
+		// measured nothing, and printing 100% would make the strongest claim
+		// in the table out of the weakest evidence.
+		loss = "no reply"
+	}
+	typical := "-"
+	switch {
+	case leg.P50MS > 0:
+		typical = fmt.Sprintf("%.1f", leg.P50MS)
+	case leg.MeanMS > 0:
+		typical = fmt.Sprintf("%.1f avg", leg.MeanMS)
+	}
+	burst := "-"
+	if leg.Loss > 0 && leg.BurstFactor > 0 {
+		burst = fmt.Sprintf("%.1f", leg.BurstFactor)
+	}
+	return fmt.Sprintf("  %s\t%s\t%s\t%d\t%s\t%s\t%s\t%s\t%s",
+		vantage, target, leg.Method, leg.Sent, loss,
+		optional(leg.MinMS), typical, optional(leg.P99MS), burst)
+}
+
+func optional(v float64) string {
+	if v == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f", v)
+}
+
+func renderTunnel(w io.Writer, title string, v pathseg.TunnelView) {
+	fmt.Fprintf(w, "\n%s\n", title)
+	fmt.Fprintf(w, "  lanes %d, active flows %d, min rtt %.1fms, smoothed %.1fms\n",
+		v.Lanes, v.ActiveFlows, v.MinRTTMS, v.SmoothedRTTMS)
+	fmt.Fprintf(w, "  erasure        receive %.1f%% (residual %.1f%%)   send %.1f%%\n",
+		v.ReceiveErasure*100, v.ReceiveResidual*100, v.SendErasure*100)
+	fmt.Fprintf(w, "  measured over  %d coded symbols, %d packets sent\n", v.CodedSymbols, v.PacketsSent)
+	if !v.ReceiveSignificant() {
+		fmt.Fprintf(w, "  the session has not carried enough to make those ratios meaningful; drive traffic\n")
+		fmt.Fprintf(w, "  through it and run this again\n")
+	}
+	if v.Fallbacks > 0 || v.LaneFailures > 0 || v.FlowStalls > 0 || v.PortHops > 0 {
+		fmt.Fprintf(w, "  events         %d fallbacks, %d lane failures, %d flow stalls, %d port hops\n",
+			v.Fallbacks, v.LaneFailures, v.FlowStalls, v.PortHops)
+	}
+}
+
+// wrap breaks detail text at a column so a terminal shows a paragraph rather
+// than one very long line.
+func wrap(s string, width int) []string {
+	if s == "" {
+		return nil
+	}
+	var lines []string
+	var line strings.Builder
+	for _, word := range strings.Fields(s) {
+		if line.Len() > 0 && line.Len()+1+len(word) > width {
+			lines = append(lines, line.String())
+			line.Reset()
+		}
+		if line.Len() > 0 {
+			line.WriteByte(' ')
+		}
+		line.WriteString(word)
+	}
+	if line.Len() > 0 {
+		lines = append(lines, line.String())
+	}
+	return lines
+}

--- a/cmd/queqiaod/segments_test.go
+++ b/cmd/queqiaod/segments_test.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/pathseg"
+)
+
+// Both ping families have to parse, because the fallback exists precisely for
+// gateways this project did not install and does not control.
+func TestParsePingSummaryReadsBothFamilies(t *testing.T) {
+	iputils := `PING example.com (203.0.113.9) 56(84) bytes of data.
+
+--- example.com ping statistics ---
+50 packets transmitted, 47 received, 6% packet loss, time 9803ms
+rtt min/avg/max/mdev = 189.123/191.456/295.789/12.345 ms
+`
+	bsd := `PING example.com (203.0.113.9): 56 data bytes
+
+--- example.com ping statistics ---
+50 packets transmitted, 47 packets received, 6.0% packet loss
+round-trip min/avg/max/stddev = 189.123/191.456/295.789/12.345 ms
+`
+	for name, out := range map[string]string{"iputils": iputils, "bsd": bsd} {
+		leg, err := parsePingSummary(out, "example.com:443")
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if leg.Sent != 50 || leg.Arrived != 47 {
+			t.Fatalf("%s: sent %d arrived %d", name, leg.Sent, leg.Arrived)
+		}
+		if got := leg.Loss; got < 0.059 || got > 0.061 {
+			t.Fatalf("%s: loss %v, want about 0.06", name, got)
+		}
+		if leg.MinMS != 189.123 || leg.P99MS != 295.789 {
+			t.Fatalf("%s: timing %v/%v", name, leg.MinMS, leg.P99MS)
+		}
+		// ping reports a mean and this tool reports medians everywhere else.
+		// Folding one into the other would misreport exactly the tailed
+		// distributions this command is pointed at.
+		if leg.MeanMS != 191.456 {
+			t.Fatalf("%s: mean %v", name, leg.MeanMS)
+		}
+		if leg.P50MS != 0 {
+			t.Fatalf("%s: a mean was reported as a median: %v", name, leg.P50MS)
+		}
+	}
+}
+
+func TestParsePingSummaryMarksATotalLossAsBlocked(t *testing.T) {
+	leg, err := parsePingSummary(
+		"50 packets transmitted, 0 received, 100% packet loss, time 9999ms\n", "x:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !leg.Blocked {
+		t.Fatal("a run with no replies was not marked blocked")
+	}
+	if leg.Usable() {
+		t.Fatal("a blocked leg is being offered as evidence")
+	}
+}
+
+func TestParsePingSummaryRefusesOutputItCannotRead(t *testing.T) {
+	if _, err := parsePingSummary("ping: command not found\n", "x:443"); err == nil {
+		t.Fatal("unparseable output was accepted as a measurement")
+	}
+}
+
+// ssh hands the command to a shell on the far side, so a path with a space in
+// it would otherwise arrive as two arguments and run something else.
+func TestShellQuoteSurvivesAShell(t *testing.T) {
+	for in, want := range map[string]string{
+		"queqiaod":                 `'queqiaod'`,
+		"/opt/my gateway/queqiaod": `'/opt/my gateway/queqiaod'`,
+		"/opt/it's/queqiaod":       `'/opt/it'\''s/queqiaod'`,
+		"; rm -rf /; echo":         `'; rm -rf /; echo'`,
+	} {
+		if got := shellQuote(in); got != want {
+			t.Fatalf("shellQuote(%q) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// The agent writes to a pipe that ssh carries back, so anything on stdout that
+// is not the result arrives at the other end as a parse error.
+func TestTheAgentWritesNothingButJSON(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+
+	req := pathseg.AgentRequest{
+		References: []string{ln.Addr().String()},
+		Count:      2, IntervalMS: 20, TimeoutMS: 200, EstablishCount: 1,
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runSegmentsAgent(bytes.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	var resp pathseg.AgentResponse
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("the agent wrote something that is not JSON: %v\n%s", err, out.String())
+	}
+	if len(resp.References) != 1 {
+		t.Fatalf("%d references came back", len(resp.References))
+	}
+	if resp.References[0].Establish.Arrived != 1 {
+		t.Fatalf("the reachability instrument did not reach a listener that accepted: %+v",
+			resp.References[0].Establish)
+	}
+}
+
+func TestTheAgentRefusesARequestItCannotRead(t *testing.T) {
+	var out bytes.Buffer
+	if err := runSegmentsAgent(strings.NewReader("{}"), &out); err == nil {
+		t.Fatal("a request naming nothing to measure was accepted")
+	}
+	if out.Len() != 0 {
+		t.Fatalf("a refused request still wrote to stdout: %s", out.String())
+	}
+}
+
+func TestSegmentsRefusesToRunWithoutAGateway(t *testing.T) {
+	err := runSegmentsCommand([]string{"--count", "1"})
+	if err == nil || !strings.Contains(err.Error(), "--endpoint") {
+		t.Fatalf("a run with no gateway gave %v", err)
+	}
+}
+
+func TestSegmentsRefusesAnEmptyRun(t *testing.T) {
+	err := runSegmentsCommand([]string{"--endpoint", "gw:443", "--count", "0"})
+	if err == nil || !strings.Contains(err.Error(), "--count") {
+		t.Fatalf("a zero-probe run gave %v", err)
+	}
+}
+
+// The two anchors are one Chinese and one global on purpose, and they are used
+// unchanged at both ends: a probe from a filtered network to a filtered
+// destination measures the filter, and whichever anchor answers cleanly is the
+// one that establishes that vantage point's own link.
+func TestTheDefaultAnchorsSpanBothSidesOfAFilter(t *testing.T) {
+	if len(defaultReferences) < 2 {
+		t.Fatal("a single default anchor cannot distinguish a filtered route from a lossy link")
+	}
+	joined := strings.Join(defaultReferences, ",")
+	for _, want := range []string{"baidu.com", "google.com"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("the defaults omit %s: %v", want, defaultReferences)
+		}
+	}
+}
+
+func TestRenderShowsTheVerdictTheLegsAndWhatWasNotMeasured(t *testing.T) {
+	e := pathseg.Evidence{
+		Gateway: pathseg.Reference{Target: "gw:12443",
+			Echo: pathseg.Leg{Name: "echo:gw", To: "gw:12443", Method: "icmp",
+				Sent: 50, Arrived: 50, MinMS: 195, P50MS: 197, P99MS: 240}},
+		ClientReferences: []pathseg.Reference{{Target: "baidu.com:443",
+			Echo: pathseg.Leg{Name: "echo:baidu", To: "baidu.com:443", Method: "icmp",
+				Sent: 50, Arrived: 50, MinMS: 11, P50MS: 12, P99MS: 20}}},
+		Tunnel: pathseg.TunnelView{Present: true, ReceiveErasure: 0.142, SendErasure: 0.003,
+			ReceiveResidual: 0.011, MinRTTMS: 197, SmoothedRTTMS: 214, Lanes: 2,
+			CodedSymbols: 100000, PacketsSent: 100000},
+	}
+	r := segmentReport{
+		Version: "test", StartedAt: time.Now().UTC(), Probes: 50, IntervalMS: 100,
+		Gateway: "gw:12443", Evidence: e, Attribution: pathseg.Attribute(e),
+		Notes: []string{"a note that should survive rendering"},
+	}
+	var out bytes.Buffer
+	renderSegments(&out, r)
+	got := out.String()
+	for _, want := range []string{
+		"VERDICT", "client-to-gateway", "14.2%", "baidu.com:443", "icmp",
+		"a note that should survive rendering",
+		// The absence of a far vantage point has to be visible, or silence
+		// about the gateway's own transit reads as a clean bill of health.
+		"far vantage    none",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("the report omits %q:\n%s", want, got)
+		}
+	}
+}
+
+// A leg that got nothing back must never be rendered as a hundred percent loss,
+// which would be the strongest number in the table drawn from the weakest
+// evidence in it.
+func TestRenderCallsAnUnansweredLegUnanswered(t *testing.T) {
+	leg := pathseg.Leg{Name: "echo:x", To: "x:443", Method: "icmp", Sent: 50, Loss: 1, Blocked: true}
+	row := legRow("client", "x:443", leg)
+	if !strings.Contains(row, "no reply") {
+		t.Fatalf("row does not say the probes went unanswered: %s", row)
+	}
+	if strings.Contains(row, "100.0%") {
+		t.Fatalf("an unanswered leg was rendered as total loss: %s", row)
+	}
+}
+
+func TestWrapKeepsWholeWords(t *testing.T) {
+	lines := wrap("the quick brown fox jumps over the lazy dog", 12)
+	if len(lines) < 3 {
+		t.Fatalf("no wrapping happened: %v", lines)
+	}
+	for _, l := range lines {
+		if len(l) > 12 {
+			t.Fatalf("line %q exceeds the width", l)
+		}
+	}
+	if strings.Join(lines, " ") != "the quick brown fox jumps over the lazy dog" {
+		t.Fatalf("wrapping lost or reordered words: %v", lines)
+	}
+}
+
+func TestWithDefaultPortLeavesAnExplicitOneAlone(t *testing.T) {
+	if got := withDefaultPort("example.com"); got != "example.com:443" {
+		t.Fatalf("got %q", got)
+	}
+	if got := withDefaultPort("example.com:8443"); got != "example.com:8443" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFirstLinePrefersStderrThenTheError(t *testing.T) {
+	if got := firstLine("\n  ssh: connect refused\nmore\n", nil); got != "ssh: connect refused" {
+		t.Fatalf("got %q", got)
+	}
+	if got := firstLine("", fmt.Errorf("exit status 127")); got != "exit status 127" {
+		t.Fatalf("got %q", got)
+	}
+	if got := firstLine("", nil); got != "no output" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// A failed leg has no figures, and threading its error through the table would
+// widen a numeric column to the width of a sentence and make every measured row
+// unreadable. The reason still has to appear somewhere.
+func TestAFailedLegIsListedApartFromTheTable(t *testing.T) {
+	e := pathseg.Evidence{
+		Gateway: pathseg.Reference{Target: "gw:12443",
+			Echo: pathseg.Leg{Name: "echo:gw", To: "gw:12443", Method: "icmp",
+				Sent: 10, Arrived: 10, MinMS: 195, P50MS: 197, P99MS: 240}},
+		GatewayReferences: []pathseg.Reference{{Target: "baidu.com:443",
+			Error: "ssh: Could not resolve hostname gateway.invalid: nodename nor servname provided"}},
+		GatewayVantage: true,
+	}
+	rows, problems := legRows(e)
+	for _, row := range rows {
+		if strings.Contains(row, "Could not resolve") {
+			t.Fatalf("an error was rendered inside the table: %s", row)
+		}
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "Could not resolve") {
+		t.Fatalf("the failure was dropped instead of listed: %v", problems)
+	}
+	if !strings.Contains(problems[0], "gateway") {
+		t.Fatalf("the failure does not say which vantage point it was: %s", problems[0])
+	}
+
+	var out bytes.Buffer
+	renderSegments(&out, segmentReport{Version: "test", StartedAt: time.Now().UTC(),
+		Evidence: e, Attribution: pathseg.Attribute(e)})
+	if !strings.Contains(out.String(), "not measured") {
+		t.Fatalf("the report hides the failed leg:\n%s", out.String())
+	}
+}
+
+// A profile spends tens of seconds per leg producing no output, so silence has
+// to be broken or an operator kills the run before it reaches the verdict.
+func TestProgressNarratesEachLeg(t *testing.T) {
+	var out bytes.Buffer
+	p := &progress{w: &out, on: true, total: 2}
+	done := p.begin("client", "baidu.com:443")
+	done("clean, 28ms")
+	p.notef("metrics: %d symbols", 1234)
+
+	got := out.String()
+	for _, want := range []string{"[1/2]", "client", "baidu.com:443", "clean, 28ms", "metrics: 1234 symbols"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("progress omits %q:\n%s", want, got)
+		}
+	}
+	// The leg has to be announced on one line with its result, or a reader
+	// cannot tell which leg a figure belongs to.
+	if lines := strings.Count(strings.TrimSpace(got), "\n"); lines != 1 {
+		t.Fatalf("expected two lines, got:\n%s", got)
+	}
+}
+
+// --quiet exists for a log that should hold only the result, and it has to
+// silence the narration completely rather than merely shorten it.
+func TestQuietProgressWritesNothing(t *testing.T) {
+	var out bytes.Buffer
+	p := &progress{w: &out, on: false, total: 3}
+	p.begin("client", "baidu.com:443")("clean")
+	p.notef("something")
+	if out.Len() != 0 {
+		t.Fatalf("--quiet still wrote: %s", out.String())
+	}
+}
+
+func TestSummarizeReferenceNamesWhatTheVerdictWillRestOn(t *testing.T) {
+	clean := pathseg.Reference{Target: "baidu.com:443",
+		Echo:      pathseg.Leg{Name: "e", Method: "icmp", Sent: 20, Arrived: 20, P50MS: 28},
+		Establish: pathseg.Leg{Name: "s", Method: "tcp-connect", Sent: 3, Arrived: 3, P50MS: 30}}
+	if got := summarizeReference(clean); got != "clean, 28ms" {
+		t.Fatalf("got %q", got)
+	}
+
+	lossy := clean
+	lossy.Echo = pathseg.Leg{Name: "e", Method: "icmp", Sent: 20, Arrived: 18, Loss: 0.1, P50MS: 213}
+	if got := summarizeReference(lossy); got != "10.0% loss, 213ms" {
+		t.Fatalf("got %q", got)
+	}
+
+	// The filtering signature has its own line, because "no reply" and "the
+	// handshake was refused" send an operator to different places.
+	blocked := clean
+	blocked.Establish = pathseg.Leg{Name: "s", Method: "tcp-connect", Sent: 3, Loss: 1, Blocked: true}
+	if got := summarizeReference(blocked); got != "echo ok, handshake refused" {
+		t.Fatalf("got %q", got)
+	}
+
+	dead := pathseg.Reference{Target: "x:443",
+		Echo:      pathseg.Leg{Name: "e", Method: "icmp", Sent: 20, Loss: 1, Blocked: true},
+		Establish: pathseg.Leg{Name: "s", Method: "tcp-connect", Sent: 3, Loss: 1, Blocked: true}}
+	if got := summarizeReference(dead); got != "no reply" {
+		t.Fatalf("got %q", got)
+	}
+
+	if got := summarizeReference(pathseg.Reference{Target: "x", Error: "resolve failed"}); got != "failed" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/docs/CHOOSING-A-GATEWAY.md
+++ b/docs/CHOOSING-A-GATEWAY.md
@@ -107,8 +107,10 @@ reasoning about the vendor that operates it.
 
 ## Establishing the facts before deploying
 
-Three instruments answer three different questions, and reaching for the wrong
-one produces a confident answer to a question nobody asked.
+Four instruments answer four different questions, and reaching for the wrong
+one produces a confident answer to a question nobody asked. The first three
+below settle whether to deploy at all; the fourth is for a deployment that
+already exists and is misbehaving.
 
 ### What a local check can settle
 
@@ -206,6 +208,31 @@ transport's advantage scales with how much of it there is.
 
 [Reproducing the datacenter measurements](MEASURING-A-DC-PATH.md) gives the
 commands and the analysis in full.
+
+### What only a second vantage point can settle
+
+The three above are run from the client, and none of them can say *which
+segment* a loss belongs to. A slow deployment has three candidates that need
+three different responses -- the client's own access link, the long haul this
+transport carries, and the gateway's transit onward -- and a figure measured end
+to end is consistent with all three.
+
+`queqiaod segments` localises it by measuring both ends in the same minutes and
+reading the running client's own per-direction erasure, which is the only
+measurement that separates upstream from downstream. Note that the far leg
+`doctor` prints above is a subtraction; `--ssh` measures it from the gateway
+instead:
+
+```sh
+queqiaod segments --profile ~/.config/queqiao/*.json \
+  --metrics http://127.0.0.1:12090/metrics \
+  --ssh operator@gateway.example.net
+```
+
+This is the one instrument here that needs a live, busy session rather than a
+quiet host, so it belongs after deployment rather than before it. [Which segment
+is at fault](PROFILING-A-TUNNEL.md) explains the reasoning, and why each end
+needs an anchor that is unfiltered where it is probing from.
 
 ### What only the workload can settle
 

--- a/docs/MEASURING-A-DC-PATH.md
+++ b/docs/MEASURING-A-DC-PATH.md
@@ -4,6 +4,12 @@ Everything in [PATH-CHARACTER-DC-20260826.md](PATH-CHARACTER-DC-20260826.md)
 came from two binaries in this repository. Here's how to re-run it, so the
 numbers can be checked on another path instead of taken on trust.
 
+These two describe a path end to end. To find out *which segment* of a
+deployment a loss belongs to — the client's access link, the long haul, or the
+gateway's own transit — see [which segment is at
+fault](PROFILING-A-TUNNEL.md), which measures both ends in the same minutes and
+localises it.
+
 ## Why there are two tools
 
 `pathprobe` is open-loop. It sends at a rate nothing is allowed to adjust and

--- a/docs/PROFILING-A-TUNNEL.md
+++ b/docs/PROFILING-A-TUNNEL.md
@@ -1,0 +1,166 @@
+# Finding out which segment is at fault
+
+A slow deployment raises one question that no measurement in this repository
+answered until now: not how bad the path is, but *whose fault it is*.
+
+There are three candidates and they need three different responses.
+
+| Segment | What it is | What fixes it |
+| --- | --- | --- |
+| `client-to-internet` | the client's own access link and first mile | the client's ISP; no transport can repair it |
+| `client-to-gateway` | the long haul this transport carries | this transport: coding, pacing, lane recovery |
+| `gateway-to-internet` | the gateway's own transit onward | the gateway's provider, or moving the gateway |
+
+`pathprobe` finds an erasure floor, `pathmeasure` says what a stack achieves,
+and `queqiaod doctor` checks preconditions and placement — but all three
+describe a path end to end. An operator losing a seventh of everything that
+crosses the path learns from them only that they are losing a seventh.
+
+```sh
+queqiaod segments \
+  --profile ~/.config/queqiao/provider.json \
+  --metrics http://127.0.0.1:12090/metrics \
+  --ssh operator@gateway.example.net \
+  --remote-metrics http://127.0.0.1:19090/metrics \
+  --destination www.wikipedia.org:443
+```
+
+## How the segments are told apart
+
+The legs overlap in exactly one place each, so the pattern of which ones are
+lossy names the segment they share.
+
+- The client reaching an unfiltered destination **near itself** crosses its own
+  access link and nothing else.
+- The client reaching the gateway crosses its access link *and* the long haul.
+- The gateway reaching an unfiltered destination **near itself** shares neither.
+
+So a lossy leg to the gateway with a clean local anchor is the long haul; the
+same loss with a lossy local anchor is the first mile, which the gateway leg
+merely inherited. The report says which, and says so in those words.
+
+For this to hold, the legs have to be measured in the same minutes. The path
+this project was built for moves between roughly zero and seventeen percent
+loss within minutes, so the far side runs while the near side does rather than
+after it.
+
+## The anchors, and why they are not shared
+
+**A probe from a filtered network to a filtered destination measures the
+filter.** Read as loss, that would convict a healthy access link of the worst
+fault this report can report and send the operator to their ISP. A client in
+China probing a blocked host sees near-total loss on a first mile in perfect
+health.
+
+So each vantage point is judged against a destination that is local and
+unfiltered *from where it is probing*. Rather than guess where each end is,
+both a Chinese and a global anchor are probed from both ends:
+
+```sh
+--client-reference baidu.com:443  --client-reference www.google.com:443
+--gateway-reference baidu.com:443 --gateway-reference www.google.com:443
+```
+
+Each end's link is then judged by **whichever anchor answered cleanly**, never
+by the average. One clean anchor proves the link carries traffic; an anchor
+that did not is evidence about the route to *it*. That makes the defaults
+correct at both ends without a geolocation table, and it turns the
+disagreement between the two anchors into a finding of its own:
+
+- an address that **answers echo but refuses a handshake** is reported as
+  filtering, and charged to no segment;
+- a leg that returns **nothing at all** is reported as unanswered, never as
+  100% loss — from the client those two are indistinguishable, and only one of
+  them is a finding.
+
+Override the anchors whenever the defaults are wrong for your ends. Any
+destination works as long as it is unfiltered and genuinely near the vantage
+point that probes it.
+
+## Why `--metrics` matters more than the probes
+
+The running client already measures the client-to-gateway segment better than
+anything this command can send at it: on the real four-tuple, at the real rate,
+and **separately per direction**. An echo probe is a round trip and averages
+the two halves of a path this project has measured differing by fourteen
+percentage points.
+
+Run the client with `--metrics-listen 127.0.0.1:12090` and pass that URL. The
+report then reads the erasure the transport is acting on, the residual the code
+could not repair, and the minimum round trip the delay bound is held against.
+Without it the segment falls back to a round-trip probe, and the report says so.
+
+Ratios drawn from an idle session are not quoted as measurements. Drive some
+traffic through the tunnel before profiling it.
+
+## Why `--ssh` matters
+
+Without a vantage point on the gateway, the gateway's own transit is not
+measured at all — `doctor` infers that leg by subtracting the gateway round
+trip from a tunnelled establishment, which is a derivation, not a measurement.
+A clean report from the client alone has not cleared that segment; it never
+looked at it, and the report says that too.
+
+`--ssh` runs the *same code* on the gateway over your existing ssh config,
+agent and keys — no credentials pass through this process. It needs a
+`queqiaod` there that has this command; point `--remote-binary` at it if it is
+not on the path. A gateway running an older build falls back to parsing
+`ping(8)`, which loses the per-packet order and therefore the loss pattern, and
+the report labels every leg measured that way.
+
+Because stdin carries the request, ssh runs with `BatchMode=yes`: key or agent
+authentication only, and a password prompt fails fast instead of hanging.
+
+## Reading the verdict
+
+```
+VERDICT  The fault is on the client-to-gateway segment.
+
+  FAULT  client-to-gateway
+         the tunnel measures 14.2% erasure downstream and 0.3% upstream, at 197ms
+         minimum round trip
+         Measured by the running transport itself on the live session, which is the
+         only instrument here that separates the two directions. Of the downstream
+         erasure, 1.1% was left unrepaired after coding and cost a further round
+         trip. The client's local anchor is clean, so this is the long haul rather
+         than the first mile, and it is the one segment this transport exists to
+         repair.
+
+  OK     client-to-internet
+         clean: 0.0% to baidu.com:443 at 12.4ms
+```
+
+The `burst` column separates the two loss regimes, on the same statistic
+`pathprobe -pattern` reports. A burst factor near 1 is an erasure channel and
+sending slower will not make it drop less; a high one is a queue or a policer,
+where backing off is exactly the response.
+
+A run takes a few seconds per leg and minutes with `--ssh` and several
+destinations, so it narrates itself on stderr as it goes:
+
+```
+  profiling 155.103.252.95:12540: 4 legs from the client at about 7s each
+  gateway vantage: ssh rtx-pro, 2 legs running alongside these
+  [1/4] client -> 155.103.252.95:12540         9.9% loss, 216ms         (7.1s)
+  [2/4] client -> baidu.com:443                clean, 28ms              (7.0s)
+  [3/4] client -> www.google.com:443           echo ok, handshake refused (7.2s)
+  metrics: 9.8% receive erasure, 1.5% send, over 48219 coded symbols
+```
+
+That goes to stderr, so `--json` on stdout stays machine-readable with the
+narration still visible; `--quiet` silences it for a log that should hold only
+the result.
+
+`--json` emits the whole run — every leg, both ends' metrics, and the findings
+— which is the form to attach to a bug report. Check what it says about your
+own infrastructure before sharing it; see
+[contributing network evidence](CONTRIBUTING-NETWORK-EVIDENCE.md).
+
+## What this command is not
+
+It samples segments; it does not drive them. Throughput, capacity knees, and
+completion time under load belong to [`pathprobe` and
+`pathmeasure`](MEASURING-A-DC-PATH.md), which drive a path rather than sample
+it. Gateway *placement* — whether a destination is served closer to the client
+than the gateway is — belongs to `queqiaod doctor --destination`, which
+alternates its arms properly for that comparison.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ you choose the next document based on what you want to do.
 | Use a provider and client | [Deployment guide](DEPLOYING.md) |
 | Understand the transport in depth | [Current design](DESIGN.md), then [architecture](ARCHITECTURE.md) |
 | Measure a path or compare a baseline | [Benchmarking](BENCHMARKING.md) |
+| Work out which segment a deployment's loss is on | [Which segment is at fault](PROFILING-A-TUNNEL.md) |
 | Run inference traffic between two regions you own | [Datacenter profile](DEPLOYING-DC-PROFILE.md) |
 | Contribute code, documentation, or network results | [Contributing](../CONTRIBUTING.md) |
 
@@ -65,6 +66,10 @@ you choose the next document based on what you want to do.
 
 ## Measure and qualify
 
+- [Finding out which segment is at fault](PROFILING-A-TUNNEL.md) — profiling a
+  live tunnel to localise loss to the client's access link, the long haul, or
+  the gateway's own transit, and why each end needs an anchor that is unfiltered
+  where it is probing from.
 - [Benchmarking](BENCHMARKING.md) — reproducible short-lived, interactive, and
   bulk workload measurements.
 - [Reproducing the datacenter measurements](MEASURING-A-DC-PATH.md) — how to

--- a/internal/pathseg/agent.go
+++ b/internal/pathseg/agent.go
@@ -1,0 +1,193 @@
+package pathseg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+)
+
+// The gateway half of a profile runs this code, reached over SSH, rather than a
+// second implementation driven by parsing some other program's output.
+//
+// That is the point of the agent. The whole method rests on comparing what one
+// vantage point sees with what another sees, and a comparison between two
+// instruments measures the instruments as much as the path: a different probe
+// size, a different cadence, a different idea of what counts as a timeout, and
+// the difference between the two ends is no longer attributable to the network.
+// One binary, one set of options, two places.
+//
+// There is a fallback that parses ping(8) for gateways whose queqiaod is older
+// than this command, and it is a fallback precisely because it gives that
+// property up; the report says so wherever it is used.
+
+// AgentRequest is what the near side asks the far side to measure.
+type AgentRequest struct {
+	References []string `json:"references"`
+	Count      int      `json:"count"`
+	IntervalMS int      `json:"interval_ms"`
+	TimeoutMS  int      `json:"timeout_ms"`
+	// EstablishCount is kept small: it is a reachability instrument rather than
+	// a timing one, and every sample is a real connection to a third party.
+	EstablishCount int `json:"establish_count"`
+	// MetricsURL is read on the far side, because a gateway publishes its
+	// metrics on loopback and the only way to reach them is from there.
+	MetricsURL string `json:"metrics_url,omitempty"`
+	// PinAddress forces a target to one address, so that both vantage points
+	// measure the same machine when the operator wants them to. Left empty,
+	// each side resolves for itself, which is what shows up an anycast name
+	// that resolves to two different continents.
+	PinAddress map[string]string `json:"pin_address,omitempty"`
+}
+
+// AgentResponse is what comes back.
+type AgentResponse struct {
+	Version      string      `json:"version"`
+	Hostname     string      `json:"hostname,omitempty"`
+	References   []Reference `json:"references"`
+	Metrics      TunnelView  `json:"metrics"`
+	MetricsError string      `json:"metrics_error,omitempty"`
+}
+
+// ProbeConfig is the cadence both vantage points share.
+type ProbeConfig struct {
+	Count          int
+	Interval       time.Duration
+	Timeout        time.Duration
+	EstablishCount int
+	LocalAddress   string
+	PinAddress     map[string]string
+}
+
+// MeasureReferences points both instruments at each anchor in turn.
+//
+// The anchors are measured one after another rather than at once. They are
+// third parties, and a tool that fans probes out in parallel to several of them
+// looks like something other than a diagnostic; the run is short enough that
+// the path does not move underneath it, which is the only reason to have
+// preferred parallel.
+func MeasureReferences(ctx context.Context, targets []string, cfg ProbeConfig) []Reference {
+	out := make([]Reference, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, MeasureReference(ctx, target, cfg))
+	}
+	return out
+}
+
+// MeasureReference measures one anchor. It is separate from the loop above so
+// that a caller which wants to say what it is doing between anchors can drive
+// the loop itself: a run takes tens of seconds per leg and minutes in total,
+// and silence for that long is indistinguishable from a hang.
+func MeasureReference(ctx context.Context, target string, cfg ProbeConfig) Reference {
+	r := Reference{Target: target}
+	host, hostPort := splitReference(target)
+
+	// One address for both instruments. Resolving twice would let the echo leg
+	// and the establishment leg land on two machines and turn a load balancer
+	// into a finding.
+	var ip net.IP
+	if pinned := cfg.PinAddress[target]; pinned != "" {
+		ip = net.ParseIP(pinned)
+	}
+	if ip == nil {
+		resolved, err := Resolve(ctx, host, cfg.LocalAddress)
+		if err != nil {
+			r.Error = fmt.Sprintf("resolve %s: %v", host, err)
+			return r
+		}
+		ip = resolved
+	}
+	r.Address = ip.String()
+
+	seq, err := Ping(ctx, PingOptions{
+		Target: ip, LocalAddress: cfg.LocalAddress,
+		Count: cfg.Count, Interval: cfg.Interval, Timeout: cfg.Timeout,
+	})
+	r.Echo = Summarize("echo:"+target, "", target, "icmp", seq)
+	r.Echo.Address = r.Address
+	if err != nil {
+		r.Echo.Error = err.Error()
+	}
+
+	establishCount := cfg.EstablishCount
+	if establishCount <= 0 {
+		establishCount = 3
+	}
+	eseq := Establish(ctx, EstablishOptions{
+		Target: hostPort, Address: r.Address, LocalAddress: cfg.LocalAddress,
+		Count: establishCount, Interval: cfg.Interval, Timeout: cfg.Timeout,
+	})
+	r.Establish = Summarize("establish:"+target, "", target, "tcp-connect", eseq)
+	r.Establish.Address = r.Address
+	return r
+}
+
+// splitReference accepts a bare host or a host:port and returns both forms.
+// Port 443 is the default because it is the port a filtered path is filtered
+// on, and a reachability check on a port nothing is listening to would report
+// every anchor as blocked.
+func splitReference(target string) (host, hostPort string) {
+	if h, p, err := net.SplitHostPort(target); err == nil {
+		return h, net.JoinHostPort(h, p)
+	}
+	return target, net.JoinHostPort(target, "443")
+}
+
+// RunAgent performs one far-side measurement. It is the whole of what the
+// remote half does, so that the remote half cannot drift from the near one.
+func RunAgent(ctx context.Context, req AgentRequest, version string) AgentResponse {
+	cfg := ProbeConfig{
+		Count:          req.Count,
+		Interval:       time.Duration(req.IntervalMS) * time.Millisecond,
+		Timeout:        time.Duration(req.TimeoutMS) * time.Millisecond,
+		EstablishCount: req.EstablishCount,
+		PinAddress:     req.PinAddress,
+	}
+	resp := AgentResponse{Version: version}
+	if name, err := os.Hostname(); err == nil {
+		resp.Hostname = name
+	}
+	resp.References = MeasureReferences(ctx, req.References, cfg)
+	if req.MetricsURL != "" {
+		view, err := FetchMetrics(ctx, req.MetricsURL)
+		if err != nil {
+			resp.MetricsError = err.Error()
+		} else {
+			resp.Metrics = view
+		}
+	}
+	return resp
+}
+
+// DecodeAgentRequest reads a request, bounding it so that a wrong pipe cannot
+// be read until this process runs out of memory.
+func DecodeAgentRequest(r io.Reader) (AgentRequest, error) {
+	var req AgentRequest
+	if err := json.NewDecoder(io.LimitReader(r, 1<<20)).Decode(&req); err != nil {
+		return AgentRequest{}, err
+	}
+	if len(req.References) == 0 {
+		return AgentRequest{}, fmt.Errorf("the request names no references")
+	}
+	// The far side is a third party's machine as far as this process is
+	// concerned, so the request is bounded here rather than trusted.
+	if req.Count <= 0 || req.Count > 1000 {
+		req.Count = 50
+	}
+	if req.IntervalMS <= 0 || req.IntervalMS > 10000 {
+		req.IntervalMS = 100
+	}
+	if req.TimeoutMS <= 0 || req.TimeoutMS > 60000 {
+		req.TimeoutMS = 2000
+	}
+	if req.EstablishCount < 0 || req.EstablishCount > 50 {
+		req.EstablishCount = 3
+	}
+	if len(req.References) > 16 {
+		req.References = req.References[:16]
+	}
+	return req, nil
+}

--- a/internal/pathseg/agent_test.go
+++ b/internal/pathseg/agent_test.go
@@ -1,0 +1,57 @@
+package pathseg
+
+import (
+	"strings"
+	"testing"
+)
+
+// The request arrives over ssh from another machine, so it is bounded here
+// rather than trusted. A far side that asked for a million probes at a
+// microsecond apart would be a packet flood wearing a diagnostic's clothes.
+func TestDecodeAgentRequestBoundsWhatItWasAsked(t *testing.T) {
+	req, err := DecodeAgentRequest(strings.NewReader(
+		`{"references":["a:443"],"count":100000,"interval_ms":0,"timeout_ms":-5,"establish_count":900}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Count != 50 {
+		t.Fatalf("count %d, want the default", req.Count)
+	}
+	if req.IntervalMS != 100 {
+		t.Fatalf("interval %d, want the default", req.IntervalMS)
+	}
+	if req.TimeoutMS != 2000 {
+		t.Fatalf("timeout %d, want the default", req.TimeoutMS)
+	}
+	if req.EstablishCount != 3 {
+		t.Fatalf("establish count %d, want the default", req.EstablishCount)
+	}
+}
+
+func TestDecodeAgentRequestCapsTheReferenceList(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString(`{"references":[`)
+	for i := 0; i < 40; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"h:443"`)
+	}
+	sb.WriteString(`]}`)
+	req, err := DecodeAgentRequest(strings.NewReader(sb.String()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(req.References) != 16 {
+		t.Fatalf("%d references survived the cap", len(req.References))
+	}
+}
+
+func TestDecodeAgentRequestRejectsARequestWithNothingToMeasure(t *testing.T) {
+	if _, err := DecodeAgentRequest(strings.NewReader(`{"count":10}`)); err == nil {
+		t.Fatal("a request naming no references was accepted")
+	}
+	if _, err := DecodeAgentRequest(strings.NewReader(`not json`)); err == nil {
+		t.Fatal("a non-JSON request was accepted")
+	}
+}

--- a/internal/pathseg/attribute.go
+++ b/internal/pathseg/attribute.go
@@ -1,0 +1,588 @@
+package pathseg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Attribution turns a set of legs into the statement an operator can act on:
+// which segment is at fault, and therefore whether this transport is the answer
+// to it.
+//
+// The reasoning is a shared-element argument over legs measured in the same
+// minutes. A client reaching its gateway and the same client reaching an
+// unfiltered destination near itself share the client's own access link and
+// nothing else. A gateway reaching an unfiltered destination near itself shares
+// nothing with either. So a leg that is lossy while the legs it shares nothing
+// with are clean has localised the fault to the part only it traverses, and a
+// pair of lossy legs localises it to the part they share.
+//
+// The reference destinations are what make that argument valid, and choosing
+// them is not a detail. A probe from a filtered network to a filtered
+// destination measures the filter, and reading that as a lossy access link
+// would blame the client's ISP for a policy decision made elsewhere: on the
+// path this project exists for, a client in China probing a blocked host would
+// report near-total loss on a first mile that is in perfect health. So each
+// vantage point is measured against a destination that is local and unfiltered
+// *from that vantage* -- a Chinese anchor from a Chinese client, a global one
+// from a gateway outside -- and a vantage's local health is taken from its best
+// reference rather than its average. A reference that is clean proves the
+// access link works; a reference that is not, next to one that is, is evidence
+// about filtering or international transit, which is a finding of its own and
+// never a fault charged to the link.
+type Attribution struct {
+	Headline string    `json:"headline"`
+	Findings []Finding `json:"findings"`
+}
+
+// Finding is one statement about one segment.
+type Finding struct {
+	Segment  string `json:"segment"`
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// Severities, ordered by how much they should move an operator.
+const (
+	SeverityOK    = "ok"
+	SeverityNote  = "note"
+	SeverityWarn  = "warn"
+	SeverityFault = "fault"
+)
+
+// Segment names, which are the vocabulary the whole report speaks.
+const (
+	SegmentClientAccess  = "client-to-internet"
+	SegmentLongHaul      = "client-to-gateway"
+	SegmentGatewayEgress = "gateway-to-internet"
+	SegmentDestination   = "destination"
+	SegmentTunnel        = "tunnel"
+)
+
+// Thresholds separating a clean segment from a degraded one from a broken one.
+//
+// They are round numbers rather than measured constants, chosen to sit either
+// side of the difference that matters: an ordinary Internet segment loses well
+// under half a percent, and the erasure that motivated this project ran from
+// fourteen to forty-five percent. Anything between is degraded and worth
+// naming without being called a fault on its own.
+const (
+	CleanLoss = 0.005
+	LossyLoss = 0.02
+)
+
+// reading is a leg together with the figure a verdict should read off it.
+//
+// The distinction it carries is load-bearing. An echo leg counts packets, so
+// its loss rate is a loss rate. An establishment leg counts connections, and on
+// a path erasing a fifth of everything almost every connection still completes
+// -- TCP simply retransmits -- so its failure rate is near zero and reading it
+// as loss would report a badly damaged path as clean. What an establishment leg
+// can see is the cost of that retransmission, which is why the tail stands in
+// for loss wherever no echo socket was available.
+type reading struct {
+	Leg   Leg
+	Value float64
+	Proxy bool
+}
+
+func read(l Leg) reading {
+	if l.Method == "icmp" {
+		return reading{Leg: l, Value: l.Loss}
+	}
+	value := l.Loss
+	if l.TailRate > value {
+		value = l.TailRate
+	}
+	return reading{Leg: l, Value: value, Proxy: true}
+}
+
+// proxyNote says so wherever a verdict rested on the stand-in rather than on a
+// counted loss rate, because the two are not the same measurement and a reader
+// acting on the figure should know which they have.
+func (r reading) proxyNote() string {
+	if !r.Proxy {
+		return ""
+	}
+	return fmt.Sprintf(" This leg had no echo socket, so the figure is the share of connections that "+
+		"paid a retransmission timeout (%s of %d) rather than a counted loss rate.",
+		percent(r.Value), r.Leg.Sent)
+}
+
+// Evidence is everything one run measured.
+type Evidence struct {
+	// Gateway is the client's own path to the gateway. It is the long haul,
+	// first mile included, and it is measured with both instruments for the
+	// same reason an anchor is: a gateway that answers echo but refuses a
+	// handshake is being blocked, not lost.
+	Gateway Reference `json:"gateway"`
+	// ClientReferences and GatewayReferences are each vantage point's local,
+	// unfiltered anchors. They are what turn a lossy leg into a located one.
+	ClientReferences  []Reference `json:"client_references,omitempty"`
+	GatewayReferences []Reference `json:"gateway_references,omitempty"`
+	// Direct and Tunneled are the destinations the operator actually cares
+	// about, reached both ways, index for index.
+	Direct   []Leg `json:"direct,omitempty"`
+	Tunneled []Leg `json:"tunneled,omitempty"`
+
+	// Tunnel is the client's own account of the segment it sits on, which no
+	// external probe can match, and Remote is the gateway's account of the
+	// same segment from the other end.
+	Tunnel TunnelView `json:"tunnel"`
+	Remote TunnelView `json:"remote_tunnel"`
+
+	// GatewayVantage records whether anything was measured from the gateway at
+	// all, because a report that cannot see the far side has to say so rather
+	// than let silence read as health.
+	GatewayVantage bool `json:"gateway_vantage"`
+}
+
+// Attribute reduces the evidence to findings, worst first.
+func Attribute(e Evidence) Attribution {
+	var a Attribution
+	clientLocal, clientKnown := bestReference(e.ClientReferences)
+	gatewayLocal, gatewayKnown := bestReference(e.GatewayReferences)
+
+	a.Findings = append(a.Findings, clientAccessFinding(clientLocal, clientKnown, e.ClientReferences))
+	a.Findings = append(a.Findings, longHaulFinding(e, clientLocal, clientKnown))
+	a.Findings = append(a.Findings, gatewayEgressFinding(e, gatewayLocal, gatewayKnown))
+	a.Findings = append(a.Findings, filteringFindings(e)...)
+	a.Findings = append(a.Findings, destinationFindings(e)...)
+
+	sort.SliceStable(a.Findings, func(i, j int) bool {
+		return severityRank(a.Findings[i].Severity) > severityRank(a.Findings[j].Severity)
+	})
+	a.Headline = headline(a.Findings)
+	return a
+}
+
+func headline(findings []Finding) string {
+	var faults, warns []string
+	for _, f := range findings {
+		switch f.Severity {
+		case SeverityFault:
+			faults = append(faults, f.Segment)
+		case SeverityWarn:
+			warns = append(warns, f.Segment)
+		}
+	}
+	switch {
+	case len(faults) == 1:
+		return "The fault is on the " + faults[0] + " segment."
+	case len(faults) > 1:
+		return "More than one segment is at fault: " + strings.Join(faults, ", ") + "."
+	case len(warns) > 0:
+		return "No segment is clearly at fault; " + strings.Join(warns, ", ") + " is degraded."
+	default:
+		return "Every segment that could be measured is clean."
+	}
+}
+
+// clientAccessFinding reads the client's own link off its best local anchor.
+//
+// The best rather than the mean, because these anchors are not repeated
+// measurements of one thing. One clean anchor is proof the access link carries
+// traffic; a second anchor that is not clean says something about that anchor's
+// path, and averaging the two would turn evidence of health into a fault.
+func clientAccessFinding(best reading, known bool, all []Reference) Finding {
+	f := Finding{Segment: SegmentClientAccess}
+	if !known {
+		f.Severity = SeverityNote
+		f.Summary = "not measured"
+		f.Detail = "No local reference answered from this client, so its own access link was not " +
+			"established as healthy and nothing below can be charged to it or cleared of it. " +
+			"Name a destination that is local and unfiltered here with --client-reference."
+		if len(all) > 0 {
+			f.Detail += " Tried: " + strings.Join(referenceNames(all), ", ") + "."
+		}
+		return f
+	}
+	switch {
+	case best.Value >= LossyLoss:
+		f.Severity = SeverityFault
+		f.Summary = fmt.Sprintf("losing %s to %s, a destination that should be local to this client",
+			percent(best.Value), best.Leg.To)
+		f.Detail = "An unfiltered anchor near the client is the one leg whose loss cannot be blamed on " +
+			"distance, transit, or filtering. Loss here is the client's own access network, and no " +
+			"transport can repair a first mile: every other segment measured below crosses this one " +
+			"and inherits it. " + patternNote(best.Leg) + best.proxyNote()
+	case best.Value > CleanLoss:
+		f.Severity = SeverityWarn
+		f.Summary = fmt.Sprintf("losing %s to %s", percent(best.Value), best.Leg.To)
+		f.Detail = "Slight loss on a local anchor. It is small enough to be the anchor rather than the " +
+			"link, and large enough that it should be ruled out before any figure below is trusted." +
+			best.proxyNote()
+	default:
+		f.Severity = SeverityOK
+		f.Summary = fmt.Sprintf("clean: %s to %s at %s", percent(best.Value), best.Leg.To, rtt(best.Leg))
+		f.Detail = "The client's own access network carries traffic without loss, so any loss measured " +
+			"further out belongs further out." + best.proxyNote()
+	}
+	return f
+}
+
+// longHaulFinding reports the segment this transport actually carries.
+//
+// It prefers the tunnel's own figures over the echo probe, and says which it
+// used. The transport measured that segment on the real four-tuple at the real
+// rate and in each direction separately; the echo probe offers a few packets a
+// second and cannot tell the directions apart. Where the path erases one
+// direction and not the other -- which is the case this project was built
+// around -- only the first of those two instruments can see it.
+func longHaulFinding(e Evidence, clientLocal reading, clientKnown bool) Finding {
+	f := Finding{Segment: SegmentLongHaul}
+	firstMile := clientKnown && clientLocal.Value >= LossyLoss
+
+	if e.Tunnel.ReceiveSignificant() || e.Tunnel.SendSignificant() {
+		down, up := e.Tunnel.ReceiveErasure, e.Tunnel.SendErasure
+		worst := down
+		dir := "downstream (gateway to client)"
+		if up > worst {
+			worst, dir = up, "upstream (client to gateway)"
+		}
+		summary := fmt.Sprintf("the tunnel measures %s erasure downstream and %s upstream, at %.0fms minimum round trip",
+			percent(down), percent(up), e.Tunnel.MinRTTMS)
+		detail := fmt.Sprintf("Measured by the running transport itself on the live session, which is the "+
+			"only instrument here that separates the two directions. Of the downstream erasure, %s was left "+
+			"unrepaired after coding and cost a further round trip. ", percent(e.Tunnel.ReceiveResidual))
+		switch {
+		case worst >= LossyLoss && firstMile:
+			f.Severity = SeverityWarn
+			f.Summary = summary
+			f.Detail = detail + "The client's own access link is also lossy, and this segment crosses it, " +
+				"so this figure is the two together rather than the long haul alone. Fix the access link " +
+				"first and measure again."
+		case worst >= LossyLoss:
+			f.Severity = SeverityFault
+			f.Summary = summary
+			f.Detail = detail + "The client's local anchor is clean, so this is the long haul rather than " +
+				"the first mile, and it is the one segment this transport exists to repair. The " + dir +
+				" direction is the worse of the two."
+		case worst > CleanLoss:
+			f.Severity = SeverityWarn
+			f.Summary = summary
+			f.Detail = detail + "Low but not nil; the code should be absorbing it."
+		default:
+			f.Severity = SeverityOK
+			f.Summary = summary
+			f.Detail = detail + "The segment this transport carries is not where the loss is."
+		}
+		if e.Remote.Present {
+			f.Detail += remoteCrossCheck(e)
+		}
+		return f
+	}
+
+	// No live tunnel to read, so fall back to probing the gateway, which is a
+	// round-trip figure and has to be labelled as one.
+	gw, gwOK := e.Gateway.Health()
+	if !gwOK {
+		f.Severity = SeverityNote
+		f.Summary = "not measured"
+		f.Detail = "The tunnel published no usable erasure figures" + idleNote(e.Tunnel) +
+			", and the gateway did not answer probes" + blockedNote(e.Gateway.Echo) +
+			". Start the client with --metrics-listen and re-run, which reads the segment " +
+			"directly rather than probing it."
+		return f
+	}
+	r := read(gw)
+	summary := fmt.Sprintf("%s loss to the gateway at %s, round trip", percent(r.Value), rtt(gw))
+	detail := "Measured with " + gw.Method + " probes, which cannot separate upstream from downstream. " +
+		"On a path that erases one direction and not the other this understates the bad direction by " +
+		"half. Run the client with --metrics-listen for a per-direction figure. " + patternNote(gw) +
+		r.proxyNote()
+	switch {
+	case r.Value >= LossyLoss && firstMile:
+		f.Severity, f.Summary, f.Detail = SeverityWarn, summary, detail+
+			" The client's access link is lossy too, and this leg crosses it, so the two are not yet separated."
+	case r.Value >= LossyLoss:
+		f.Severity, f.Summary, f.Detail = SeverityFault, summary, detail+
+			" The client's local anchor is clean, so this is the long haul rather than the first mile."
+	case r.Value > CleanLoss:
+		f.Severity, f.Summary, f.Detail = SeverityWarn, summary, detail
+	default:
+		f.Severity, f.Summary, f.Detail = SeverityOK, summary, detail
+	}
+	return f
+}
+
+// remoteCrossCheck compares the two ends' accounts of one segment.
+//
+// The client infers what it sent and lost from acknowledgements; the gateway
+// counts what actually arrived. Where they disagree materially, one of them is
+// wrong about the segment they share, and an operator should know that before
+// acting on either.
+func remoteCrossCheck(e Evidence) string {
+	if !e.Remote.ReceiveSignificant() {
+		return ""
+	}
+	note := fmt.Sprintf(" The gateway's own metrics put the erasure it receives -- the client's upstream -- "+
+		"at %s, against the %s the client inferred from acknowledgements.",
+		percent(e.Remote.ReceiveErasure), percent(e.Tunnel.SendErasure))
+	if absDiff(e.Remote.ReceiveErasure, e.Tunnel.SendErasure) > LossyLoss {
+		note += " Those disagree by more than the threshold this report uses, and the gateway's figure is " +
+			"the counted one. Note that a gateway serving several clients publishes their sum, so this " +
+			"comparison only holds where this client is the only one on it."
+	}
+	return note
+}
+
+// gatewayEgressFinding reports the segment past the gateway, which is the one
+// this transport ends before and cannot do anything about.
+func gatewayEgressFinding(e Evidence, best reading, known bool) Finding {
+	f := Finding{Segment: SegmentGatewayEgress}
+	if !e.GatewayVantage {
+		f.Severity = SeverityNote
+		f.Summary = "not measured; no vantage point on the gateway"
+		f.Detail = "Everything above was measured from the client, which cannot see what the gateway's own " +
+			"transit does. Pass --ssh to measure it from there instead of inferring it by subtraction. " +
+			"Until then a clean report above does not rule this segment out."
+		return f
+	}
+	if !known {
+		f.Severity = SeverityNote
+		f.Summary = "not measured; no reference answered from the gateway"
+		f.Detail = "The gateway was reachable but none of its local anchors answered, so its transit was " +
+			"not established as healthy. Name one that is local and unfiltered there with --gateway-reference."
+		return f
+	}
+	switch {
+	case best.Value >= LossyLoss:
+		f.Severity = SeverityFault
+		f.Summary = fmt.Sprintf("the gateway loses %s to %s, a destination that should be local to it",
+			percent(best.Value), best.Leg.To)
+		f.Detail = "This is the gateway's own transit, past the point where this transport ends. Nothing in " +
+			"the tunnel repairs it: coding, pacing and lane recovery all stop at the gateway, and traffic " +
+			"leaves it as ordinary packets. This is a question for the gateway's provider, or a reason to " +
+			"move the gateway. " + patternNote(best.Leg) + best.proxyNote()
+	case best.Value > CleanLoss:
+		f.Severity = SeverityWarn
+		f.Summary = fmt.Sprintf("the gateway loses %s to %s", percent(best.Value), best.Leg.To)
+		f.Detail = "Small, but it is past the point this transport can repair, so it passes through to every " +
+			"flow undiminished." + best.proxyNote()
+	default:
+		f.Severity = SeverityOK
+		f.Summary = fmt.Sprintf("clean: %s to %s at %s", percent(best.Value), best.Leg.To, rtt(best.Leg))
+		f.Detail = "The gateway's own transit carries traffic without loss, so loss seen through the tunnel " +
+			"was not introduced past the gateway."
+	}
+	return f
+}
+
+// filteringFindings reports anchors that disagree with each other from one
+// vantage point.
+//
+// This is the finding the reference design exists to make possible. One anchor
+// clean and another blocked, from the same place in the same minutes, is not a
+// statement about a link -- the link demonstrably carries traffic -- it is a
+// statement about the route to the second anchor, and on the path this project
+// was built for that is usually a filter rather than a fault. Reporting it as
+// loss would be the single most misleading thing this tool could do.
+func filteringFindings(e Evidence) []Finding {
+	var out []Finding
+	for _, v := range []struct {
+		vantage string
+		refs    []Reference
+	}{{"client", e.ClientReferences}, {"gateway", e.GatewayReferences}} {
+		best, ok := bestReference(v.refs)
+		if !ok || best.Value >= LossyLoss {
+			continue
+		}
+		var filtered, degraded []string
+		for _, r := range v.refs {
+			health, ok := r.Health()
+			if ok && health.Name == best.Leg.Name {
+				continue
+			}
+			switch {
+			case r.Filtered():
+				filtered = append(filtered, r.Target)
+			case !ok || read(health).Value >= LossyLoss:
+				degraded = append(degraded, fmt.Sprintf("%s (%s)", r.Target, describeReference(r)))
+			}
+		}
+		if len(filtered) > 0 {
+			out = append(out, Finding{
+				Segment:  SegmentDestination,
+				Severity: SeverityNote,
+				Summary: fmt.Sprintf("from the %s, %s answers echo but refuses a handshake",
+					v.vantage, strings.Join(filtered, ", ")),
+				Detail: "That pair of outcomes is filtering, not loss: the address is reachable at the " +
+					"packet level and the connection is prevented from completing. It is counted against " +
+					"no segment, and it is the condition a tunnel exists to route around rather than a " +
+					"fault a tunnel could repair.",
+			})
+		}
+		if len(degraded) > 0 {
+			out = append(out, Finding{
+				Segment:  SegmentDestination,
+				Severity: SeverityNote,
+				Summary: fmt.Sprintf("from the %s, %s is clean but %s is not",
+					v.vantage, best.Leg.To, strings.Join(degraded, ", ")),
+				Detail: "One anchor answering cleanly from this vantage point proves its link carries " +
+					"traffic, so the anchors that did not are evidence about the route to them -- " +
+					"filtering, or international transit -- and not about the link. This difference is " +
+					"not counted as loss on any segment above.",
+			})
+		}
+	}
+	return out
+}
+
+func describeReference(r Reference) string {
+	health, ok := r.Health()
+	switch {
+	case !ok && r.Error != "":
+		return r.Error
+	case !ok:
+		return "no reply"
+	default:
+		return percent(read(health).Value) + " loss"
+	}
+}
+
+// destinationFindings compare each destination reached directly against the
+// same destination reached through the tunnel.
+//
+// This is the only part of the report that answers "is the tunnel worth it for
+// this", and it is deliberately separate from the segment findings: a direct
+// arm that fails where the tunnelled arm succeeds is not a fault anywhere, it
+// is the tunnel doing the job it was deployed for.
+func destinationFindings(e Evidence) []Finding {
+	var out []Finding
+	for i, direct := range e.Direct {
+		if i >= len(e.Tunneled) {
+			break
+		}
+		tunneled := e.Tunneled[i]
+		f := Finding{Segment: SegmentTunnel}
+		switch {
+		case !direct.Usable() && tunneled.Usable():
+			f.Severity = SeverityOK
+			f.Summary = fmt.Sprintf("%s: unreachable directly, %s through the tunnel", direct.To, rtt(tunneled))
+			f.Detail = "The direct arm did not establish at all while the tunnelled arm did. That is the " +
+				"case this deployment exists for, and it is not loss on any segment."
+		case direct.Usable() && !tunneled.Usable():
+			f.Severity = SeverityFault
+			f.Summary = fmt.Sprintf("%s: reachable directly, not through the tunnel", direct.To)
+			f.Detail = "A destination the gateway cannot open is a gateway problem rather than a path one. " +
+				"Check the gateway's own resolver and egress policy for this name."
+		case !direct.Usable() && !tunneled.Usable():
+			f.Severity = SeverityWarn
+			f.Summary = fmt.Sprintf("%s: neither arm reached it", direct.To)
+			f.Detail = "Nothing here distinguishes a destination that is down from one both paths are " +
+				"blocked from."
+		case tunneled.P50MS > 2*direct.P50MS && tunneled.P50MS-direct.P50MS > 5:
+			f.Severity = SeverityWarn
+			f.Summary = fmt.Sprintf("%s: %s direct against %s tunnelled", direct.To, rtt(direct), rtt(tunneled))
+			f.Detail = "The tunnel costs more than twice the direct establishment for this destination, so " +
+				"it is served closer to this client than the gateway is. queqiaod doctor --destination " +
+				"examines that placement question properly, with the arms alternated."
+		default:
+			f.Severity = SeverityOK
+			f.Summary = fmt.Sprintf("%s: %s direct against %s tunnelled", direct.To, rtt(direct), rtt(tunneled))
+			f.Detail = "The tunnel is not costing this destination a detour."
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// patternNote says whether the loss clustered, which decides what to do about
+// it. Independent loss at a steady rate is an erasure channel and backing off
+// does not make it drop less; loss in runs is a queue or a policer, and backing
+// off is exactly the response.
+func patternNote(l Leg) string {
+	if l.Sent == 0 || l.Loss == 0 {
+		return ""
+	}
+	if l.BurstFactor >= 2 {
+		return fmt.Sprintf("The loss clustered (burst factor %.1f, longest run %d), which is the signature "+
+			"of a queue or a policer rather than an erasure channel.", l.BurstFactor, l.LongestBurst)
+	}
+	return fmt.Sprintf("The loss was near-independent (burst factor %.1f), which is an erasure channel "+
+		"rather than congestion: sending slower will not make it drop less.", l.BurstFactor)
+}
+
+func idleNote(v TunnelView) string {
+	if !v.Present {
+		return " (no metrics endpoint was read)"
+	}
+	return fmt.Sprintf(" (the session has carried %d coded symbols and %d packets, below the floor this "+
+		"report will quote a ratio from)", v.CodedSymbols, v.PacketsSent)
+}
+
+func blockedNote(l Leg) string {
+	if l.Blocked {
+		return " (every probe was unanswered, which is filtering as often as it is loss)"
+	}
+	if l.Error != "" {
+		return " (" + l.Error + ")"
+	}
+	return ""
+}
+
+// bestReference returns the healthiest anchor, which is how a vantage point's
+// own link is read: one clean anchor proves the link carries traffic, and the
+// others describe their own routes rather than that link. Taking the mean
+// instead would let one filtered anchor convict a healthy access network.
+func bestReference(refs []Reference) (reading, bool) {
+	var best reading
+	found := false
+	for _, r := range refs {
+		health, ok := r.Health()
+		if !ok {
+			continue
+		}
+		candidate := read(health)
+		if !found || candidate.Value < best.Value {
+			best, found = candidate, true
+		}
+	}
+	return best, found
+}
+
+func referenceNames(refs []Reference) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Target)
+	}
+	return out
+}
+
+func severityRank(s string) int {
+	switch s {
+	case SeverityFault:
+		return 3
+	case SeverityWarn:
+		return 2
+	case SeverityNote:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func percent(v float64) string { return fmt.Sprintf("%.1f%%", v*100) }
+
+func rtt(l Leg) string {
+	switch {
+	case l.Arrived == 0:
+		return "no samples"
+	case l.P50MS > 0:
+		return fmt.Sprintf("%.1fms", l.P50MS)
+	case l.MeanMS > 0:
+		return fmt.Sprintf("%.1fms mean", l.MeanMS)
+	default:
+		return "no timing"
+	}
+}
+
+func absDiff(a, b float64) float64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/pathseg/attribute_test.go
+++ b/internal/pathseg/attribute_test.go
@@ -1,0 +1,336 @@
+package pathseg
+
+import (
+	"strings"
+	"testing"
+)
+
+// reference builds an anchor that answered both instruments, with the loss and
+// round trip given.
+func reference(target string, loss, rttMS float64) Reference {
+	sent := 100
+	arrived := sent - int(loss*float64(sent)+0.5)
+	return Reference{
+		Target: target,
+		Echo: Leg{Name: "echo:" + target, To: target, Method: "icmp",
+			Sent: sent, Arrived: arrived, Loss: loss, BurstFactor: 1.0,
+			MinMS: rttMS, P50MS: rttMS, P99MS: rttMS * 2},
+		Establish: Leg{Name: "establish:" + target, To: target, Method: "tcp-connect",
+			Sent: 3, Arrived: 3, MinMS: rttMS, P50MS: rttMS, P99MS: rttMS},
+	}
+}
+
+// filtered is the signature this whole design exists to keep out of the loss
+// column: the address answers echo and a handshake to it never completes.
+func filtered(target string) Reference {
+	r := reference(target, 0, 40)
+	r.Establish = Leg{Name: "establish:" + target, To: target, Method: "tcp-connect",
+		Sent: 3, Arrived: 0, Loss: 1, Blocked: true}
+	return r
+}
+
+func findingFor(t *testing.T, a Attribution, segment string) Finding {
+	t.Helper()
+	for _, f := range a.Findings {
+		if f.Segment == segment {
+			return f
+		}
+	}
+	t.Fatalf("no finding for %q in %+v", segment, a.Findings)
+	return Finding{}
+}
+
+// The client's first mile is under every other leg measured from the client, so
+// when it is lossy the leg to the gateway inherits that loss and has not
+// separated anything. Reporting both as faults would send an operator to fix a
+// long haul that may be in perfect health.
+func TestLossOnTheClientAnchorIsChargedToItsAccessLink(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.09, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.08, 12)},
+	})
+	access := findingFor(t, a, SegmentClientAccess)
+	if access.Severity != SeverityFault {
+		t.Fatalf("a lossy local anchor reported %q: %s", access.Severity, access.Summary)
+	}
+	long := findingFor(t, a, SegmentLongHaul)
+	if long.Severity != SeverityWarn {
+		t.Fatalf("the long haul reported %q where the first mile was already lossy", long.Severity)
+	}
+	if !strings.Contains(long.Detail, "crosses it") {
+		t.Fatalf("the long haul finding does not say it inherits the access link: %s", long.Detail)
+	}
+}
+
+// The same loss on the gateway leg with a clean local anchor is the long haul,
+// which is the one segment this transport repairs.
+func TestLossToTheGatewayWithACleanAnchorIsTheLongHaul(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.09, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+	})
+	if got := findingFor(t, a, SegmentLongHaul); got.Severity != SeverityFault {
+		t.Fatalf("the long haul reported %q: %s", got.Severity, got.Summary)
+	}
+	if got := findingFor(t, a, SegmentClientAccess); got.Severity != SeverityOK {
+		t.Fatalf("a clean anchor reported %q", got.Severity)
+	}
+	if !strings.Contains(a.Headline, SegmentLongHaul) {
+		t.Fatalf("the headline does not name the segment: %s", a.Headline)
+	}
+}
+
+// Loss past the gateway is not this transport's to repair, and saying so is the
+// point: coding, pacing and lane recovery all stop at the gateway.
+func TestLossPastTheGatewayIsNamedAsBeyondRepair(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:           reference("gw:12443", 0.0, 200),
+		ClientReferences:  []Reference{reference("baidu.com:443", 0.0, 12)},
+		GatewayReferences: []Reference{reference("www.google.com:443", 0.07, 8)},
+		GatewayVantage:    true,
+	})
+	egress := findingFor(t, a, SegmentGatewayEgress)
+	if egress.Severity != SeverityFault {
+		t.Fatalf("a lossy gateway transit reported %q: %s", egress.Severity, egress.Summary)
+	}
+	if !strings.Contains(egress.Detail, "stop at the gateway") {
+		t.Fatalf("the finding does not say the transport cannot repair it: %s", egress.Detail)
+	}
+	if got := findingFor(t, a, SegmentLongHaul); got.Severity != SeverityOK {
+		t.Fatalf("the long haul was implicated by the gateway's own transit: %q", got.Severity)
+	}
+}
+
+// The case this tool would be worst at if it were naive. A client behind a
+// filter probing a blocked anchor sees a dead destination; charged as loss it
+// would convict an access link that is carrying traffic perfectly well, which
+// is both wrong and the most expensive kind of wrong -- it sends the operator
+// to their ISP.
+func TestAFilteredAnchorIsNotChargedToTheAccessLink(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway: reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{
+			reference("baidu.com:443", 0.0, 12),
+			filtered("www.google.com:443"),
+		},
+	})
+	if got := findingFor(t, a, SegmentClientAccess); got.Severity != SeverityOK {
+		t.Fatalf("a filtered second anchor moved the access link to %q: %s", got.Severity, got.Summary)
+	}
+	note := findingFor(t, a, SegmentDestination)
+	if note.Severity != SeverityNote {
+		t.Fatalf("filtering reported as %q rather than a note", note.Severity)
+	}
+	if !strings.Contains(note.Summary, "refuses a handshake") {
+		t.Fatalf("the filtering finding does not describe the signature: %s", note.Summary)
+	}
+	if !strings.Contains(a.Headline, "clean") {
+		t.Fatalf("a filtered anchor produced a fault headline: %s", a.Headline)
+	}
+}
+
+// An anchor that answers nothing at all has measured nothing at all. It is
+// indistinguishable from here from a firewall that drops echo, so it must not
+// become the strongest possible finding.
+func TestAnUnansweredAnchorDoesNotConvictAnything(t *testing.T) {
+	dead := Reference{Target: "unreachable:443",
+		Echo:      Leg{Name: "echo:unreachable", To: "unreachable:443", Method: "icmp", Sent: 100, Loss: 1, Blocked: true},
+		Establish: Leg{Name: "establish:unreachable", To: "unreachable:443", Method: "tcp-connect", Sent: 3, Loss: 1, Blocked: true}}
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{dead},
+	})
+	access := findingFor(t, a, SegmentClientAccess)
+	if access.Severity != SeverityNote {
+		t.Fatalf("an unanswered anchor reported %q rather than declining to conclude", access.Severity)
+	}
+	if !strings.Contains(access.Summary, "not measured") {
+		t.Fatalf("the finding claims a measurement it did not take: %s", access.Summary)
+	}
+}
+
+// Silence about the far side must not read as health. Without a vantage point
+// on the gateway, a clean report has not examined its transit at all.
+func TestNoGatewayVantageIsReportedRatherThanAssumedClean(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+	})
+	egress := findingFor(t, a, SegmentGatewayEgress)
+	if egress.Severity != SeverityNote {
+		t.Fatalf("an unmeasured gateway transit reported %q", egress.Severity)
+	}
+	for _, want := range []string{"--ssh", "does not rule this segment out"} {
+		if !strings.Contains(egress.Detail, want) {
+			t.Fatalf("the finding omits %q: %s", want, egress.Detail)
+		}
+	}
+}
+
+// The transport's own figures beat any probe this command can send, and the
+// reason is the direction: an echo probe averages the two halves of a path that
+// this project has measured differing by fourteen points.
+func TestTheTunnelsOwnErasureIsPreferredAndNamesTheDirection(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+		Tunnel: TunnelView{Present: true, ReceiveErasure: 0.142, SendErasure: 0.003,
+			ReceiveResidual: 0.011, MinRTTMS: 197, CodedSymbols: 100000, PacketsSent: 100000},
+	})
+	long := findingFor(t, a, SegmentLongHaul)
+	if long.Severity != SeverityFault {
+		t.Fatalf("14%% erasure reported as %q", long.Severity)
+	}
+	for _, want := range []string{"14.2%", "0.3%", "downstream (gateway to client)", "197ms"} {
+		if !strings.Contains(long.Summary+long.Detail, want) {
+			t.Fatalf("the finding omits %q: %s / %s", want, long.Summary, long.Detail)
+		}
+	}
+}
+
+// An idle session's ratios are not evidence, so the probe has to take over
+// rather than the report quoting a figure drawn from nothing.
+func TestAnIdleTunnelFallsBackToTheProbe(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.06, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+		Tunnel:           TunnelView{Present: true, ReceiveErasure: 0.5, CodedSymbols: 4, PacketsSent: 4},
+	})
+	long := findingFor(t, a, SegmentLongHaul)
+	if !strings.Contains(long.Summary, "6.0%") {
+		t.Fatalf("the probe's figure was not used: %s", long.Summary)
+	}
+	if strings.Contains(long.Summary, "50.0%") {
+		t.Fatal("a ratio from four symbols was quoted as a measurement")
+	}
+}
+
+// A destination the direct arm cannot reach and the tunnel can is not a fault
+// anywhere; it is the deployment working.
+func TestADestinationOnlyTheTunnelReachesIsNotAFault(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+		Direct:           []Leg{{To: "www.google.com:443", Method: "tcp-connect", Sent: 4, Blocked: true, Loss: 1}},
+		Tunneled:         []Leg{{To: "www.google.com:443", Method: "tcp-connect", Sent: 4, Arrived: 4, P50MS: 210}},
+	})
+	got := findingFor(t, a, SegmentTunnel)
+	if got.Severity != SeverityOK {
+		t.Fatalf("the tunnel doing its job reported %q: %s", got.Severity, got.Summary)
+	}
+}
+
+// A destination the gateway cannot open, that the client can, is the gateway's
+// problem rather than the path's.
+func TestADestinationOnlyTheDirectArmReachesIsAGatewayFault(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)},
+		Direct:           []Leg{{To: "internal:443", Method: "tcp-connect", Sent: 4, Arrived: 4, P50MS: 5}},
+		Tunneled:         []Leg{{To: "internal:443", Method: "tcp-connect", Sent: 4, Blocked: true, Loss: 1}},
+	})
+	if got := findingFor(t, a, SegmentTunnel); got.Severity != SeverityFault {
+		t.Fatalf("a destination the gateway cannot open reported %q", got.Severity)
+	}
+}
+
+// Independent loss and clustered loss need opposite responses, so the report
+// has to say which it saw rather than only how much.
+func TestThePatternDistinguishesErasureFromCongestion(t *testing.T) {
+	independent := reference("gw:12443", 0.09, 200)
+	independent.Echo.BurstFactor = 1.02
+	a := Attribute(Evidence{Gateway: independent,
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)}})
+	if got := findingFor(t, a, SegmentLongHaul); !strings.Contains(got.Detail, "sending slower will not") {
+		t.Fatalf("independent loss was not named as an erasure channel: %s", got.Detail)
+	}
+
+	clustered := reference("gw:12443", 0.09, 200)
+	clustered.Echo.BurstFactor, clustered.Echo.LongestBurst = 6.2, 14
+	b := Attribute(Evidence{Gateway: clustered,
+		ClientReferences: []Reference{reference("baidu.com:443", 0.0, 12)}})
+	if got := findingFor(t, b, SegmentLongHaul); !strings.Contains(got.Detail, "queue or a policer") {
+		t.Fatalf("clustered loss was not named as congestion: %s", got.Detail)
+	}
+}
+
+func TestFilteredIsNotClaimedWhenEchoIsAlsoDown(t *testing.T) {
+	r := filtered("x:443")
+	if !r.Filtered() {
+		t.Fatal("the filtering signature was not recognised")
+	}
+	r.Echo.Blocked = true
+	r.Echo.Arrived = 0
+	if r.Filtered() {
+		t.Fatal("a destination nothing reached was called filtered")
+	}
+}
+
+// Where no echo socket exists at all -- an ordinary unprivileged Linux host --
+// the anchor still has to yield a verdict from the instrument that did work.
+func TestHealthFallsBackToEstablishmentWhenEchoIsUnavailable(t *testing.T) {
+	r := reference("baidu.com:443", 0, 12)
+	r.Echo = Leg{Name: "echo:x", Error: ErrICMPUnavailable.Error()}
+	leg, ok := r.Health()
+	if !ok || leg.Method != "tcp-connect" {
+		t.Fatalf("no fallback to establishment: %+v ok=%v", leg, ok)
+	}
+}
+
+// Where no echo socket exists -- an ordinary unprivileged Linux host -- the
+// verdict falls back to the establishment leg, and reading that leg's
+// connection failure rate as loss would be a false negative on exactly the
+// paths this tool exists for: TCP retransmits, so almost every connection
+// still completes on a path erasing a fifth of everything, and the failure
+// rate stays at zero while the path is in ruins. The cost of those
+// retransmissions is what the fallback has to read instead.
+func TestWithoutAnEchoSocketTheHandshakeTailStandsInForLoss(t *testing.T) {
+	ruined := Reference{Target: "baidu.com:443",
+		Echo: Leg{Name: "echo:baidu", Error: ErrICMPUnavailable.Error()},
+		Establish: Leg{Name: "establish:baidu", To: "baidu.com:443", Method: "tcp-connect",
+			// Every connection completed, and a third of them paid a
+			// retransmission timeout to do it.
+			Sent: 30, Arrived: 30, Loss: 0, TailRate: 0.33,
+			MinMS: 30, P50MS: 40, P99MS: 1300}}
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{ruined},
+	})
+	access := findingFor(t, a, SegmentClientAccess)
+	if access.Severity != SeverityFault {
+		t.Fatalf("a link where a third of handshakes retransmitted reported %q: %s",
+			access.Severity, access.Summary)
+	}
+	// The figure is a stand-in and the report has to say so, because a reader
+	// acting on it should know it is not a counted loss rate.
+	if !strings.Contains(access.Detail, "retransmission timeout") {
+		t.Fatalf("the finding does not say the figure is a proxy: %s", access.Detail)
+	}
+}
+
+// The same fallback must not invent a fault where the tail is clean.
+func TestACleanHandshakeTailIsStillClean(t *testing.T) {
+	fine := Reference{Target: "baidu.com:443",
+		Echo: Leg{Name: "echo:baidu", Error: ErrICMPUnavailable.Error()},
+		Establish: Leg{Name: "establish:baidu", To: "baidu.com:443", Method: "tcp-connect",
+			Sent: 30, Arrived: 30, TailRate: 0, MinMS: 30, P50MS: 32, P99MS: 40}}
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{fine},
+	})
+	if got := findingFor(t, a, SegmentClientAccess); got.Severity != SeverityOK {
+		t.Fatalf("a clean establishment leg reported %q: %s", got.Severity, got.Summary)
+	}
+}
+
+// An echo leg's loss rate is a counted loss rate and must not be relabelled a
+// proxy, or every finding would carry a caveat that does not apply to it.
+func TestAnEchoLegIsNotReportedAsAProxy(t *testing.T) {
+	a := Attribute(Evidence{
+		Gateway:          reference("gw:12443", 0.0, 200),
+		ClientReferences: []Reference{reference("baidu.com:443", 0.09, 12)},
+	})
+	if got := findingFor(t, a, SegmentClientAccess); strings.Contains(got.Detail, "retransmission timeout") {
+		t.Fatalf("a counted loss rate was labelled a proxy: %s", got.Detail)
+	}
+}

--- a/internal/pathseg/dial.go
+++ b/internal/pathseg/dial.go
@@ -1,0 +1,37 @@
+package pathseg
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"golang.org/x/net/proxy"
+)
+
+// dialThrough opens one connection, optionally through a local SOCKS5 listener.
+//
+// The tunnelled arm and the direct arm go through this one function so that
+// the only difference between them is the proxy, and not two dialers that
+// happen to time slightly different things.
+//
+// A name is resolved by whoever dials it: locally on the direct arm, at the
+// gateway on the tunnelled one. That asymmetry is deliberate and is the same
+// one queqiaod doctor relies on -- an anycast name resolves to whatever is near
+// whoever asked, so resolving once here and handing both arms the same address
+// would hide the case where the gateway reaches a different machine entirely.
+// Callers that want the arms pinned to one machine resolve first and pass
+// EstablishOptions.Address.
+func dialThrough(ctx context.Context, target, socksAddr string, dialer *net.Dialer) (net.Conn, error) {
+	if socksAddr == "" {
+		return dialer.DialContext(ctx, "tcp", target)
+	}
+	d, err := proxy.SOCKS5("tcp", socksAddr, nil, dialer)
+	if err != nil {
+		return nil, err
+	}
+	cd, ok := d.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("socks5 dialer for %s does not honour a context", socksAddr)
+	}
+	return cd.DialContext(ctx, "tcp", target)
+}

--- a/internal/pathseg/metrics.go
+++ b/internal/pathseg/metrics.go
@@ -1,0 +1,185 @@
+package pathseg
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TunnelView is what the running transport already knows about the one segment
+// it sits on, read from the endpoint queqiaod publishes with --metrics-listen.
+//
+// This is the best measurement of the client-to-gateway segment that exists,
+// and no external probe can match it. It was taken on the real four-tuple, at
+// the real rate, in the direction it names, by the code that had to decide what
+// to do about it -- where an echo probe offers a few packets a second on a
+// path whose loss behaviour changes with load, and cannot tell the two
+// directions apart at all. On the path this project was built for, that last
+// point is the whole story: upstream and downstream differed by fourteen
+// percentage points minutes apart, and a round-trip figure would have averaged
+// that into nothing.
+//
+// It measures only that segment, which is why the rest of this package exists.
+type TunnelView struct {
+	Present bool `json:"present"`
+
+	// SendErasure is the share of what this endpoint sent that the path did
+	// not deliver -- upstream, from a client's point of view. ReceiveErasure
+	// is the opposite direction, measured by this endpoint's own decoders
+	// rather than inferred from acknowledgements.
+	SendErasure     float64 `json:"send_erasure"`
+	ReceiveErasure  float64 `json:"receive_erasure"`
+	ReceiveResidual float64 `json:"receive_residual"`
+
+	MinRTTMS      float64 `json:"min_rtt_ms"`
+	SmoothedRTTMS float64 `json:"smoothed_rtt_ms"`
+	LatestRTTMS   float64 `json:"latest_rtt_ms"`
+
+	Lanes       int     `json:"lanes"`
+	ActiveFlows int     `json:"active_flows"`
+	DelayBrake  float64 `json:"delay_brake_ratio"`
+
+	// CodedSymbols is the denominator the receive-direction ratios were
+	// computed over. It is reported because a ratio without one is not a
+	// measurement: an erasure figure drawn from a handful of symbols says
+	// nothing, and a report that quoted it anyway would manufacture a finding
+	// out of an idle tunnel.
+	CodedSymbols   uint64 `json:"coded_symbols"`
+	PacketsSent    uint64 `json:"packets_sent"`
+	LossObserved   uint64 `json:"loss_observed_packets"`
+	Fallbacks      uint64 `json:"fallbacks"`
+	LaneFailures   uint64 `json:"lane_failures"`
+	FlowStalls     uint64 `json:"flow_stalls_detected"`
+	PortHops       uint64 `json:"port_hops"`
+	BytesUp        uint64 `json:"bytes_up"`
+	BytesDown      uint64 `json:"bytes_down"`
+	FlowsFailed    uint64 `json:"flows_failed"`
+	FlowsCompleted uint64 `json:"flows_completed"`
+}
+
+// significanceFloor is how many coded symbols the receive-direction erasure has
+// to be drawn from before it is quoted as a measurement. It is a few seconds of
+// an ordinary flow and far below anything a busy tunnel produces, so it
+// excludes only the case it is meant to exclude: a tunnel that has been idle.
+const significanceFloor = 500
+
+// ReceiveSignificant reports whether the receive-direction erasure was measured
+// over enough traffic to be worth attributing to anything.
+func (v TunnelView) ReceiveSignificant() bool {
+	return v.Present && v.CodedSymbols >= significanceFloor
+}
+
+// SendSignificant reports the same for the send direction, whose denominator is
+// the packets this endpoint put on the wire.
+func (v TunnelView) SendSignificant() bool {
+	return v.Present && v.PacketsSent >= significanceFloor
+}
+
+// FetchMetrics reads one metrics endpoint.
+func FetchMetrics(ctx context.Context, url string) (TunnelView, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return TunnelView{}, err
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return TunnelView{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return TunnelView{}, fmt.Errorf("%s returned %s", url, resp.Status)
+	}
+	// A metrics page is a few kilobytes. The cap is there so that a wrong URL
+	// pointed at something that streams cannot be read until this process runs
+	// out of memory.
+	return ParseMetrics(io.LimitReader(resp.Body, 1<<20))
+}
+
+// ParseMetrics reads the subset of the exposition format queqiaod emits, which
+// is one sample per line with at most one label.
+//
+// It deliberately does not pull in a Prometheus parser. The producer is in this
+// repository, the format it writes is fixed by metrics.Registry.ServeHTTP, and
+// a dependency whose job is to tolerate input this endpoint never emits would
+// be larger than the code it replaced.
+func ParseMetrics(r io.Reader) (TunnelView, error) {
+	v := TunnelView{}
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		f, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		// ParseFloat accepts "NaN" and "+Inf", and a ratio whose denominator
+		// was zero upstream would arrive as one of them. Carrying it forward
+		// would put a value into the report that JSON cannot encode, so a
+		// sample that is not a number is treated as a sample that is not there.
+		if err != nil || !finite(f) {
+			continue
+		}
+		v.Present = true
+		switch name {
+		case `queqiao_erasure_ratio{direction="send"}`:
+			v.SendErasure = f
+		case `queqiao_erasure_ratio{direction="receive"}`:
+			v.ReceiveErasure = f
+		case `queqiao_erasure_residual_ratio{direction="receive"}`:
+			v.ReceiveResidual = f
+		case "queqiao_quic_controller_min_rtt_seconds":
+			v.MinRTTMS = round3(f * 1000)
+		case "queqiao_quic_smoothed_rtt_seconds":
+			v.SmoothedRTTMS = round3(f * 1000)
+		case "queqiao_quic_latest_rtt_seconds":
+			v.LatestRTTMS = round3(f * 1000)
+		case "queqiao_quic_lanes":
+			v.Lanes = int(f)
+		case "queqiao_active_flows":
+			v.ActiveFlows = int(f)
+		case "queqiao_delay_brake_ratio":
+			v.DelayBrake = f
+		case `queqiao_coded_symbols_total{outcome="arrived"}`,
+			`queqiao_coded_symbols_total{outcome="recovered"}`,
+			`queqiao_coded_symbols_total{outcome="lost"}`:
+			v.CodedSymbols += uint64(f)
+		case "queqiao_quic_packets_sent":
+			v.PacketsSent = uint64(f)
+		case "queqiao_quic_loss_observed_packets_total":
+			v.LossObserved = uint64(f)
+		case "queqiao_fallbacks_total":
+			v.Fallbacks = uint64(f)
+		case "queqiao_lane_failures_total":
+			v.LaneFailures = uint64(f)
+		case "queqiao_flow_stalls_detected_total":
+			v.FlowStalls = uint64(f)
+		case "queqiao_port_hops_total":
+			v.PortHops = uint64(f)
+		case "queqiao_bytes_up_total":
+			v.BytesUp = uint64(f)
+		case "queqiao_bytes_down_total":
+			v.BytesDown = uint64(f)
+		case "queqiao_flows_failed_total":
+			v.FlowsFailed = uint64(f)
+		case "queqiao_flows_completed_total":
+			v.FlowsCompleted = uint64(f)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return TunnelView{}, err
+	}
+	if !v.Present {
+		return TunnelView{}, fmt.Errorf("no metrics samples found")
+	}
+	return v, nil
+}

--- a/internal/pathseg/metrics_test.go
+++ b/internal/pathseg/metrics_test.go
@@ -1,0 +1,113 @@
+package pathseg
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bojieli/queqiao/internal/metrics"
+)
+
+// The parser is checked against the registry that writes the page rather than
+// against a string copied out of it once. A hand-written fixture keeps passing
+// after a metric is renamed, and the failure it would then hide is silent: this
+// command would report a clean client-to-gateway segment on a path that was
+// erasing half of everything, because the field it reads no longer exists and
+// zero is what a missing sample parses to.
+func TestParseMetricsReadsWhatTheRegistryWrites(t *testing.T) {
+	r := metrics.New()
+	r.ObserveQUIC(1, metrics.QUICObservation{
+		Lanes:       2,
+		SmoothedRTT: 214 * time.Millisecond,
+		LatestRTT:   230 * time.Millisecond,
+		// The registry aggregates every controller-derived field only for an
+		// observation that names its controller, erasure and minimum round
+		// trip included. A fixture that leaves this empty parses to zero
+		// everywhere and proves nothing.
+		ControllerKind:       "queqiao",
+		ControllerMinRTT:     197 * time.Millisecond,
+		ControllerErasure:    0.031,
+		ControllerDelayBrake: 0.25,
+	})
+	r.AddQUICConnectionCounters(metrics.QUICConnectionCounters{
+		PacketsSent:         120_000,
+		LossObservedPackets: 3_700,
+		CodedSources:        85_800,
+		CodedRecovered:      13_100,
+		CodedLost:           1_100,
+	})
+	r.FlowStarted()
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	view, err := FetchMetrics(t.Context(), srv.URL+"/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !view.Present {
+		t.Fatal("the parser read no samples from a live registry")
+	}
+	if view.SendErasure != 0.031 {
+		t.Fatalf("send erasure %v, want 0.031", view.SendErasure)
+	}
+	// The receive direction is derived by the registry from the three coded
+	// outcomes, and the two ratios are different questions: what the path
+	// erased, and what the code could not put back.
+	if got, want := view.ReceiveErasure, 14200.0/100000.0; !closeTo(got, want, 1e-6) {
+		t.Fatalf("receive erasure %v, want %v", got, want)
+	}
+	if got, want := view.ReceiveResidual, 1100.0/100000.0; !closeTo(got, want, 1e-6) {
+		t.Fatalf("receive residual %v, want %v", got, want)
+	}
+	if view.MinRTTMS != 197 {
+		t.Fatalf("min rtt %v, want 197", view.MinRTTMS)
+	}
+	if view.SmoothedRTTMS != 214 {
+		t.Fatalf("smoothed rtt %v, want 214", view.SmoothedRTTMS)
+	}
+	if view.Lanes != 2 || view.ActiveFlows != 1 {
+		t.Fatalf("lanes %d flows %d, want 2 and 1", view.Lanes, view.ActiveFlows)
+	}
+	if view.CodedSymbols != 100_000 {
+		t.Fatalf("coded symbols %d, want 100000", view.CodedSymbols)
+	}
+	if view.PacketsSent != 120_000 || view.LossObserved != 3_700 {
+		t.Fatalf("packet counters %d/%d", view.PacketsSent, view.LossObserved)
+	}
+	if !view.ReceiveSignificant() || !view.SendSignificant() {
+		t.Fatal("a session with a hundred thousand symbols was called insignificant")
+	}
+}
+
+// An idle tunnel publishes ratios drawn from almost nothing. Quoting those as
+// a measurement would manufacture a finding out of a session that has not
+// carried enough traffic to have an opinion.
+func TestAnIdleSessionIsNotQuotedAsAMeasurement(t *testing.T) {
+	r := metrics.New()
+	r.AddQUICConnectionCounters(metrics.QUICConnectionCounters{
+		PacketsSent: 10, CodedSources: 8, CodedLost: 2,
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	view, err := FetchMetrics(t.Context(), srv.URL+"/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.ReceiveErasure != 0.2 {
+		t.Fatalf("receive erasure %v, want the raw 0.2", view.ReceiveErasure)
+	}
+	if view.ReceiveSignificant() || view.SendSignificant() {
+		t.Fatal("a ten-packet session was treated as evidence")
+	}
+}
+
+func TestParseMetricsRejectsAPageWithNoSamples(t *testing.T) {
+	if _, err := ParseMetrics(strings.NewReader("# just a comment\n\n")); err == nil {
+		t.Fatal("a page with no samples parsed successfully")
+	}
+}
+
+func closeTo(a, b, tol float64) bool { return a-b < tol && b-a < tol }

--- a/internal/pathseg/probe.go
+++ b/internal/pathseg/probe.go
@@ -1,0 +1,599 @@
+// Package pathseg measures a path one segment at a time, so that a loss or
+// latency figure can be attributed to the part of the world that produced it.
+//
+// The instruments this project already has describe a path end to end.
+// cmd/pathprobe says what fraction of an offered rate survives, cmd/pathmeasure
+// says what a stack achieves on it, and queqiaod doctor says whether the
+// gateway is on the useful side of a destination. None of them answers the
+// question an operator actually asks when a deployment is slow, which is not
+// "how bad is it" but "whose fault is it": the client's own access link, the
+// long haul this transport carries, or the gateway's transit onward.
+//
+// That question is answerable because the three segments overlap. A client
+// reaching its gateway and the same client reaching a destination directly
+// share the client's first mile and nothing else. A client reaching its gateway
+// and the gateway reaching a destination share nothing at all. So three legs
+// measured in the same minutes have exactly one segment in common per pair, and
+// the pattern of which legs are lossy names the segment they share. attribute.go
+// does that reasoning; this file takes the measurements it reasons over.
+//
+// Two probes are provided because neither alone is enough. ICMP echo counts
+// individual packets, which is the only way to see a loss rate at all, and it
+// is also the thing a network is most willing to rate-limit or drop outright --
+// so a leg with no replies is reported as blocked rather than as total loss,
+// because the two are indistinguishable from here and only one of them is a
+// finding. TCP establishment cannot count packets, but it travels as ordinary
+// traffic that nobody deprioritises, so it is the honest fallback and the
+// cross-check.
+package pathseg
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
+
+	"github.com/bojieli/queqiao/internal/lossmodel"
+)
+
+// ErrICMPUnavailable reports that no echo socket could be opened at all, which
+// is a property of this host rather than of the path. Linux hands out datagram
+// ICMP only to groups named in net.ipv4.ping_group_range, and the common
+// default names none, so an unprivileged run on an ordinary Linux box lands
+// here and has to fall back to establishment timing.
+var ErrICMPUnavailable = errors.New("ICMP echo is not usable from this host")
+
+// Sequence is one probe run in send order: whether each probe came back, and
+// how long the ones that did took.
+//
+// The order matters and is why this is not just a pair of counts. Loss that
+// arrives in runs and loss that arrives independently need different responses
+// -- backing off does not make an erasure channel drop less -- and the
+// difference is only visible in the order the outcomes occurred.
+type Sequence struct {
+	Arrived []bool
+	// RTTs holds one millisecond figure per arrived probe, in send order.
+	RTTs []float64
+}
+
+// Leg is one measured segment, reduced to the figures a verdict is read from.
+type Leg struct {
+	Name   string `json:"name"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Method string `json:"method"`
+	// Address is what the vantage point resolved the target to. Two vantage
+	// points resolving one name to two addresses are not measuring the same
+	// machine, which is a finding in itself rather than a detail.
+	Address string `json:"address,omitempty"`
+
+	Sent    int     `json:"sent"`
+	Arrived int     `json:"arrived"`
+	Loss    float64 `json:"loss"`
+
+	// BurstFactor separates an erasure channel from a congested one. It is 1
+	// for memoryless loss and rises as loss clusters, which is the reading
+	// cmd/pathprobe's -pattern produces and the same statistic the transport's
+	// own estimator publishes.
+	BurstFactor  float64 `json:"burst_factor,omitempty"`
+	LongestBurst int     `json:"longest_burst,omitempty"`
+
+	MinMS float64 `json:"min_ms,omitempty"`
+	P50MS float64 `json:"p50_ms,omitempty"`
+	P99MS float64 `json:"p99_ms,omitempty"`
+	// MeanMS is set only where the samples themselves were never available and
+	// a mean is all the instrument reported -- ping(8)'s summary line. It is
+	// kept apart from P50MS rather than folded into it because a mean and a
+	// median differ most on exactly the tailed distributions this tool is
+	// pointed at, and labelling one as the other would misreport the case that
+	// matters.
+	MeanMS float64 `json:"mean_ms,omitempty"`
+
+	// TailRate is the share of successful establishments that took materially
+	// longer than the fastest one. On a TCP leg it is the only loss signal
+	// available, because a retransmitted handshake packet shows up as a whole
+	// retransmission timeout rather than as a missing sample. It is a proxy
+	// and is named one; a verdict leans on it only when ICMP was unavailable.
+	TailRate float64 `json:"tail_rate,omitempty"`
+
+	// Blocked distinguishes a filtered probe from a destroyed one. A leg that
+	// got nothing back has not measured 100% loss, it has measured nothing,
+	// and attributing on it would invent the strongest possible finding out of
+	// a firewall rule.
+	Blocked bool   `json:"blocked,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// Usable reports whether this leg carries evidence a verdict may rest on.
+func (l Leg) Usable() bool { return l.Sent > 0 && !l.Blocked && l.Error == "" }
+
+// PingOptions configures one ICMP echo run.
+type PingOptions struct {
+	// Target is an address, already resolved. Resolution is the caller's job
+	// so that the echo leg and the establishment leg to one destination are
+	// aimed at the same machine; a name that resolves differently per probe
+	// would silently compare two paths.
+	Target net.IP
+	// LocalAddress binds the socket to one source address. On a host with a
+	// TUN route this is what keeps a "direct" measurement direct rather than
+	// carrying it through the very tunnel being measured -- the same reason
+	// cmd/pathprobe and cmd/pathmeasure grew the flag.
+	LocalAddress string
+	Count        int
+	Interval     time.Duration
+	// Timeout is how long to keep listening after the last probe was sent.
+	Timeout time.Duration
+	Payload int
+}
+
+const (
+	tokenSize      = 8
+	minPayload     = tokenSize
+	defaultPayload = 56
+	// maxSequence is what the echo header's 16-bit sequence field can carry.
+	// A run longer than this would reuse a number and attribute one probe's
+	// reply to another.
+	maxSequence = 1<<16 - 1
+)
+
+// Ping sends echo requests at a fixed cadence and reports which came back.
+//
+// The cadence is fixed and the probes are not adaptive, because the question is
+// what the path does to traffic offered at a rate nobody is adjusting. That is
+// the same discipline cmd/pathprobe applies at a much higher rate; here the
+// rate is negligible and the run is safe to point at a third party, which the
+// open-loop blast never is.
+func Ping(ctx context.Context, opts PingOptions) (Sequence, error) {
+	if opts.Count <= 0 {
+		return Sequence{}, errors.New("count must be positive")
+	}
+	if opts.Count > maxSequence {
+		opts.Count = maxSequence
+	}
+	if opts.Interval <= 0 {
+		opts.Interval = 100 * time.Millisecond
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = 2 * time.Second
+	}
+	if opts.Payload < minPayload {
+		opts.Payload = defaultPayload
+	}
+	if opts.Target == nil {
+		return Sequence{}, errors.New("no target address")
+	}
+
+	conn, raw, err := listenICMP(opts.Target, opts.LocalAddress)
+	if err != nil {
+		return Sequence{}, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	token := make([]byte, tokenSize)
+	if _, err := rand.Read(token); err != nil {
+		return Sequence{}, fmt.Errorf("draw a run token: %w", err)
+	}
+
+	v6 := opts.Target.To4() == nil
+	echoType := icmp.Type(ipv4.ICMPTypeEcho)
+	replyType := icmp.Type(ipv4.ICMPTypeEchoReply)
+	proto := ipv4.ICMPTypeEchoReply.Protocol()
+	if v6 {
+		echoType, replyType = ipv6.ICMPTypeEchoRequest, ipv6.ICMPTypeEchoReply
+		proto = ipv6.ICMPTypeEchoReply.Protocol()
+	}
+	dest := icmpDestination(opts.Target, raw)
+
+	// The identifier is only meaningful on a raw socket. A datagram ICMP
+	// socket has its identifier rewritten by the kernel, which then demuxes
+	// replies to this socket by the value it chose, so matching on the one we
+	// wrote would discard every reply on exactly the platforms where the
+	// unprivileged path works.
+	id := int(binary.BigEndian.Uint16(token[:2]))
+
+	var (
+		mu     sync.Mutex
+		sentAt = make([]time.Time, opts.Count)
+		rtt    = make([]time.Duration, opts.Count)
+		got    = make([]bool, opts.Count)
+	)
+
+	// stop is what ends the reader. Closing the read deadline alone would not:
+	// a deadline in the past makes every read return a timeout immediately,
+	// and a reader that treats a timeout as "keep waiting" would spin on the
+	// CPU forever instead of returning.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 1500)
+		for {
+			// A short read deadline keeps this loop responsive to the outer
+			// deadline without blocking on a path that has gone silent.
+			_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+			n, _, err := conn.ReadFrom(buf)
+			if err != nil {
+				var ne net.Error
+				if errors.As(err, &ne) && ne.Timeout() {
+					select {
+					case <-ctx.Done():
+						return
+					case <-stop:
+						return
+					default:
+						continue
+					}
+				}
+				return
+			}
+			at := time.Now()
+			msg, err := icmp.ParseMessage(proto, buf[:n])
+			if err != nil || msg.Type != replyType {
+				continue
+			}
+			echo, ok := msg.Body.(*icmp.Echo)
+			if !ok || len(echo.Data) < minPayload {
+				continue
+			}
+			if raw && echo.ID != id {
+				continue
+			}
+			// The token is what makes a raw socket, which sees every ICMP
+			// message on the host, keep only this run's own replies.
+			if !bytes.Equal(echo.Data[:tokenSize], token) {
+				continue
+			}
+			// The sequence is read from the header rather than the payload.
+			// A datagram ICMP socket has its identifier rewritten by the
+			// kernel but not its sequence number, so this is the one field
+			// that survives both socket types unchanged -- and it is already
+			// an int, so nothing here converts a number a peer chose.
+			seq := echo.Seq
+			if seq < 0 || seq >= opts.Count {
+				continue
+			}
+			mu.Lock()
+			// A duplicated reply is not a second delivery of the same probe,
+			// and counting it would let a duplicating middlebox report more
+			// arrivals than there were probes.
+			if !got[seq] && !sentAt[seq].IsZero() {
+				got[seq] = true
+				rtt[seq] = at.Sub(sentAt[seq])
+			}
+			mu.Unlock()
+		}
+	}()
+
+	payload := make([]byte, opts.Payload)
+	copy(payload, token)
+	ticker := time.NewTicker(opts.Interval)
+	defer ticker.Stop()
+	var sendErr error
+send:
+	for i := 0; i < opts.Count; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				opts.Count = i
+				break send
+			case <-ticker.C:
+			}
+		}
+		wm := icmp.Message{Type: echoType, Code: 0,
+			Body: &icmp.Echo{ID: id, Seq: i, Data: payload}}
+		wb, err := wm.Marshal(nil)
+		if err != nil {
+			return Sequence{}, err
+		}
+		mu.Lock()
+		sentAt[i] = time.Now()
+		mu.Unlock()
+		if _, err := conn.WriteTo(wb, dest); err != nil {
+			// A send that fails locally never reached the path, so it is not
+			// evidence about the path and must not be counted as a loss.
+			mu.Lock()
+			sentAt[i] = time.Time{}
+			mu.Unlock()
+			sendErr = err
+		}
+	}
+
+	timer := time.NewTimer(opts.Timeout)
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
+	}
+	timer.Stop()
+	close(stop)
+	_ = conn.SetReadDeadline(time.Now())
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	var seq Sequence
+	for i := 0; i < opts.Count; i++ {
+		if sentAt[i].IsZero() {
+			continue
+		}
+		seq.Arrived = append(seq.Arrived, got[i])
+		if got[i] {
+			seq.RTTs = append(seq.RTTs, milliseconds(rtt[i]))
+		}
+	}
+	if len(seq.Arrived) == 0 && sendErr != nil {
+		// Every send failed locally, so nothing reached the path and there is
+		// no measurement to report. The caller falls back to establishment on
+		// this, which is the right response whether the socket was refused or
+		// the host has no route.
+		return Sequence{}, fmt.Errorf("%w: no probe left this host (%v)", ErrICMPUnavailable, sendErr)
+	}
+	return seq, nil
+}
+
+func listenICMP(target net.IP, localAddress string) (*icmp.PacketConn, bool, error) {
+	v6 := target.To4() == nil
+	local := localAddress
+	if local == "" {
+		if v6 {
+			local = "::"
+		} else {
+			local = "0.0.0.0"
+		}
+	}
+	datagram, raw := "udp4", "ip4:icmp"
+	if v6 {
+		datagram, raw = "udp6", "ip6:ipv6-icmp"
+	}
+	// Datagram ICMP first: it needs no privilege where the operating system
+	// allows it, and a profiling tool an operator has to run as root is a
+	// profiling tool they run once.
+	if c, err := icmp.ListenPacket(datagram, local); err == nil {
+		return c, false, nil
+	}
+	c, err := icmp.ListenPacket(raw, local)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: datagram and raw echo sockets were both refused (%v)", ErrICMPUnavailable, err)
+	}
+	return c, true, nil
+}
+
+func icmpDestination(ip net.IP, raw bool) net.Addr {
+	if raw {
+		return &net.IPAddr{IP: ip}
+	}
+	return &net.UDPAddr{IP: ip}
+}
+
+// Resolve turns a host into one address, preferring the family of the source
+// address the caller intends to bind.
+//
+// It returns a single address on purpose. Every leg aimed at a destination has
+// to be aimed at the same machine, or the comparison between legs is between
+// two different paths; where a name is anycast and each vantage point resolves
+// it differently, that difference belongs in the report as a finding rather
+// than inside a measurement as noise.
+func Resolve(ctx context.Context, host, localAddress string) (net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return ip, nil
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	wantV6 := false
+	if localAddress != "" {
+		if ip := net.ParseIP(localAddress); ip != nil && ip.To4() == nil {
+			wantV6 = true
+		}
+	}
+	var fallback net.IP
+	for _, a := range addrs {
+		isV6 := a.IP.To4() == nil
+		if isV6 == wantV6 {
+			return a.IP, nil
+		}
+		if fallback == nil {
+			fallback = a.IP
+		}
+	}
+	if fallback == nil {
+		return nil, fmt.Errorf("no address for %s", host)
+	}
+	return fallback, nil
+}
+
+// EstablishOptions configures a run of TCP establishments.
+type EstablishOptions struct {
+	// Target is host:port. When Address is set the host is replaced by it, so
+	// that this leg reaches the same machine the echo leg did.
+	Target       string
+	Address      string
+	LocalAddress string
+	// SOCKS routes the establishment through a local listener, which is how
+	// the tunnelled arm is measured with the same instrument as the direct one.
+	SOCKS    string
+	Count    int
+	Interval time.Duration
+	Timeout  time.Duration
+}
+
+// Establish opens and discards connections, reporting how long each took.
+//
+// It stops at establishment for the reason queqiaod doctor stops there: a
+// handshake is the part of a path a local instrument can hold still, and
+// anything past it is a question about a transport rather than about a segment.
+// What it adds over doctor is that it is pointed at one segment at a time.
+func Establish(ctx context.Context, opts EstablishOptions) Sequence {
+	if opts.Count <= 0 {
+		opts.Count = 1
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = 5 * time.Second
+	}
+	target := opts.Target
+	if opts.Address != "" {
+		if _, port, err := net.SplitHostPort(opts.Target); err == nil {
+			target = net.JoinHostPort(opts.Address, port)
+		}
+	}
+	dialer := &net.Dialer{}
+	if opts.LocalAddress != "" {
+		if ip := net.ParseIP(opts.LocalAddress); ip != nil {
+			dialer.LocalAddr = &net.TCPAddr{IP: ip}
+		}
+	}
+	var seq Sequence
+	for i := 0; i < opts.Count; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		if i > 0 && opts.Interval > 0 {
+			timer := time.NewTimer(opts.Interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return seq
+			case <-timer.C:
+			}
+		}
+		attempt, cancel := context.WithTimeout(ctx, opts.Timeout)
+		start := time.Now()
+		conn, err := dialThrough(attempt, target, opts.SOCKS, dialer)
+		elapsed := time.Since(start)
+		cancel()
+		if err != nil {
+			seq.Arrived = append(seq.Arrived, false)
+			continue
+		}
+		_ = conn.Close()
+		seq.Arrived = append(seq.Arrived, true)
+		seq.RTTs = append(seq.RTTs, milliseconds(elapsed))
+	}
+	return seq
+}
+
+// Summarize reduces a run to the figures a verdict is read from.
+//
+// The tail threshold is absolute rather than a multiple of the minimum because
+// what it is looking for is absolute: a lost handshake packet costs a
+// retransmission timeout, which is a second on the initial send and does not
+// scale with how far away the peer is.
+func Summarize(name, from, to, method string, seq Sequence) Leg {
+	leg := Leg{Name: name, From: from, To: to, Method: method, Sent: len(seq.Arrived)}
+	if leg.Sent == 0 {
+		return leg
+	}
+	pattern := lossmodel.Analyze(seq.Arrived)
+	leg.Arrived = leg.Sent - pattern.Lost
+	leg.Loss = pattern.Loss
+	leg.BurstFactor = round3(pattern.BurstFactor)
+	leg.LongestBurst = pattern.LongestBurst
+	// A run with no arrivals has no pattern to report. Its mean burst is one
+	// divided by an arrival rate of zero, and its burst factor is that infinity
+	// multiplied by a loss rate of one, which is NaN. Left in place that is not
+	// merely a meaningless figure: JSON has no NaN, so one blocked leg would
+	// make the entire report unserialisable, and the report is the form meant
+	// to be attached to a bug.
+	if !finite(leg.BurstFactor) {
+		leg.BurstFactor = 0
+	}
+	if leg.Arrived == 0 {
+		leg.Blocked = true
+		return leg
+	}
+	sorted := append([]float64(nil), seq.RTTs...)
+	sort.Float64s(sorted)
+	leg.MinMS = round3(sorted[0])
+	leg.P50MS = round3(quantile(sorted, 0.50))
+	leg.P99MS = round3(quantile(sorted, 0.99))
+	var slow int
+	for _, v := range sorted {
+		if v > sorted[0]+tailThresholdMS {
+			slow++
+		}
+	}
+	leg.TailRate = round3(float64(slow) / float64(len(sorted)))
+	return leg
+}
+
+// tailThresholdMS is one initial retransmission timeout, rounded down. A
+// handshake that took this much longer than the fastest one on the same leg
+// most likely retransmitted a packet.
+const tailThresholdMS = 900
+
+// quantile reads a percentile by nearest rank, which is the convention
+// cmd/pathmeasure and queqiaod doctor already report with. Interpolating would
+// invent a value between two measurements that were both real.
+func quantile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(p*float64(len(sorted))+0.5) - 1
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+func milliseconds(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }
+
+func round3(v float64) float64 { return math.Round(v*1000) / 1000 }
+
+// finite reports whether a figure can be both believed and serialised.
+func finite(v float64) bool { return !math.IsNaN(v) && !math.IsInf(v, 0) }
+
+// Reference is one anchor measured from one vantage point with both
+// instruments pointed at it.
+//
+// Both are needed because they fail differently, and the difference is the
+// finding. Echo counts packets and is the only loss instrument here; TCP
+// establishment counts nothing but travels as ordinary traffic. A network that
+// answers echo cleanly while refusing to complete a handshake to the same
+// address has not lost anything -- it has filtered something, which is a
+// different fact with a different remedy, and on the paths this project is
+// deployed across it is the ordinary case rather than the exotic one.
+type Reference struct {
+	Target  string `json:"target"`
+	Address string `json:"address,omitempty"`
+	// Echo is the packet-counting instrument, and Establish the traffic-shaped
+	// one. Either may be unusable on its own without the reference being
+	// worthless.
+	Echo      Leg    `json:"echo"`
+	Establish Leg    `json:"establish"`
+	Error     string `json:"error,omitempty"`
+}
+
+// Health returns the leg this reference's link should be judged on, preferring
+// the packet counter and falling back to establishment where no echo socket
+// was available -- which is the ordinary case on a Linux host whose
+// ping_group_range does not cover the caller.
+func (r Reference) Health() (Leg, bool) {
+	if r.Echo.Usable() {
+		return r.Echo, true
+	}
+	if r.Establish.Usable() {
+		return r.Establish, true
+	}
+	return Leg{}, false
+}
+
+// Filtered reports the signature of a blocked destination rather than a lossy
+// one: the address answers echo requests, and a handshake to it never
+// completes.
+func (r Reference) Filtered() bool {
+	return r.Echo.Usable() && r.Echo.Loss < LossyLoss && r.Establish.Sent > 0 && !r.Establish.Usable()
+}

--- a/internal/pathseg/probe_test.go
+++ b/internal/pathseg/probe_test.go
@@ -1,0 +1,248 @@
+package pathseg
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A leg that got nothing back has not measured total loss; it has measured
+// nothing. Reporting 100% would make the strongest claim this tool can make out
+// of the weakest evidence there is, and on a filtered path that is the ordinary
+// outcome rather than a rare one.
+func TestAnUnansweredRunIsBlockedRatherThanTotalLoss(t *testing.T) {
+	leg := Summarize("echo:x", "client", "x", "icmp", Sequence{Arrived: []bool{false, false, false}})
+	if !leg.Blocked {
+		t.Fatal("a run with no replies was not marked blocked")
+	}
+	if leg.Usable() {
+		t.Fatal("a blocked leg is being offered as evidence")
+	}
+	if leg.Loss != 1 {
+		t.Fatalf("loss %v, want the raw 1 to remain readable", leg.Loss)
+	}
+}
+
+func TestSummarizeReportsPercentilesAndPattern(t *testing.T) {
+	seq := Sequence{
+		Arrived: []bool{true, true, false, false, true, true, true, true, true, true},
+		RTTs:    []float64{10, 12, 11, 13, 90, 12, 11, 14},
+	}
+	leg := Summarize("echo:x", "client", "x", "icmp", seq)
+	if leg.Sent != 10 || leg.Arrived != 8 {
+		t.Fatalf("sent %d arrived %d", leg.Sent, leg.Arrived)
+	}
+	if leg.Loss != 0.2 {
+		t.Fatalf("loss %v, want 0.2", leg.Loss)
+	}
+	if leg.LongestBurst != 2 {
+		t.Fatalf("longest burst %d, want 2", leg.LongestBurst)
+	}
+	if leg.MinMS != 10 {
+		t.Fatalf("min %v", leg.MinMS)
+	}
+	// Nearest rank, the convention cmd/pathmeasure and doctor already report
+	// with: the p99 of eight samples is the largest one that was actually
+	// measured, not a number interpolated between two that were.
+	if leg.P99MS != 90 {
+		t.Fatalf("p99 %v, want the measured 90", leg.P99MS)
+	}
+	if leg.Blocked {
+		t.Fatal("a run with replies was marked blocked")
+	}
+}
+
+// The tail is the only loss signal an establishment leg has, because a lost
+// handshake packet costs a whole retransmission timeout rather than a missing
+// sample.
+func TestTheTailRateCountsRetransmissionSizedOutliers(t *testing.T) {
+	seq := Sequence{Arrived: []bool{true, true, true, true},
+		RTTs: []float64{200, 205, 210, 1250}}
+	leg := Summarize("establish:x", "client", "x", "tcp-connect", seq)
+	if leg.TailRate != 0.25 {
+		t.Fatalf("tail rate %v, want 0.25", leg.TailRate)
+	}
+}
+
+func TestEstablishTimesARealListener(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	seq := Establish(t.Context(), EstablishOptions{Target: ln.Addr().String(), Count: 3, Timeout: 2 * time.Second})
+	leg := Summarize("establish:local", "client", ln.Addr().String(), "tcp-connect", seq)
+	if leg.Sent != 3 || leg.Arrived != 3 {
+		t.Fatalf("sent %d arrived %d against a listener that accepted everything", leg.Sent, leg.Arrived)
+	}
+}
+
+func TestEstablishReportsARefusedPortAsFailureNotAsAHang(t *testing.T) {
+	// Port 1 on loopback, which nothing listens on and which refuses fast.
+	seq := Establish(t.Context(), EstablishOptions{Target: "127.0.0.1:1", Count: 2, Timeout: 2 * time.Second})
+	leg := Summarize("establish:refused", "client", "127.0.0.1:1", "tcp-connect", seq)
+	if leg.Sent != 2 {
+		t.Fatalf("sent %d, want both attempts recorded", leg.Sent)
+	}
+	if !leg.Blocked {
+		t.Fatal("a refused port was not reported as unreachable")
+	}
+}
+
+// Both instruments have to reach one machine or the comparison between them is
+// between two paths. Address overrides the host and keeps the port.
+func TestEstablishHonoursAPinnedAddress(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			_ = c.Close()
+		}
+	}()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := Establish(t.Context(), EstablishOptions{
+		Target: net.JoinHostPort("no-such-host.invalid", port), Address: "127.0.0.1",
+		Count: 1, Timeout: 2 * time.Second})
+	if len(seq.Arrived) != 1 || !seq.Arrived[0] {
+		t.Fatalf("the pinned address was not used: %+v", seq)
+	}
+}
+
+func TestSplitReferenceDefaultsToTheFilteredPort(t *testing.T) {
+	host, hostPort := splitReference("baidu.com")
+	if host != "baidu.com" || hostPort != "baidu.com:443" {
+		t.Fatalf("got %q and %q", host, hostPort)
+	}
+	host, hostPort = splitReference("baidu.com:80")
+	if host != "baidu.com" || hostPort != "baidu.com:80" {
+		t.Fatalf("got %q and %q", host, hostPort)
+	}
+}
+
+func TestResolveAcceptsAnAddressWithoutAskingTheResolver(t *testing.T) {
+	ip, err := Resolve(t.Context(), "203.0.113.7", "")
+	if err != nil || ip.String() != "203.0.113.7" {
+		t.Fatalf("got %v, %v", ip, err)
+	}
+}
+
+// The echo probe is exercised against loopback, which is the only target a test
+// may assume exists. Where the host will not hand out an echo socket at all --
+// an ordinary Linux default -- that is a fact about the host, and the caller's
+// contract is that it says so rather than reporting a dead path.
+func TestPingMeasuresLoopbackOrSaysItCannot(t *testing.T) {
+	seq, err := Ping(t.Context(), PingOptions{
+		Target: net.ParseIP("127.0.0.1"), Count: 3,
+		Interval: 20 * time.Millisecond, Timeout: time.Second,
+	})
+	if err != nil {
+		if errors.Is(err, ErrICMPUnavailable) {
+			t.Skip("this host does not hand out ICMP echo sockets: " + err.Error())
+		}
+		t.Fatal(err)
+	}
+	if len(seq.Arrived) != 3 {
+		t.Fatalf("sent 3, accounted for %d", len(seq.Arrived))
+	}
+	leg := Summarize("echo:loopback", "client", "127.0.0.1", "icmp", seq)
+	if leg.Blocked {
+		t.Skip("loopback echo is filtered on this host")
+	}
+	if leg.Loss > 0 {
+		t.Fatalf("loopback lost %v of three probes", leg.Loss)
+	}
+}
+
+func TestPingRefusesARunItCannotDescribe(t *testing.T) {
+	if _, err := Ping(t.Context(), PingOptions{Target: net.ParseIP("127.0.0.1"), Count: 0}); err == nil {
+		t.Fatal("a zero-length run was accepted")
+	}
+	if _, err := Ping(t.Context(), PingOptions{Count: 3}); err == nil {
+		t.Fatal("a run with no target was accepted")
+	}
+}
+
+func TestErrICMPUnavailableIsIdentifiable(t *testing.T) {
+	// The caller falls back to establishment on this error and only on this
+	// error, so it has to survive the wrapping listenICMP does to it.
+	wrapped := errors.Join(ErrICMPUnavailable, errors.New("operation not permitted"))
+	if !errors.Is(wrapped, ErrICMPUnavailable) {
+		t.Fatal("the sentinel does not survive wrapping")
+	}
+	if !strings.Contains(ErrICMPUnavailable.Error(), "ICMP") {
+		t.Fatal("the sentinel does not name what was unavailable")
+	}
+}
+
+// The whole report has to survive JSON encoding, because that is the form meant
+// to be attached to a bug. A leg with no arrivals used to produce a burst factor
+// of Inf times zero -- NaN -- which JSON cannot encode, so one filtered anchor
+// made the entire --json run fail with nothing on stdout.
+func TestABlockedLegLeavesTheReportSerialisable(t *testing.T) {
+	blocked := Summarize("echo:x", "client", "x:443", "icmp",
+		Sequence{Arrived: []bool{false, false, false, false}})
+	if !finite(blocked.BurstFactor) {
+		t.Fatalf("burst factor is not a number: %v", blocked.BurstFactor)
+	}
+	if blocked.BurstFactor != 0 {
+		t.Fatalf("a run with no arrivals reported a pattern: %v", blocked.BurstFactor)
+	}
+	if _, err := json.Marshal(blocked); err != nil {
+		t.Fatalf("a blocked leg cannot be serialised: %v", err)
+	}
+
+	// The same guard has to hold for a whole report, which is what actually
+	// broke: an Evidence containing one blocked anchor.
+	e := Evidence{
+		Gateway: Reference{Target: "gw:12443",
+			Echo: Summarize("echo:gw", "client", "gw:12443", "icmp",
+				Sequence{Arrived: []bool{true, true}, RTTs: []float64{200, 210}})},
+		ClientReferences: []Reference{{Target: "x:443", Echo: blocked}},
+	}
+	if _, err := json.Marshal(struct {
+		Evidence    Evidence    `json:"evidence"`
+		Attribution Attribution `json:"attribution"`
+	}{e, Attribute(e)}); err != nil {
+		t.Fatalf("a report containing a blocked anchor cannot be serialised: %v", err)
+	}
+}
+
+// A metrics page carrying NaN would put the same unserialisable value into the
+// report by a different door.
+func TestMetricsRejectsValuesThatAreNotNumbers(t *testing.T) {
+	view, err := ParseMetrics(strings.NewReader(
+		"queqiao_erasure_ratio{direction=\"send\"} NaN\n" +
+			"queqiao_erasure_ratio{direction=\"receive\"} +Inf\n" +
+			"queqiao_quic_lanes 2\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !finite(view.SendErasure) || !finite(view.ReceiveErasure) {
+		t.Fatalf("a non-numeric sample reached the report: %+v", view)
+	}
+	if view.Lanes != 2 {
+		t.Fatalf("the good sample on the same page was dropped: %d", view.Lanes)
+	}
+	if _, err := json.Marshal(view); err != nil {
+		t.Fatalf("the view cannot be serialised: %v", err)
+	}
+}


### PR DESCRIPTION
## The question this answers

A slow deployment raises one question no instrument here answered: not how bad the path is, but **whose fault it is**. `pathprobe` finds an erasure floor, `pathmeasure` says what a stack achieves, `doctor` checks preconditions and placement — all three describe a path end to end. An operator losing a seventh of everything that crosses it learns only that they are losing a seventh.

Three candidates, three different responses, and only one is ours:

| Segment | What it is | What fixes it |
| --- | --- | --- |
| `client-to-internet` | the client's access link and first mile | their ISP; no transport repairs a first mile |
| `client-to-gateway` | the long haul this transport carries | coding, pacing, lane recovery |
| `gateway-to-internet` | the gateway's own transit onward | its provider, or moving the gateway |

## How the legs are separated

A shared-element argument over legs measured in the same minutes. A client reaching an unfiltered anchor near itself crosses its own access link and nothing else; the same client reaching the gateway crosses that link *and* the long haul; the gateway reaching an anchor near itself shares neither. So a lossy gateway leg with a clean local anchor is the long haul, and the same loss with a lossy local anchor is a first mile the gateway leg merely inherited — the report says which, in those words.

Both ends run concurrently, not in sequence: the characterised path moves between roughly zero and seventeen percent within minutes, so sequential legs can differ by more than any fault would move them.

## Anchor choice is load-bearing, not a detail

**A probe from a filtered network to a filtered destination measures the filter.** Read as loss it would convict a healthy access link of the worst fault this report can report and send the operator to their ISP — a client in China probing a blocked host sees near-total loss on a first mile in perfect health.

Rather than geolocate either end, one Chinese and one global anchor are probed from **both**, and each end is judged by whichever answered cleanly. One clean anchor proves the link carries traffic; the disagreement between the two becomes a finding of its own. Every anchor gets both instruments, so:

- an address that **answers echo but refuses a handshake** is reported as filtering, charged to no segment;
- a leg that returns **nothing** is reported as unanswered, never as 100% loss — from the client those are indistinguishable, and only one is a finding.

## What it reads rather than probes

The client-to-gateway segment comes from the running transport's own metrics where `--metrics-listen` is available. That is the only measurement separating upstream from downstream — the directions this project has measured differing by fourteen points, which a round-trip probe would average into nothing. Ratios drawn from an idle session are not quoted as measurements.

`--ssh` runs *this same code* on the gateway over the operator's existing ssh configuration, so no key material passes through the process, and stdin carries the request (hence `BatchMode=yes`: a password prompt would hang rather than fail). An older remote binary falls back to parsing `ping(8)`; every leg measured that way is labelled, because the fallback gives up the property that made the two ends comparable. Without a far vantage point the gateway's transit is reported as **not measured** rather than passing silently.

## Two failure modes worth calling out

- **No echo socket** — an ordinary unprivileged Linux host. The verdict falls back to the share of handshakes that paid a retransmission timeout, *not* the connection failure rate: TCP retransmits, so nearly every connection completes on a path erasing a fifth of everything, and the failure rate would call it clean.
- **A blocked anchor made `--json` unencodable.** `lossmodel.Analyze` returns `BurstFactor = Inf × 0 = NaN` for a run with no arrivals, and JSON has no NaN — so one filtered anchor killed the whole report with nothing on stdout. Invisible in text mode, where `NaN > 0` renders as `-`. Guarded at both doors, with regression tests.

## Overlap removed

`doctor`'s decomposition of the gateway's hop to a destination is a **subtraction**; this command measures that same leg. Two commands answering one question by two methods will disagree, so the derived figure now says which it is and names where the measured one lives. `docs/CHOOSING-A-GATEWAY.md` gains a fourth instrument, marked as the one belonging *after* deployment rather than before it.

## Verified

Ran against a live China↔US tunnel: correctly attributed 10.6% downstream / 2.5% upstream erasure to the long haul with a clean local anchor, corroborated by an independent ICMP leg at **burst factor 1.0** — erasure, not congestion.

`go test -short ./...`, `go vet`, `gofmt`, `staticcheck -checks=all,-U1000`, the Python suite, and `changelog.py check` all pass. gosec reports **zero** findings in the new code. The metrics parser is tested against a page produced by the real `metrics.Registry` rather than a fixture — which caught that erasure is only aggregated for an observation naming its controller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HCTFdNai8pNgSyJwV8vGW
