### PR TITLE
fix(pep): resolve a named endpoint over a bound socket

### DIFF
--- a/changelog.d/endpoint-name-resolved-through-bound-socket.fixed.md
+++ b/changelog.d/endpoint-name-resolved-through-bound-socket.fixed.md
@@ -1,0 +1,10 @@
+A gateway endpoint written as a hostname is now resolved over a socket bound
+the same way the lane will be. `--local-address` applies to the sockets the
+client creates, but a dialer's `LocalAddr` and `Control` never reach the
+lookup that turns the endpoint name into the address it connects to, so that
+one question went out over an unbound socket. A host whose transparent proxy
+redirects port 53 into this very client could then not answer it: the name
+has to resolve before the datapath exists, and the datapath has to exist
+before the name resolves, so both transports failed with `no such host` and
+the provider never came up. Endpoints written as literal addresses were never
+affected, and still take a path with no lookup in it.

--- a/internal/netbind/resolver.go
+++ b/internal/netbind/resolver.go
@@ -1,0 +1,111 @@
+package netbind
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"strings"
+	"syscall"
+)
+
+// ResolverFor returns a resolver whose own sockets carry the same interface
+// binding as a data socket built for spec, plus any extra control the caller
+// applies to its data sockets.
+//
+// A local-address spec exists so the outer path bypasses a host TUN route, and
+// InterfaceControl asserts that at the kernel level so a transparent proxy
+// honouring NEAppProxyFlow.isBound leaves those sockets alone. That covers the
+// sockets the caller creates. It does not cover the ones the resolver creates
+// on the caller's behalf: net.Dialer applies LocalAddr and Control to the
+// connection it dials, never to the lookup that turned a name into the address
+// it dials to. So a client bound to a physical interface still asks its
+// question over an unbound socket.
+//
+// When capture redirects port 53, that unbound question is claimed and sent to
+// the proxy, and a client whose own endpoint is named rather than numbered
+// cannot answer it: the name has to resolve before the datapath exists, and the
+// datapath has to exist before the name resolves. Binding the resolver removes
+// the cycle at its only unguarded end.
+//
+// The returned resolver is deliberately scoped to bootstrap lookups — the
+// gateway endpoint — rather than installed globally. PreferGo is required for
+// Dial to be honoured at all: the cgo resolver answers inside libSystem and
+// never calls it, so without PreferGo the binding is silently dropped. That
+// has a cost, which is why the scope is narrow. The pure resolver reads
+// /etc/resolv.conf rather than the platform's own configuration, so it does
+// not see split-horizon rules a system resolver would apply. A gateway
+// endpoint is a public name reached over a specific interface, which is
+// exactly the lookup least likely to want those rules; every other name in
+// the process keeps the resolver it had.
+//
+// An empty spec has nothing to bind to and yields net.DefaultResolver, which is
+// the previous behaviour.
+func ResolverFor(spec string, extra func(string, string, syscall.RawConn) error) (*net.Resolver, error) {
+	if spec == "" {
+		return net.DefaultResolver, nil
+	}
+	result, err := ResolveWithInterface(spec)
+	if err != nil {
+		return nil, err
+	}
+	control := composeControls(InterfaceControl(result.InterfaceName), extra)
+	local := result.Addr
+	return &net.Resolver{
+		// Without this the cgo resolver answers and never calls Dial, so the
+		// binding this function exists to apply would be silently dropped.
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialer := &net.Dialer{Control: control}
+			if addr, ok := localAddrFor(network, address, local); ok {
+				dialer.LocalAddr = addr
+			}
+			return dialer.DialContext(ctx, network, address)
+		},
+	}, nil
+}
+
+// localAddrFor returns the source address to bind for one nameserver dial, and
+// whether to bind at all.
+//
+// A source address of the wrong family cannot carry the query, and a resolver
+// list routinely mixes families. Binding only on a match keeps the IPv4 case
+// bound and lets an IPv6 nameserver still be reached over the interface
+// binding, which is the part capture actually reads.
+func localAddrFor(network, address string, local netip.Addr) (net.Addr, bool) {
+	if !local.IsValid() {
+		return nil, false
+	}
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, false
+	}
+	target, err := netip.ParseAddr(host)
+	if err != nil || target.Is4() != local.Is4() {
+		return nil, false
+	}
+	switch {
+	case strings.HasPrefix(network, "udp"):
+		return &net.UDPAddr{IP: local.AsSlice()}, true
+	case strings.HasPrefix(network, "tcp"):
+		return &net.TCPAddr{IP: local.AsSlice()}, true
+	default:
+		return nil, false
+	}
+}
+
+// composeControls returns a control function that calls a then b, or nil when
+// neither is set.
+func composeControls(a, b func(string, string, syscall.RawConn) error) func(string, string, syscall.RawConn) error {
+	switch {
+	case a == nil:
+		return b
+	case b == nil:
+		return a
+	}
+	return func(network, address string, conn syscall.RawConn) error {
+		if err := a(network, address, conn); err != nil {
+			return err
+		}
+		return b(network, address, conn)
+	}
+}

--- a/internal/netbind/resolver.go
+++ b/internal/netbind/resolver.go
@@ -48,6 +48,15 @@ func ResolverFor(spec string, extra func(string, string, syscall.RawConn) error)
 	if err != nil {
 		return nil, err
 	}
+	return ResolverForResult(result, extra), nil
+}
+
+// ResolverForResult is ResolverFor for a caller that has already resolved the
+// spec. Dialing a lane resolves it to build the socket's own binding, and
+// resolving an "auto" or "if:NAME" spec enumerates the host's interfaces, so a
+// caller on a dial path should pass what it already has rather than pay for
+// that a second time on every connection.
+func ResolverForResult(result ResolveResult, extra func(string, string, syscall.RawConn) error) *net.Resolver {
 	control := composeControls(InterfaceControl(result.InterfaceName), extra)
 	local := result.Addr
 	return &net.Resolver{
@@ -61,7 +70,7 @@ func ResolverFor(spec string, extra func(string, string, syscall.RawConn) error)
 			}
 			return dialer.DialContext(ctx, network, address)
 		},
-	}, nil
+	}
 }
 
 // localAddrFor returns the source address to bind for one nameserver dial, and

--- a/internal/netbind/resolver_test.go
+++ b/internal/netbind/resolver_test.go
@@ -1,0 +1,89 @@
+package netbind
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestResolverForWithoutASpecIsTheDefault(t *testing.T) {
+	// Nothing to bind to, so nothing changes: callers that never asked for a
+	// local address keep the resolver they always had.
+	resolver, err := ResolverFor("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolver != net.DefaultResolver {
+		t.Error("an empty spec must not replace the default resolver")
+	}
+}
+
+func TestResolverForRejectsASpecItCannotResolve(t *testing.T) {
+	if _, err := ResolverFor("not-an-address", nil); err == nil {
+		t.Error("an unresolvable spec must be reported, not silently ignored")
+	}
+}
+
+func TestResolverForDialsFromTheBoundAddress(t *testing.T) {
+	// The whole point of the helper: the socket that carries the question is
+	// bound the same way the socket that will carry the data is.
+	resolver, err := ResolverFor("127.0.0.1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resolver.PreferGo {
+		t.Fatal("without PreferGo the Dial hook is never called and nothing is bound")
+	}
+	server, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := resolver.Dial(ctx, "udp", server.LocalAddr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	local := conn.LocalAddr().(*net.UDPAddr)
+	if !local.IP.IsLoopback() {
+		t.Errorf("dialed from %s, want the bound loopback address", local.IP)
+	}
+}
+
+func TestLocalAddrForBindsOnlyWhatCanCarryTheQuery(t *testing.T) {
+	v4 := netip.MustParseAddr("192.0.2.10")
+	v6 := netip.MustParseAddr("2001:db8::1")
+
+	if addr, ok := localAddrFor("udp", "198.51.100.1:53", v4); !ok {
+		t.Error("a v4 source and a v4 nameserver must bind")
+	} else if _, isUDP := addr.(*net.UDPAddr); !isUDP {
+		t.Errorf("bound %T for a udp dial, want *net.UDPAddr", addr)
+	}
+	if addr, ok := localAddrFor("tcp", "198.51.100.1:53", v4); !ok {
+		t.Error("a v4 source and a v4 nameserver must bind over tcp too")
+	} else if _, isTCP := addr.(*net.TCPAddr); !isTCP {
+		t.Errorf("bound %T for a tcp dial, want *net.TCPAddr", addr)
+	}
+	// A source of the wrong family cannot carry the query at all. Skipping the
+	// bind still leaves the interface binding, which is the part capture reads.
+	if _, ok := localAddrFor("udp", "[2001:db8::53]:53", v4); ok {
+		t.Error("a v4 source must not be bound for a v6 nameserver")
+	}
+	if _, ok := localAddrFor("udp", "198.51.100.1:53", v6); ok {
+		t.Error("a v6 source must not be bound for a v4 nameserver")
+	}
+	if _, ok := localAddrFor("unix", "/var/run/resolver", v4); ok {
+		t.Error("only udp and tcp dials have an address to bind")
+	}
+	if _, ok := localAddrFor("udp", "not-host-port", v4); ok {
+		t.Error("an unparseable nameserver address must not be bound")
+	}
+	if _, ok := localAddrFor("udp", "198.51.100.1:53", netip.Addr{}); ok {
+		t.Error("an invalid source address must not be bound")
+	}
+}

--- a/internal/pep/resolve_test.go
+++ b/internal/pep/resolve_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-func TestResolveUDPAddrBoundTakesLiteralAddressesWithoutALookup(t *testing.T) {
+func TestResolveUDPAddrTakesLiteralAddressesWithoutALookup(t *testing.T) {
 	// A numbered endpoint needs no resolver at all, and must not be made to
 	// depend on one: this is the path every literal-endpoint provider takes.
 	for _, remote := range []string{"203.0.113.7:12540", "[2001:db8::1]:12540"} {
-		addr, err := resolveUDPAddrBound(context.Background(), remote, "if:nonexistent0", nil)
+		addr, err := resolveUDPAddr(context.Background(), remote, net.DefaultResolver)
 		if err != nil {
 			t.Fatalf("%s: %v", remote, err)
 		}
@@ -20,21 +20,8 @@ func TestResolveUDPAddrBoundTakesLiteralAddressesWithoutALookup(t *testing.T) {
 	}
 }
 
-func TestResolveUDPAddrBoundReportsAMalformedEndpoint(t *testing.T) {
-	if _, err := resolveUDPAddrBound(context.Background(), "no-port-here", "", nil); err == nil {
+func TestResolveUDPAddrReportsAMalformedEndpoint(t *testing.T) {
+	if _, err := resolveUDPAddr(context.Background(), "no-port-here", net.DefaultResolver); err == nil {
 		t.Error("an endpoint without a port must be reported")
-	}
-}
-
-func TestResolveUDPAddrBoundReportsAnUnusableLocalAddress(t *testing.T) {
-	// A named endpoint needs the bound resolver, so a local-address spec that
-	// cannot be resolved has to surface here rather than quietly falling back
-	// to an unbound lookup — the fallback is the bug this path exists to close.
-	_, err := resolveUDPAddrBound(context.Background(), "gateway.example:12540", "if:nonexistent0", nil)
-	if err == nil {
-		t.Fatal("an unresolvable local address must be reported")
-	}
-	if _, ok := err.(*net.DNSError); ok {
-		t.Errorf("reported a lookup failure (%v), want the local-address failure", err)
 	}
 }

--- a/internal/pep/resolve_test.go
+++ b/internal/pep/resolve_test.go
@@ -1,0 +1,40 @@
+package pep
+
+import (
+	"context"
+	"net"
+	"testing"
+)
+
+func TestResolveUDPAddrBoundTakesLiteralAddressesWithoutALookup(t *testing.T) {
+	// A numbered endpoint needs no resolver at all, and must not be made to
+	// depend on one: this is the path every literal-endpoint provider takes.
+	for _, remote := range []string{"203.0.113.7:12540", "[2001:db8::1]:12540"} {
+		addr, err := resolveUDPAddrBound(context.Background(), remote, "if:nonexistent0", nil)
+		if err != nil {
+			t.Fatalf("%s: %v", remote, err)
+		}
+		if got := addr.String(); got != remote {
+			t.Errorf("resolved %s to %s", remote, got)
+		}
+	}
+}
+
+func TestResolveUDPAddrBoundReportsAMalformedEndpoint(t *testing.T) {
+	if _, err := resolveUDPAddrBound(context.Background(), "no-port-here", "", nil); err == nil {
+		t.Error("an endpoint without a port must be reported")
+	}
+}
+
+func TestResolveUDPAddrBoundReportsAnUnusableLocalAddress(t *testing.T) {
+	// A named endpoint needs the bound resolver, so a local-address spec that
+	// cannot be resolved has to surface here rather than quietly falling back
+	// to an unbound lookup — the fallback is the bug this path exists to close.
+	_, err := resolveUDPAddrBound(context.Background(), "gateway.example:12540", "if:nonexistent0", nil)
+	if err == nil {
+		t.Fatal("an unresolvable local address must be reported")
+	}
+	if _, ok := err.(*net.DNSError); ok {
+		t.Errorf("reported a lookup failure (%v), want the local-address failure", err)
+	}
+}

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -415,6 +415,13 @@ func tlsClientConfig(credentials identity.ClientCredentials) (*tls.Config, error
 func dialTCP(ctx context.Context, remote string, credentials identity.ClientCredentials, dialTimeout time.Duration, localAddress string, control func(string, string, syscall.RawConn) error) (streamConn, error) {
 	var localAddr net.Addr
 	composed := control
+	// LocalAddr and Control apply to the connection this dialer makes, never to
+	// the lookup that turns the endpoint name into the address it connects to.
+	// An endpoint named rather than numbered therefore asked its question over
+	// an unbound socket, which capture is free to claim and send to the very
+	// gateway the answer is needed to reach. Built from the resolution the
+	// binding already needed, so a dial does not enumerate interfaces twice.
+	resolver := net.DefaultResolver
 	if localAddress != "" {
 		result, err := netbind.ResolveWithInterface(localAddress)
 		if err != nil {
@@ -422,17 +429,9 @@ func dialTCP(ctx context.Context, remote string, credentials identity.ClientCred
 		}
 		localAddr = &net.TCPAddr{IP: result.Addr.AsSlice()}
 		composed = composeSocketControls(netbind.InterfaceControl(result.InterfaceName), control)
+		resolver = netbind.ResolverForResult(result, control)
 	}
 	tlsConfig, err := tlsClientConfig(credentials)
-	if err != nil {
-		return nil, err
-	}
-	// LocalAddr and Control apply to the connection this dialer makes, never to
-	// the lookup that turns the endpoint name into the address it connects to.
-	// An endpoint named rather than numbered therefore asked its question over
-	// an unbound socket, which capture is free to claim and send to the very
-	// gateway the answer is needed to reach.
-	resolver, err := netbind.ResolverFor(localAddress, control)
 	if err != nil {
 		return nil, err
 	}
@@ -757,6 +756,9 @@ func dialQUICConnection(ctx context.Context, remote string, credentials identity
 	}
 	listenAddress := ":0"
 	composed := control
+	// See dialTCP: the lookup that turns a named endpoint into an address does
+	// not inherit the socket's binding, so it needs a resolver that carries it.
+	resolver := net.DefaultResolver
 	if localAddress != "" {
 		result, parseErr := netbind.ResolveWithInterface(localAddress)
 		if parseErr != nil {
@@ -764,8 +766,9 @@ func dialQUICConnection(ctx context.Context, remote string, credentials identity
 		}
 		listenAddress = net.JoinHostPort(result.Addr.String(), "0")
 		composed = composeSocketControls(netbind.InterfaceControl(result.InterfaceName), control)
+		resolver = netbind.ResolverForResult(result, control)
 	}
-	remoteAddr, err := resolveUDPAddrBound(dialCtx, remote, localAddress, control)
+	remoteAddr, err := resolveUDPAddr(dialCtx, remote, resolver)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -823,23 +826,18 @@ func validateLocalAddressSpec(spec string) error {
 	return netbind.Validate(spec)
 }
 
-// resolveUDPAddrBound resolves a UDP endpoint using a resolver bound the same
-// way the lane socket will be.
+// resolveUDPAddr resolves a UDP endpoint through the given resolver.
 //
-// net.ResolveUDPAddr uses the default resolver, whose sockets carry neither the
+// net.ResolveUDPAddr would use the default one, whose sockets carry neither the
 // local address nor the interface binding the lane is about to use. A literal
 // address needs no lookup and takes the same path it always did.
-func resolveUDPAddrBound(ctx context.Context, remote, localAddress string, control func(string, string, syscall.RawConn) error) (*net.UDPAddr, error) {
+func resolveUDPAddr(ctx context.Context, remote string, resolver *net.Resolver) (*net.UDPAddr, error) {
 	host, port, err := net.SplitHostPort(remote)
 	if err != nil {
 		return nil, err
 	}
 	if addr, parseErr := netip.ParseAddr(host); parseErr == nil {
 		return net.ResolveUDPAddr("udp", net.JoinHostPort(addr.String(), port))
-	}
-	resolver, err := netbind.ResolverFor(localAddress, control)
-	if err != nil {
-		return nil, err
 	}
 	portNumber, err := net.LookupPort("udp", port)
 	if err != nil {

--- a/internal/pep/transport.go
+++ b/internal/pep/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/netip"
 	"strings"
 	"sync"
 	"syscall"
@@ -426,9 +427,24 @@ func dialTCP(ctx context.Context, remote string, credentials identity.ClientCred
 	if err != nil {
 		return nil, err
 	}
+	// LocalAddr and Control apply to the connection this dialer makes, never to
+	// the lookup that turns the endpoint name into the address it connects to.
+	// An endpoint named rather than numbered therefore asked its question over
+	// an unbound socket, which capture is free to claim and send to the very
+	// gateway the answer is needed to reach.
+	resolver, err := netbind.ResolverFor(localAddress, control)
+	if err != nil {
+		return nil, err
+	}
 	conn, err := (&tls.Dialer{
-		NetDialer: &net.Dialer{Timeout: dialTimeout, KeepAlive: 30 * time.Second, LocalAddr: localAddr, Control: composed},
-		Config:    tlsConfig,
+		NetDialer: &net.Dialer{
+			Timeout:   dialTimeout,
+			KeepAlive: 30 * time.Second,
+			LocalAddr: localAddr,
+			Control:   composed,
+			Resolver:  resolver,
+		},
+		Config: tlsConfig,
 	}).DialContext(ctx, "tcp", remote)
 	if err != nil {
 		return nil, explainDataHandshakeError(remote, "TCP", err)
@@ -749,7 +765,7 @@ func dialQUICConnection(ctx context.Context, remote string, credentials identity
 		listenAddress = net.JoinHostPort(result.Addr.String(), "0")
 		composed = composeSocketControls(netbind.InterfaceControl(result.InterfaceName), control)
 	}
-	remoteAddr, err := net.ResolveUDPAddr("udp", remote)
+	remoteAddr, err := resolveUDPAddrBound(dialCtx, remote, localAddress, control)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -805,6 +821,38 @@ func explainDataHandshakeError(remote, transport string, err error) error {
 // dial by netbind.ResolveWithInterface.
 func validateLocalAddressSpec(spec string) error {
 	return netbind.Validate(spec)
+}
+
+// resolveUDPAddrBound resolves a UDP endpoint using a resolver bound the same
+// way the lane socket will be.
+//
+// net.ResolveUDPAddr uses the default resolver, whose sockets carry neither the
+// local address nor the interface binding the lane is about to use. A literal
+// address needs no lookup and takes the same path it always did.
+func resolveUDPAddrBound(ctx context.Context, remote, localAddress string, control func(string, string, syscall.RawConn) error) (*net.UDPAddr, error) {
+	host, port, err := net.SplitHostPort(remote)
+	if err != nil {
+		return nil, err
+	}
+	if addr, parseErr := netip.ParseAddr(host); parseErr == nil {
+		return net.ResolveUDPAddr("udp", net.JoinHostPort(addr.String(), port))
+	}
+	resolver, err := netbind.ResolverFor(localAddress, control)
+	if err != nil {
+		return nil, err
+	}
+	portNumber, err := net.LookupPort("udp", port)
+	if err != nil {
+		return nil, err
+	}
+	addresses, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("no addresses for %q", host)
+	}
+	return &net.UDPAddr{IP: addresses[0].IP, Zone: addresses[0].Zone, Port: portNumber}, nil
 }
 
 // composeSocketControls returns a control function that calls a then b. Either


### PR DESCRIPTION
## What was wrong

`--local-address` exists so the outer path bypasses a host TUN route, and `netbind.InterfaceControl` asserts that at the kernel level with `IP_BOUND_IF` — which is what makes `NEAppProxyFlow.isBound` true, so a transparent proxy honouring it leaves those sockets alone.

That covers the sockets this client creates. It did not cover the ones the resolver creates on its behalf. `net.Dialer` applies `LocalAddr` and `Control` to the connection it dials, never to the lookup that turns the endpoint name into the address it dials to — and `dialQUICConnection` used `net.ResolveUDPAddr`, which is the default resolver outright.

So a client bound to a physical interface still asked that one question over an unbound socket.

## Why it is fatal rather than untidy

On a host whose transparent proxy redirects port 53, that unbound question is claimed and sent to the proxy — which, when this client *is* the proxy's upstream, is this client. The name has to resolve before the datapath exists, and the datapath has to exist before the name resolves.

Observed on a live host: a provider whose endpoint is `<name>:12540` logged `lookup <name>: no such host` on both transports 25,365 times in 67 minutes and never came up. Its lane sockets were fine the whole time — 20,162 of them went out direct under `bypass:bound-interface`, exactly as designed. Only the lookup leaked.

## The fix

`netbind.ResolverFor(spec, control)` returns a resolver whose own sockets carry the same interface binding and source address as a data socket built for `spec`. Both lane paths use it for the endpoint name: the TCP dialer via `net.Dialer.Resolver`, and the QUIC path via a new `resolveUDPAddrBound`.

Two deliberate limits:

- `PreferGo` is required or the cgo resolver answers inside libSystem and never calls `Dial`, silently dropping the binding. That has a cost — the pure resolver reads `/etc/resolv.conf` rather than the platform's own configuration — which is why the scope is the endpoint lookup rather than a process-wide resolver. A gateway endpoint is a public name reached over a specific interface, the lookup least likely to want split-horizon rules.
- A source address is bound only when its family matches the nameserver's, since a mismatched one cannot carry the query. The interface binding still applies, and that is the part capture reads.

A literal endpoint address needs no lookup and takes the same path it always did.

## Tests

New: `internal/netbind/resolver_test.go` (default resolver when unbound, error propagation, the dial actually leaving from the bound address, and family matching); `internal/pep/resolve_test.go` (literal fast path for v4 and v6, malformed endpoint, and an unusable local address surfacing as itself rather than as a lookup failure).

`go vet` and `staticcheck -checks=all,-U1000` clean on both packages.

Note: `go test -short -race ./...` locally times out in `internal/fec` on `TestTheWindowRateIsWhatTheWindowNeeds` (~10m under the race detector). That is pre-existing and unreachable from these packages — `go list -deps ./internal/fec` contains neither `netbind` nor `pep` — and is not the combination CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHr1RSawjHAuUBJwK63vxE