### PR TITLE
docs: update download links to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,21 +156,21 @@ All of it ships as a prebuilt binary. Download it below, or from the
 ## Platform availability
 
 Every release publishes reproducible, signed binaries for six native targets.
-The links below are v0.5.1, the current release; the
+The links below are v0.6.0, the current release; the
 [releases page](https://github.com/bojieli/queqiao/releases/latest) always has the newest.
 
 | Platform | Status | Download |
 | --- | --- | --- |
-| macOS, Apple silicon | Desktop and gateway, ready to use | [`darwin_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_darwin_arm64_signed.zip), notarized |
-| macOS, Intel | Desktop and gateway, ready to use | [`darwin_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_darwin_amd64_signed.zip), notarized |
-| Linux, x86-64 | Desktop and gateway, ready to use | [`linux_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_linux_amd64.tar.gz) |
-| Linux, arm64 | Desktop and gateway, ready to use | [`linux_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_linux_arm64.tar.gz) |
-| Windows, x86-64 | Native target built; under testing, not production-ready | [`windows_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_windows_amd64.zip) |
-| Windows, arm64 | Native target built; under testing, not production-ready | [`windows_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/queqiaod_v0.5.1_windows_arm64.zip) |
+| macOS, Apple silicon | Desktop and gateway, ready to use | [`darwin_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_darwin_arm64_signed.zip), notarized |
+| macOS, Intel | Desktop and gateway, ready to use | [`darwin_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_darwin_amd64_signed.zip), notarized |
+| Linux, x86-64 | Desktop and gateway, ready to use | [`linux_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_linux_amd64.tar.gz) |
+| Linux, arm64 | Desktop and gateway, ready to use | [`linux_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_linux_arm64.tar.gz) |
+| Windows, x86-64 | Native target built; under testing, not production-ready | [`windows_amd64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_windows_amd64.zip) |
+| Windows, arm64 | Native target built; under testing, not production-ready | [`windows_arm64`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/queqiaod_v0.6.0_windows_arm64.zip) |
 | Android and iOS | Same protocol-1 core, under testing; not yet production-ready mobile apps | -- |
 
 Check a download against its release's
-[`SHA256SUMS`](https://github.com/bojieli/queqiao/releases/download/v0.5.1/SHA256SUMS)
+[`SHA256SUMS`](https://github.com/bojieli/queqiao/releases/download/v0.6.0/SHA256SUMS)
 before running it. Each archive carries its own CycloneDX SBOM and the complete
 license text for every module linked into the binary.
 


### PR DESCRIPTION
Assembling v0.6.0 into `CHANGELOG.md` left `README.md` pointing at v0.5.1.

`docs/RELEASE-CHECKLIST.md` lists this as a public-preview blocker, and `scripts/test_download_links.py` enforces it by comparing the README links against the newest released section in `CHANGELOG.md`. So the previous commit fails that test — and therefore normal CI, which runs the Python suite — and `release-candidate.yml`'s `ci-evidence` job refuses to qualify a commit whose exact SHA has no successful CI run.

This belonged in #95. v0.5.1 corrected the same omission the same way, in `ad2670e`.

14 occurrences across the 8 lines of the download table and its surrounding prose; no other version reference in the file changed. `python3 -m unittest discover -s scripts -p 'test_*.py'` is green (85 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HCTFdNai8pNgSyJwV8vGW
