### PR TITLE
fix(pep): free wedged lane-admission slots at the rescue ceiling

### DIFF
--- a/changelog.d/lane-rescue-eviction.fixed.md
+++ b/changelog.d/lane-rescue-eviction.fixed.md
@@ -1,0 +1,10 @@
+Lane rescue JOINs at the gateway are no longer blocked by the control/bulk
+role restriction when a flow's lane ceiling is reached: eviction now picks
+the oldest evictable lane, preferring one with the replacement's role but
+never refusing a rescue for want of a same-role victim, so a dead control
+lane can no longer wedge a flow's last admission slot. A JOIN lane whose
+OPEN_OK could not be written is also removed from the flow at once instead
+of leaking an admission slot that could never carry traffic. Lanes whose
+handshake is in flight or younger than the rescue-race window remain
+unevictable, since evicting them can kill the rescue attempt the client has
+just crowned.

--- a/internal/pep/client.go
+++ b/internal/pep/client.go
@@ -2519,10 +2519,11 @@ func (c *Client) openSprayedQUICRescueJoin(ctx context.Context, flow *multipathF
 // The race is deliberately not transactional with the server, which admits
 // JOINs in arrival order while the winner here is the first finisher. What
 // keeps a late losing JOIN from evicting the winner's server side at the
-// lane ceiling is the server: it protects freshly admitted lanes from
-// eviction and refuses the loser by capacity instead (see retireOldestLane),
-// and a capacity refusal is exactly the per-attempt failure errLaneJoinCapacity
-// carries back here.
+// lane ceiling is the server: a lane is unevictable while its JOIN handshake
+// is in flight and for one path-detection budget afterwards, so the loser is
+// refused by capacity instead (see retireOldestLane), and a capacity refusal
+// is exactly the per-attempt failure errLaneJoinCapacity carries back here.
+// Past that window no role or seniority shields a lane from a newer rescue.
 func (c *Client) raceRescueAttempts(ctx context.Context, flow *multipathFlow, attempts []rescueAttempt) (*mpLane, int, error) {
 	raceCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/pep/laneisolation_test.go
+++ b/internal/pep/laneisolation_test.go
@@ -177,7 +177,7 @@ func TestServerReplacesALaneWithTheSameRole(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Eviction exists for lanes whose peer has already moved on, so the
-	// victims here must be older than the protection window: a freshly
+	// victims here must be older than the rescue-race window: a freshly
 	// admitted lane is never retired to make room.
 	control.admitted = time.Now().Add(-2 * laneDeadPathDetection)
 	bulk.admitted = time.Now().Add(-2 * laneDeadPathDetection)
@@ -201,12 +201,11 @@ func TestServerReplacesALaneWithTheSameRole(t *testing.T) {
 }
 
 // Parallel rescue JOINs race one another to the gateway, which admits in
-// arrival order while the peer crowns the first finisher. A freshly admitted
-// lane must therefore be protected from eviction at the lane ceiling:
-// without the protection, a losing JOIN admitted moments after the winner
-// retires the winner's server side before its own close lands, and the
-// "rescue" leaves the flow with no lane at all.
-func TestFreshlyAdmittedLaneIsProtectedFromEviction(t *testing.T) {
+// arrival order while the peer crowns the first finisher. Once the live
+// lanes are older than the rescue-race window, admission at the lane ceiling
+// is always by eviction: a stalled flow's retry matters more than seniority,
+// so an old lane is never shielded from a newer rescue.
+func TestRacingJoinIsAdmittedByEvictingTheOldestLane(t *testing.T) {
 	flow := newIsolationTestFlow(t, true)
 	session := newServerFlow(flow, identity.Principal{}, TransportQUIC, 1)
 	control := isolationLane(t, 0)
@@ -218,23 +217,111 @@ func TestFreshlyAdmittedLaneIsProtectedFromEviction(t *testing.T) {
 	if err := session.addLane(bulk); err != nil {
 		t.Fatal(err)
 	}
+	control.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	bulk.admitted = time.Now().Add(-2 * laneDeadPathDetection)
 
 	racing := isolationLane(t, 2)
-	if err := session.addLane(racing); err == nil {
-		t.Fatal("a racing join evicted a freshly admitted lane")
-	}
-	if bulk.closed.Load() {
-		t.Fatal("the freshly admitted lane was retired by the racing join")
-	}
-	// Once the lane is older than the path-detection budget it is the
-	// half-open socket eviction exists for, and the next join takes its slot.
-	bulk.admitted = time.Now().Add(-2 * laneDeadPathDetection)
 	if err := session.addLane(racing); err != nil {
-		t.Fatalf("replacement of an aged lane refused: %v", err)
+		t.Fatalf("racing join refused at the lane ceiling: %v", err)
 	}
-	if !bulk.closed.Load() || racing.closed.Load() {
-		t.Fatalf("aged replacement retired bulk=%t racing=%t, want true/false", bulk.closed.Load(), racing.closed.Load())
+	if !bulk.closed.Load() || control.closed.Load() || racing.closed.Load() {
+		t.Fatalf("racing join retired bulk=%t control=%t racing=%t, want true/false/false", bulk.closed.Load(), control.closed.Load(), racing.closed.Load())
 	}
+	if got := flow.laneCount(); got != 2 {
+		t.Fatalf("lane count = %d, want the admission ceiling of 2", got)
+	}
+}
+
+// A lane whose JOIN handshake is still in flight is the one lane eviction
+// never takes: parallel rescue attempts race to the gateway, and evicting a
+// staged lane can kill the attempt the peer has just crowned. The racing
+// join is refused instead -- the transient capacity answer the peer already
+// expects for its losing attempts -- and the protection ends with the
+// rescue-race window: once the lane is live and older than the window, it is
+// evictable by any newer rescue.
+func TestStagedLaneIsProtectedOnlyUntilActivated(t *testing.T) {
+	flow := newIsolationTestFlow(t, false)
+	session := newServerFlow(flow, identity.Principal{}, TransportQUIC, 1)
+	staged := isolationLane(t, 1)
+	staged.staged = true
+	if err := session.addLane(staged); err != nil {
+		t.Fatal(err)
+	}
+	racer := isolationLane(t, 2)
+	if err := session.addLane(racer); err == nil {
+		t.Fatal("a racing join evicted a lane whose handshake was in flight")
+	}
+	if staged.closed.Load() {
+		t.Fatal("the in-flight lane was retired by the racing join")
+	}
+	if err := flow.activateLane(staged); err != nil {
+		t.Fatal(err)
+	}
+	staged.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	if err := session.addLane(racer); err != nil {
+		t.Fatalf("join behind a live lane refused: %v", err)
+	}
+	if !staged.closed.Load() || racer.closed.Load() {
+		t.Fatalf("eviction retired staged=%t racer=%t, want true/false", staged.closed.Load(), racer.closed.Load())
+	}
+	if got := flow.laneCount(); got != 1 {
+		t.Fatalf("lane count = %d, want the admission ceiling of 1", got)
+	}
+}
+
+// Role only orders the victim choice; it never blocks a rescue. When no
+// lane with the replacement's role is evictable, the oldest lane of any role
+// is retired instead of refusing the join.
+func TestEvictionCrossesRolesWhenNoSameRoleLaneIsLive(t *testing.T) {
+	flow := newIsolationTestFlow(t, true)
+	session := newServerFlow(flow, identity.Principal{}, TransportQUIC, 1)
+	control := isolationLane(t, 0)
+	control.control = true
+	otherControl := isolationLane(t, 1)
+	otherControl.control = true
+	if err := flow.addLane(control); err != nil {
+		t.Fatal(err)
+	}
+	if err := flow.addLane(otherControl); err != nil {
+		t.Fatal(err)
+	}
+	control.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	otherControl.admitted = time.Now().Add(-2 * laneDeadPathDetection)
+	bulk := isolationLane(t, 2)
+	if err := session.addLane(bulk); err != nil {
+		t.Fatalf("bulk join behind two control lanes refused: %v", err)
+	}
+	if !control.closed.Load() || otherControl.closed.Load() {
+		t.Fatalf("cross-role eviction retired oldest-control=%t other=%t, want true/false", control.closed.Load(), otherControl.closed.Load())
+	}
+	if got := flow.laneCount(); got != 2 {
+		t.Fatalf("lane count = %d, want the admission ceiling of 2", got)
+	}
+}
+
+// A staged JOIN lane whose acknowledgement could not be written must leave
+// the flow entirely: keeping it would count a lane that can never carry
+// traffic against the admission ceiling for the life of the flow.
+func TestFailedStagedJoinIsRemovedFromTheFlow(t *testing.T) {
+	flow := newIsolationTestFlow(t, true)
+	lane := isolationLane(t, 1)
+	lane.staged = true
+	if err := flow.addLane(lane); err != nil {
+		t.Fatal(err)
+	}
+	if got := flow.laneCount(); got != 1 {
+		t.Fatalf("staged lane consumes %d admission slots, want one", got)
+	}
+	flow.removeLane(lane)
+	if got := flow.laneCount(); got != 0 {
+		t.Fatalf("failed staged join still consumes %d admission slots", got)
+	}
+	if !lane.closed.Load() {
+		t.Fatal("removed lane was not closed")
+	}
+	// A second removal -- for example when a racing eviction already withdrew
+	// the lane -- must not panic or miscount.
+	flow.removeLane(lane)
 }
 
 // Without the reservation there is no separate control lane, so the budget is

--- a/internal/pep/lanejoinrefusal_test.go
+++ b/internal/pep/lanejoinrefusal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net"
 	"testing"
@@ -79,5 +80,30 @@ func TestLaneJoinRefusalsAreVisibleAndCountedByReason(t *testing.T) {
 				t.Fatalf("record total = %#v, want 1", record["total"])
 			}
 		})
+	}
+}
+
+// A JOIN admitted whose OPEN_OK cannot be written must not leave the staged
+// lane behind: it counts against the flow's admission ceiling yet can never
+// carry traffic, so one failed handshake would wedge the slot for the life
+// of the flow.
+func TestJoinLaneIsRemovedWhenOpenOKCannotBeWritten(t *testing.T) {
+	owner := identity.Principal{ProviderID: "provider", AccountID: "account", DeviceID: "owner"}
+	flow := newIsolationTestFlow(t, false)
+	server := &Server{
+		cfg:      ServerConfig{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))},
+		sessions: map[[16]byte]*serverFlow{flow.sessionID: newServerFlow(flow, owner, TransportTCP, 1)},
+		metrics:  metrics.New(),
+	}
+	local, remote := net.Pipe()
+	_ = remote.Close()
+	t.Cleanup(func() { _ = local.Close() })
+	request := protocol.Frame{Header: protocol.Header{
+		Version: protocol.Version, Type: protocol.TypeJoin, SessionID: flow.sessionID,
+		FlowID: flow.flowID, Class: protocol.ClassBulk,
+	}}
+	server.handleLaneJoinOpen(context.Background(), local, newFrameConn(local), owner, flow.sessionID, 1, request)
+	if got := flow.laneCount(); got != 0 {
+		t.Fatalf("lane whose OPEN_OK could not be written still consumes %d admission slots", got)
 	}
 }

--- a/internal/pep/mpflow.go
+++ b/internal/pep/mpflow.go
@@ -133,8 +133,9 @@ type mpLane struct {
 	cwndBytes     int
 	inFlightBytes int
 	cwndSampled   time.Time
-	// admitted is when this lane joined the flow, which is what bounds the
-	// handover of bulk traffic off the shared control lane.
+	// admitted is when this lane joined the flow. It bounds eviction at the
+	// lane ceiling: a lane younger than the rescue-race window may still be
+	// waiting on the peer's crowning decision, so it is never the victim.
 	admitted          time.Time
 	writeInteractiveQ chan laneFrame
 	writeSlots        chan struct{}
@@ -872,23 +873,35 @@ func (f *multipathFlow) laneCount() int {
 // the configured lane cap; deleting the entry keeps the cap a real resource
 // bound rather than allowing unbounded historical lane IDs.
 //
-// A lane younger than minAge is never the victim. Parallel rescue JOINs race
-// one another to this endpoint, and admission order is not the order the
-// peer crowned its winner in: retiring a lane admitted moments ago lets a
-// losing JOIN evict the winner's server side before its own close lands.
-// The lanes eviction legitimately exists for -- half-open sockets whose
-// peer has already given up -- are at least a path-detection budget old.
+// The victim is the oldest evictable lane with the replacement's role, or the
+// oldest evictable lane of any role when no same-role lane exists: role
+// orders the choice but never blocks a rescue. Two lanes are never evictable.
+// A lane whose JOIN handshake is still in flight: parallel rescue attempts
+// race to this endpoint, and evicting a staged lane can kill the attempt the
+// peer has just crowned. And a lane younger than minAge: admission order is
+// not the order the peer crowned its winner in, so a freshly admitted lane
+// may still be waiting on the peer's decision while the racing losers it
+// beat are still arriving; the half-open sockets eviction exists for are
+// never that young. With no evictable lane the JOIN is refused -- the
+// transient capacity answer the racing peer already expects for its losing
+// attempts.
 func (f *multipathFlow) retireOldestLane(control bool, minAge time.Duration) bool {
 	f.lanesMu.Lock()
 	var victim *mpLane
 	for _, lane := range f.lanes {
-		if lane.closed.Load() || !f.laneReady(lane) || f.laneIsControl(lane) != control {
+		if lane.closed.Load() || !f.laneReady(lane) {
 			continue
 		}
 		if minAge > 0 && time.Since(lane.admitted) < minAge {
 			continue
 		}
-		if victim == nil || lane.id < victim.id {
+		switch {
+		case victim == nil:
+			victim = lane
+		case f.laneIsControl(lane) == control && f.laneIsControl(victim) != control:
+			// A lane with the replacement's role always beats any other role.
+			victim = lane
+		case f.laneIsControl(lane) == f.laneIsControl(victim) && lane.id < victim.id:
 			victim = lane
 		}
 	}
@@ -903,6 +916,24 @@ func (f *multipathFlow) retireOldestLane(control bool, minAge time.Duration) boo
 		_ = victim.fc.Close()
 	}
 	return true
+}
+
+// removeLane withdraws a lane whose admission failed after it entered the
+// flow -- a staged JOIN lane whose OPEN_OK never left. Anything less leaves
+// a lane that counts against the admission cap but can neither carry traffic
+// nor be scheduled, leaking the slot for the life of the flow.
+func (f *multipathFlow) removeLane(lane *mpLane) {
+	f.lanesMu.Lock()
+	if f.lanes[lane.id] != lane {
+		f.lanesMu.Unlock()
+		return
+	}
+	delete(f.lanes, lane.id)
+	lane.closed.Store(true)
+	f.lanesMu.Unlock()
+	if lane.fc != nil {
+		_ = lane.fc.Close()
+	}
 }
 
 // retireLanesExcept performs an intentional transport handoff without

--- a/internal/pep/server.go
+++ b/internal/pep/server.go
@@ -162,14 +162,12 @@ func (s *serverFlow) addLane(lane *mpLane) error {
 	}
 	if s.flow.laneCount() >= s.maxLanes {
 		// The peer can detect a dead QUIC socket before this endpoint does
-		// (for example, when the return path is black-holed). Retire the
-		// oldest lane with the same role as its authenticated replacement.
-		// A bulk replacement must never evict the control lane, and a control
-		// generation replacement must not evict healthy bulk capacity. A lane
-		// younger than the path-detection budget is protected: several rescue
-		// JOINs racing here must not evict the winner the peer already
-		// crowned, and the half-open lanes eviction exists for are never
-		// that young.
+		// (for example, when the return path is black-holed). Admission at
+		// the ceiling is by eviction, and no role blocks it: the choice is
+		// limited only by the rescue-race window -- lanes whose JOIN
+		// handshake is in flight or whose admission is younger than the
+		// path-detection budget may still be waiting on the peer's crowning
+		// decision, so evicting one can kill the rescue that just won.
 		if !s.flow.retireOldestLane(lane.control, laneDeadPathDetection) || s.flow.laneCount() >= s.maxLanes {
 			return errors.New("flow lane limit reached")
 		}
@@ -1037,9 +1035,11 @@ func (s *Server) handleLaneJoinOpen(ctx context.Context, conn streamConn, fc *fr
 		return
 	}
 	if err := fc.Write(protocol.Frame{Header: protocol.Header{Version: protocol.Version, Type: protocol.TypeOpenOK, SessionID: sessionID, FlowID: open.Header.FlowID, Class: protocol.ClassBulk}}); err != nil {
+		serverSession.flow.removeLane(replacement)
 		return
 	}
 	if err := serverSession.flow.activateLane(replacement); err != nil {
+		serverSession.flow.removeLane(replacement)
 		return
 	}
 	s.cfg.Logger.Debug("lane joined", "lane", laneID, "transport", kind, "control", controlReplacement, "lanes", serverSession.flow.laneCount())


### PR DESCRIPTION
## Problem

On the live icourse gateway: 337,054 `lane_unavailable` refusals against 21,385 flows in 12 h. During a path outage (2026-09-05 ~10:20 CST), stalled flows burned their whole 45 s replacement grace on capacity refusals — ~200/min sustained — and died.

Root causes found in admission/eviction:

1. **Leaked staged lanes**: a JOIN lane whose OPEN_OK write or activation failed was left in the lane map (`handleLaneJoinOpen` early return) — counted against the ceiling, never schedulable, never evictable (`laneReady` filter skipped it). One failed handshake wedged a slot for the life of the flow.
2. **Hard same-role restriction**: a bulk rescue could never evict a dead half-open control lane, collapsing the effective budget of a `reserveControlLane` flow to 1 stuck slot.

## Fix

- `removeLane`: failed staged JOIN lanes leave the flow immediately (idempotent).
- `retireOldestLane`: role is now a victim *preference*, not a filter — any role is retired when no same-role lane is evictable.
- Readiness + age windows **kept**: verified by test that unconditional eviction makes every parallel racing-rescue round evict its own crowned winner — `TestQUICFlowSurvivesOneLaneFailure` deterministically recovered only 24 KB of 2.8 MB. The JOIN frame has no rescue-round marker, so the handshake window + one path-detection budget is how the server tells a racing loser (safe to refuse, transient) from a genuine rescue (must be admitted).

## Tests

Full `internal/pep` suite green. New coverage: staged-lane protection until activation, immediate eviction of aged live lanes, cross-role eviction fallback, `removeLane` idempotence, and an integration test that a JOIN lane is removed when OPEN_OK cannot be written.