### PR TITLE
fix(portmux): skip a hop port the host will not bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,18 @@ to `changelog.d/` instead, as [`CONTRIBUTING.md`](CONTRIBUTING.md) describes.
   of the 100 configured ports were never tried — and the detector waits for a
   full measurement window before firing instead of hopping seconds after
   connect.
+- A gateway with port hopping enabled no longer refuses to start because one
+  hop port is unavailable. The pool is derived from a hash over the provider
+  identity, so a derivation eventually lands on a port the host will not hand
+  out -- Windows carves dynamic exclusion ranges out of the same space and
+  refuses them with a permissions error, Linux has `ip_local_reserved_ports`,
+  and on any host another service may already hold one -- and binding the pool
+  was all-or-nothing, so a single such port took the whole listener down with
+  it. Ports that cannot be bound are now skipped and named in the listener's
+  log, leaving a narrower pool rather than no gateway. A pool that binds no
+  hop port at all is still an error, because hopping is then absent rather
+  than degraded, and an operator who asked for it should not have to infer
+  that from traffic which never evades anything.
 - Rescue races no longer misfire on the peer's lane ceiling. A capacity
   refusal of the pooled control JOIN is a benign per-attempt outcome — usually
   a sibling attempt already holds the lane — but it fell through to the

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -515,9 +515,14 @@ func (s *Server) serveQUIC(ctx context.Context) error {
 		_ = primaryConn.Close()
 		return fmt.Errorf("create server port mux: %w", err)
 	}
+	// A pool narrower than configured is reported rather than inferred: the
+	// deployment still works, but it hops across fewer ports than the operator
+	// asked for, and that is a fact about this host worth having in the log.
 	s.cfg.Logger.Info("port hop listener ready",
 		"primary_addr", primaryConn.LocalAddr(),
-		"hop_port_count", len(ports))
+		"hop_port_count", len(ports)-len(mux.SkippedPorts()),
+		"hop_ports_configured", len(ports),
+		"hop_ports_unavailable", mux.SkippedPorts())
 	return s.ServePacketConn(ctx, mux)
 }
 

--- a/internal/portmux/portmux.go
+++ b/internal/portmux/portmux.go
@@ -257,6 +257,9 @@ type serverPacket struct {
 type ServerPortMux struct {
 	primary     *net.UDPConn
 	secondaries []*net.UDPConn
+	// skipped records hop ports the host refused, so a degraded pool is
+	// visible in the log rather than silently narrower than configured.
+	skipped []int
 	// incoming is the merged receive queue. It is sized large enough to absorb
 	// bursts across all sockets without a secondary blocking a primary read.
 	incoming  chan serverPacket
@@ -270,6 +273,23 @@ type ServerPortMux struct {
 // primary, starts per-socket reader goroutines, and returns the multiplexed
 // PacketConn. primary must already be bound to ports[0].
 //
+// A hop port that cannot be bound is skipped rather than fatal, and the caller
+// can read which ones with SkippedPorts. The pool is derived from a hash over
+// the provider identity, so it is only a matter of time before a derivation
+// lands on a port the host will not hand out: Windows carves dynamic exclusion
+// ranges out of [1024, 65535) for WinNAT and Hyper-V and refuses them with a
+// permissions error, Linux has ip_local_reserved_ports, and on any host
+// another service may already hold one. Refusing to start a gateway because
+// one of several hop ports is unavailable trades a working deployment for a
+// slightly wider pool, which is the wrong way round -- hopping is best-effort
+// by construction, and a client that hops to a port this server could not bind
+// sees the same silence it sees from a blocked port and hops again.
+//
+// Losing every hop port is different, and still an error. It means hopping is
+// entirely non-functional rather than degraded, which an operator who asked
+// for it needs to be told rather than left to infer from traffic that never
+// evades anything.
+//
 // On error, any successfully opened extra sockets are closed before returning.
 func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error) {
 	primaryAddr, ok := primary.LocalAddr().(*net.UDPAddr)
@@ -278,16 +298,21 @@ func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error)
 	}
 
 	secondaries := make([]*net.UDPConn, 0, len(ports)-1)
+	var skipped []int
+	var lastErr error
 	for _, port := range ports[1:] {
 		addr := &net.UDPAddr{IP: primaryAddr.IP, Port: port}
 		conn, err := net.ListenUDP("udp", addr)
 		if err != nil {
-			for _, s := range secondaries {
-				_ = s.Close()
-			}
-			return nil, fmt.Errorf("server portmux: listen on hop port %d: %w", port, err)
+			skipped = append(skipped, port)
+			lastErr = err
+			continue
 		}
 		secondaries = append(secondaries, conn)
+	}
+	if len(ports) > 1 && len(secondaries) == 0 {
+		return nil, fmt.Errorf("server portmux: no hop port could be bound, last error on %d: %w",
+			skipped[len(skipped)-1], lastErr)
 	}
 
 	// Buffer depth: 4096 slots shared across all sockets. At 1500 B/packet
@@ -295,6 +320,7 @@ func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error)
 	m := &ServerPortMux{
 		primary:     primary,
 		secondaries: secondaries,
+		skipped:     skipped,
 		incoming:    make(chan serverPacket, 4096),
 		done:        make(chan struct{}),
 	}
@@ -308,6 +334,10 @@ func NewServerPortMux(primary *net.UDPConn, ports []int) (*ServerPortMux, error)
 
 	return m, nil
 }
+
+// SkippedPorts returns the hop ports this host would not bind. The caller must
+// not modify it.
+func (m *ServerPortMux) SkippedPorts() []int { return m.skipped }
 
 // readSocket copies datagrams from one listening socket into the merged
 // incoming queue, tagging each with the socket it arrived on so replies can

--- a/internal/portmux/portmux_test.go
+++ b/internal/portmux/portmux_test.go
@@ -382,3 +382,87 @@ func TestHopControllerNoHopWhenReceiving(t *testing.T) {
 	}
 	<-done
 }
+
+// A hop pool is derived from a hash, so a derivation will eventually land on a
+// port the host will not hand out -- Windows carves dynamic exclusion ranges
+// out of the same space and refuses them outright. Losing one of several hop
+// ports has to degrade the pool rather than take the gateway down with it.
+func TestAnUnbindableHopPortIsSkippedRatherThanFatal(t *testing.T) {
+	primary, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Hold one hop port ourselves, which is the portable stand-in for a port
+	// the operating system has reserved.
+	blocker, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = blocker.Close() }()
+	blocked := blocker.LocalAddr().(*net.UDPAddr).Port
+
+	free, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	usable := free.LocalAddr().(*net.UDPAddr).Port
+	_ = free.Close()
+
+	primaryPort := primary.LocalAddr().(*net.UDPAddr).Port
+	mux, err := portmux.NewServerPortMux(primary, []int{primaryPort, blocked, usable})
+	if err != nil {
+		t.Fatalf("one unbindable hop port took the whole mux down: %v", err)
+	}
+	defer func() { _ = mux.Close() }()
+
+	if got := mux.SkippedPorts(); len(got) != 1 || got[0] != blocked {
+		t.Fatalf("skipped ports %v, want exactly [%d]", got, blocked)
+	}
+	// The port that was available still has to be listening, or the pool has
+	// silently collapsed to the primary.
+	probe, err := net.DialUDP("udp", nil, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: usable})
+	if err != nil {
+		t.Fatalf("the usable hop port is not listening: %v", err)
+	}
+	_ = probe.Close()
+}
+
+// Losing every hop port is a different condition from losing one: hopping is
+// then not degraded but absent, and an operator who configured it should be
+// told rather than left to infer it from traffic that never evades anything.
+func TestAHopPoolThatBindsNothingIsAnError(t *testing.T) {
+	primary, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = primary.Close() }()
+	blocker, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = blocker.Close() }()
+	blocked := blocker.LocalAddr().(*net.UDPAddr).Port
+
+	primaryPort := primary.LocalAddr().(*net.UDPAddr).Port
+	if _, err := portmux.NewServerPortMux(primary, []int{primaryPort, blocked}); err == nil {
+		t.Fatal("a pool that bound no hop port at all was accepted")
+	}
+}
+
+// A mux asked for no hop ports at all is not a degraded pool; it is hopping
+// switched off, and it must not be turned into an error by the check above.
+func TestASinglePortPoolIsNotTreatedAsAFailure(t *testing.T) {
+	primary, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	primaryPort := primary.LocalAddr().(*net.UDPAddr).Port
+	mux, err := portmux.NewServerPortMux(primary, []int{primaryPort})
+	if err != nil {
+		t.Fatalf("a single-port pool was rejected: %v", err)
+	}
+	defer func() { _ = mux.Close() }()
+	if len(mux.SkippedPorts()) != 0 {
+		t.Fatalf("skipped %v with nothing to skip", mux.SkippedPorts())
+	}
+}


### PR DESCRIPTION
The v0.6.0 release candidate failed on `windows-11-arm` with:

```
server portmux: listen on hop port 51359: listen udp 127.0.0.1:51359:
bind: An attempt was made to access a socket in a way forbidden by its
access permissions.
```

That is not test noise. It is a real defect in the port-hopping feature **this release introduces**: `NewServerPortMux` bound the pool all-or-nothing, so one unavailable hop port took down the entire gateway listener — `internal/pep/server.go` turns the error into a failed `ServeQUIC`.

### Why it will happen in production

The pool comes from a hash over the provider identity, mapped into `[1024, 65535)`. Sooner or later a derivation lands on a port the host will not hand out:

- Windows carves dynamic exclusion ranges out of that space for WinNAT/Hyper-V and refuses them with `WSAEACCES`
- Linux has `ip_local_reserved_ports`
- on any host, another service may already hold one

Hopping is opt-in (`--hop-port-count` defaults to 0), which bounds the blast radius — but an operator who enables it with a large pool on a real server is quite likely to hit exactly this, and they are the users who need the feature most.

### The fix

Skip what will not bind, keep what will, and say so. Hopping is best-effort by construction: a client that hops to a port this server could not bind sees the same silence a blocked port gives it, and hops again. The listener log now reports the pool actually achieved alongside the pool configured, and the ports that were refused.

Losing *every* hop port stays an error — hopping is then absent rather than degraded, and that is worth failing on rather than leaving an operator to infer it from traffic that never evades anything.

Skipping is safe with respect to routing: the server's `secondaries` are not indexed by hop index; replies follow the route map back to the socket a client was last seen on.

### Tests

Three, all portable — they hold a port open as the stand-in for one the OS has reserved, rather than depending on Windows:

- one unbindable hop port is skipped, recorded, and the remaining port still listens
- a pool that binds nothing is an error
- a single-port pool (hopping off) is not mistaken for that failure

### Changelog

Added to the assembled but **unreleased** v0.6.0 section rather than to `changelog.d/`, because the fix ships in v0.6.0 — a fragment would record it against the following release. Hence the `changelog` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HCTFdNai8pNgSyJwV8vGW
